### PR TITLE
Use a Load function for plugin registration

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -42,14 +42,14 @@ var (
 	flagDBURI = flag.String("dbURI", defaultDBURI, "Database URI")
 )
 
-var targetManagers = map[string]target.TargetManagerFactory{
-	csvtargetmanager.Name: csvtargetmanager.New,
-	targetlist.Name:       targetlist.New,
+var targetManagers = []target.TargetManagerLoader{
+	csvtargetmanager.Load,
+	targetlist.Load,
 }
 
-var testFetchers = map[string]test.TestFetcherFactory{
-	uri.Name:     uri.New,
-	literal.Name: literal.New,
+var testFetchers = []test.TestFetcherLoader{
+	uri.Load,
+	literal.Load,
 }
 
 var testSteps = []test.TestStepLoader{
@@ -62,8 +62,8 @@ var testSteps = []test.TestStepLoader{
 	terminalexpect.Load,
 }
 
-var reporters = map[string]job.ReporterFactory{
-	targetsuccess.Name: targetsuccess.New,
+var reporters = []job.ReporterLoader{
+	targetsuccess.Load,
 }
 
 // user-defined functions that will be made available to plugins for advanced
@@ -86,15 +86,15 @@ func main() {
 	pluginRegistry := pluginregistry.NewPluginRegistry()
 
 	// Register TargetManager plugins
-	for name, tmfactory := range targetManagers {
-		if err := pluginRegistry.RegisterTargetManager(name, tmfactory); err != nil {
+	for _, tmloader := range targetManagers {
+		if err := pluginRegistry.RegisterTargetManager(tmloader()); err != nil {
 			log.Fatal(err)
 		}
 	}
 
 	// Register TestFetcher plugins
-	for name, tffactory := range testFetchers {
-		if err := pluginRegistry.RegisterTestFetcher(name, tffactory); err != nil {
+	for _, tfloader := range testFetchers {
+		if err := pluginRegistry.RegisterTestFetcher(tfloader()); err != nil {
 			log.Fatal(err)
 		}
 	}
@@ -108,8 +108,8 @@ func main() {
 	}
 
 	// Register Reporter plugins
-	for name, rfactory := range reporters {
-		if err := pluginRegistry.RegisterReporter(name, rfactory); err != nil {
+	for _, rfloader := range reporters {
+		if err := pluginRegistry.RegisterReporter(rfloader()); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/pkg/job/reporter.go
+++ b/pkg/job/reporter.go
@@ -13,6 +13,10 @@ import (
 // ReporterFactory is a type representing a function which builds a Reporter object
 type ReporterFactory func() Reporter
 
+// ReporterLoader is a type representing a function which returns all the
+// needed things to be able to load a Reporter object
+type ReporterLoader func() (string, ReporterFactory)
+
 // Reporter is an interface used to implement logic which calculates the result
 // of a Job. The result is conveyed via a JobReport object.
 type Reporter interface {

--- a/pkg/target/targetmanager.go
+++ b/pkg/target/targetmanager.go
@@ -11,6 +11,10 @@ import "github.com/facebookincubator/contest/pkg/types"
 // a TargetManager.
 type TargetManagerFactory func() TargetManager
 
+// TargetManagerLoader is a type representing a function which returns all the
+// needed things to be able to load a TestStep.
+type TargetManagerLoader func() (string, TargetManagerFactory)
+
 // TargetManager is an interface used to acquire and release the targets to
 // run tests on.
 type TargetManager interface {

--- a/pkg/test/fetcher.go
+++ b/pkg/test/fetcher.go
@@ -9,6 +9,10 @@ package test
 // a TestFetcher
 type TestFetcherFactory func() TestFetcher
 
+// TestFetcherLoader is a type representing a function which returns all the
+// needed things to be able to load a TestFetcher
+type TestFetcherLoader func() (string, TestFetcherFactory)
+
 // TestFetcher is an interface used to get the test to run on the selected
 // hosts.
 type TestFetcher interface {

--- a/plugins/reporters/targetsuccess/targetsuccess.go
+++ b/plugins/reporters/targetsuccess/targetsuccess.go
@@ -87,3 +87,8 @@ func (ts *TargetSuccessReporter) Report(cancel <-chan struct{}, parameters inter
 func New() job.Reporter {
 	return &TargetSuccessReporter{}
 }
+
+// Load returns the name and factory which are needed to register the Reporter
+func Load() (string, job.ReporterFactory) {
+	return Name, New
+}

--- a/plugins/targetmanagers/csvtargetmanager/csvfile.go
+++ b/plugins/targetmanagers/csvtargetmanager/csvfile.go
@@ -163,3 +163,9 @@ func (tf *CSVFileTargetManager) Release(jobID types.JobID, cancel <-chan struct{
 func New() target.TargetManager {
 	return &CSVFileTargetManager{}
 }
+
+// Load returns the name and factory which are needed to register the
+// TargetManager.
+func Load() (string, target.TargetManagerFactory) {
+	return Name, New
+}

--- a/plugins/targetmanagers/targetlist/targetlist.go
+++ b/plugins/targetmanagers/targetlist/targetlist.go
@@ -111,3 +111,9 @@ func (t *TargetList) Release(jobID types.JobID, cancel <-chan struct{}, params i
 func New() target.TargetManager {
 	return &TargetList{}
 }
+
+// Load returns the name and factory which are needed to register the
+// TargetManager.
+func Load() (string, target.TargetManagerFactory) {
+	return Name, New
+}

--- a/plugins/testfetchers/literal/literal.go
+++ b/plugins/testfetchers/literal/literal.go
@@ -64,3 +64,9 @@ func (tf *Literal) Fetch(params interface{}) (string, []*test.TestStepDescriptor
 func New() test.TestFetcher {
 	return &Literal{}
 }
+
+// Load returns the name and factory which are needed to register the
+// TestFetcher.
+func Load() (string, test.TestFetcherFactory) {
+	return Name, New
+}

--- a/plugins/testfetchers/uri/uri.go
+++ b/plugins/testfetchers/uri/uri.go
@@ -129,3 +129,9 @@ func (tf *URI) Fetch(params interface{}) (string, []*test.TestStepDescriptor, er
 func New() test.TestFetcher {
 	return &URI{}
 }
+
+// Load returns the name and factory which are needed to register the
+// TestFetcher.
+func Load() (string, test.TestFetcherFactory) {
+	return Name, New
+}


### PR DESCRIPTION
Simplifying plugin registration as suggested in #1 . Continuation of #2. Fixes #1.