### PR TITLE
[teststep] Use a Load function for plugin registration

### DIFF
--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -63,6 +63,10 @@ type TestStepStatus string
 // TestStep factories are registered in the plugin registry.
 type TestStepFactory func() TestStep
 
+// TestStepLoader is a type representing a function which returns all the
+// needed things to be able to load a TestStep.
+type TestStepLoader func() (string, TestStepFactory, []event.Name)
+
 // TestStepDescriptor is the definition of a test step matching a test step
 // configuration.
 type TestStepDescriptor struct {

--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -121,3 +121,8 @@ func (ts *Cmd) CanResume() bool {
 func New() test.TestStep {
 	return &Cmd{}
 }
+
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}

--- a/plugins/teststeps/echo/echo.go
+++ b/plugins/teststeps/echo/echo.go
@@ -33,6 +33,11 @@ func New() test.TestStep {
 	return &Step{}
 }
 
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}
+
 // ValidateParameters validates the parameters that will be passed to the Run
 // and Resume methods of the test step.
 func (e Step) ValidateParameters(params test.TestStepParameters) error {

--- a/plugins/teststeps/example/example.go
+++ b/plugins/teststeps/example/example.go
@@ -113,3 +113,8 @@ func (ts *Step) CanResume() bool {
 func New() test.TestStep {
 	return &Step{}
 }
+
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}

--- a/plugins/teststeps/randecho/randecho.go
+++ b/plugins/teststeps/randecho/randecho.go
@@ -35,6 +35,11 @@ func New() test.TestStep {
 	return &Step{}
 }
 
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}
+
 // ValidateParameters validates the parameters that will be passed to the Run
 // and Resume methods of the test step.
 func (e Step) ValidateParameters(params test.TestStepParameters) error {

--- a/plugins/teststeps/slowecho/slowecho.go
+++ b/plugins/teststeps/slowecho/slowecho.go
@@ -39,6 +39,11 @@ func New() test.TestStep {
 	return &Step{}
 }
 
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}
+
 // Name returns the name of the Step
 func (e *Step) Name() string {
 	return Name

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -259,3 +259,8 @@ func (ts *SSHCmd) CanResume() bool {
 func New() test.TestStep {
 	return &SSHCmd{}
 }
+
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}

--- a/plugins/teststeps/terminalexpect/terminalexpect.go
+++ b/plugins/teststeps/terminalexpect/terminalexpect.go
@@ -135,3 +135,8 @@ func (ts *TerminalExpect) CanResume() bool {
 func New() test.TestStep {
 	return &TerminalExpect{}
 }
+
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}


### PR DESCRIPTION
Simplifying plugin registration as suggested in #1.

This is only for the test steps. If it look good, I'll do the same with the other type of plugins.