### PR TITLE
Reporting: initial support for multiple reporters

### DIFF
--- a/cmds/clients/contestcli-http/start-literal.json
+++ b/cmds/clients/contestcli-http/start-literal.json
@@ -31,8 +31,14 @@
             }
         }
     ],
-    "ReporterName": "TargetSuccess",
-    "ReporterParameters": {
-        "SuccessExpression": ">50%"
-   }
+    "Reporting": {
+        "RunReporters": [
+            {
+                "Name": "TargetSuccess",
+                "Parameters": {
+                    "SuccessExpression": ">80%"
+                }
+            }
+        ]
+    }
 }

--- a/cmds/clients/contestcli-http/start.json
+++ b/cmds/clients/contestcli-http/start.json
@@ -22,8 +22,14 @@
             }
         }
     ],
-    "ReporterName": "TargetSuccess",
-    "ReporterParameters": {
-	"SuccessExpression": ">10%"
+    "Reporting": {
+        "RunReporters": [
+            {
+                "Name": "TargetSuccess",
+                "Parameters": {
+                    "SuccessExpression": ">80%"
+                }
+            }
+        ]
    }
 }

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -6,7 +6,6 @@
 package job
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/facebookincubator/contest/pkg/test"
@@ -23,11 +22,7 @@ type JobDescriptor struct {
 	Runs            uint
 	RunInterval     xjson.Duration
 	TestDescriptors []*test.TestDescriptor
-
-	// Reporter-related parameters. There is one single Reporter per Job which
-	// elaborates the results of all Tests within the Job
-	ReporterName       string
-	ReporterParameters json.RawMessage
+	Reporting       Reporting
 }
 
 // Job is used to run a type of test job on a given set of targets.

--- a/pkg/job/reporting.go
+++ b/pkg/job/reporting.go
@@ -1,0 +1,27 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package job
+
+import "encoding/json"
+
+// Reporting is the configuration section that determines how to report the
+// results. It is divided in run reporting and final reporting. The run
+// reporters are called when each test run is completed, while the final
+// reporters are called once at the end of the whole set of runs is completed.
+// The final reporters are optional.
+// If the job is continuous (e.g. run indefinitely), the final reporters are
+// only called if the job is interrupted.
+type Reporting struct {
+	RunReporters   []ReporterConfig
+	FinalReporters []ReporterConfig
+}
+
+// ReporterConfig is the configuration of a specific reporter, either a run
+// reporter or a final reporter.
+type ReporterConfig struct {
+	Name       string
+	Parameters json.RawMessage
+}


### PR DESCRIPTION
This is the first of a large, API-breaking changes to the reporting contract.
Before this change, we only support a single reporter, that is executed at the
end of each run. This changeset enables specifying multiple reporters (now
called run reporters), and adds the concept of final reporters, i.e. reporters
that are executed when all the runs have completed. This is useful to create
reports based on the results of the whole job instead that on individual runs.

A final reporter for an indefinitely-running job (i.e. with Runs set to
0) will run only when the job is cancelled.
Final reporters are optional, but at least one run reporter has to be
specified.

This commit simply changes the job descriptor to use the new syntax, but
the behaviour is unchanged. Only one run reporter is supported at this
point, and no final reporters yet.

The reporting syntax in the job descriptor should now look like the
followingi (remembering that with this commit only one run reporter and
no final reporters are supported for now):
```
    "Reporting": {
        "RunReporters": [
            {
                "Name": "TargetSuccess",
                "Parameters": {
                    "SuccessExpression": ">80%"
                }
            },
            {
                "Name": "SomeOtherReporter",
                "Parameters": {
                    "SomeParameters": "Blah"
                }
            }
        ],
        "FinalReporters": [
            {
                "Name": "TargetSuccess",
                "Parameters": {
                    "OverallSuccessExpression": ">50%"
                }
            },
            {
                "Name": "AverageTime",
                "Parameters": {
                    "blah": "blah"
                }
            }
        ]
    }
```

Signed-off-by: Andrea Barberio <barberio@fb.com>