### PR TITLE
Do not fail if there are no job reports

### DIFF
--- a/plugins/storage/rdbms/report.go
+++ b/plugins/storage/rdbms/report.go
@@ -53,7 +53,13 @@ func (r *RDBMS) GetJobReport(jobID types.JobID) (*job.Report, error) {
 	report := job.Report{}
 	report.JobReport = jobReportJSON
 
-	rows.Next()
+	if next := rows.Next(); !next {
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("could not fetch job report: %v", err)
+		}
+		// No job report was found
+		return nil, nil
+	}
 	rr := ""
 	err = rows.Scan(
 		&report.JobID,


### PR DESCRIPTION
We should check whether the iterator returned from the query is empty.

Signed-off-by: Marco Guerri <marcoguerri@fb.com>