### PR TITLE
Update Travis-CI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ConTest
-[![Build Status](https://travis-ci.org/facebookincubator/contest.svg?branch=master)](https://travis-ci.org/facebookincubator/contest)
+[![Build Status](https://travis-ci.com/facebookincubator/contest.svg?branch=master)](https://travis-ci.com/facebookincubator/contest)
 [![codecov](https://codecov.io/gh/facebookincubator/contest/branch/master/graph/badge.svg)](https://codecov.io/gh/facebookincubator/contest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/facebookincubator/contest)](https://goreportcard.com/report/github.com/facebookincubator/contest)
 


### PR DESCRIPTION
This is running on .com, not .org. It is currently showing "status: unknown". After this fix, it shows "status: passing".