### PR TITLE
Reporting called at the end of each run instead of the end of the job

### DIFF
--- a/cmds/clients/contestcli-http/start-literal.json
+++ b/cmds/clients/contestcli-http/start-literal.json
@@ -1,6 +1,6 @@
 {
     "JobName": "test job",
-    "Runs": 1,
+    "Runs": 3,
     "RunInterval": "5s",
     "Tags": ["test", "csv"],
     "TestDescriptors": [

--- a/pkg/job/reporter.go
+++ b/pkg/job/reporter.go
@@ -17,7 +17,7 @@ type ReporterFactory func() Reporter
 // of a Job. The result is conveyed via a JobReport object.
 type Reporter interface {
 	ValidateParameters([]byte) (interface{}, error)
-	Report(cancel <-chan struct{}, parameters interface{}, results []*test.TestResult, ev testevent.Fetcher) (bool, interface{}, error)
+	Report(cancel <-chan struct{}, parameters interface{}, result *test.TestResult, ev testevent.Fetcher) (bool, interface{}, error)
 }
 
 // ReporterBundle bundles the selected Reporter together with its parameters

--- a/plugins/reporters/targetsuccess/targetsuccess.go
+++ b/plugins/reporters/targetsuccess/targetsuccess.go
@@ -50,24 +50,20 @@ func (ts *TargetSuccessReporter) ValidateParameters(params []byte) (interface{},
 }
 
 // Report calculates the Report object to be associated with the job
-func (ts *TargetSuccessReporter) Report(cancel <-chan struct{}, parameters interface{}, results []*test.TestResult, ev testevent.Fetcher) (bool, interface{}, error) {
+func (ts *TargetSuccessReporter) Report(cancel <-chan struct{}, parameters interface{}, result *test.TestResult, ev testevent.Fetcher) (bool, interface{}, error) {
 	reportParameters, ok := parameters.(TargetSuccessParameters)
 	if !ok {
 		return false, nil, fmt.Errorf("report parameteres should be of type TargetSuccessParameters")
 	}
 
-	if results == nil {
-		return false, nil, fmt.Errorf("test results is empty, cannot calculate results")
-	}
-
-	if len(results) > 1 {
-		return false, nil, fmt.Errorf("TargetSuccess reporter supports only one TestResult")
+	if result == nil {
+		return false, nil, fmt.Errorf("test result is empty, cannot calculate success metrics")
 	}
 
 	var ignoreList []*target.Target
 
 	// Evaluate the success threshold for every test for which we got a TestResult
-	res, err := results[0].GetResult(reportParameters.SuccessExpression, ignoreList)
+	res, err := result.GetResult(reportParameters.SuccessExpression, ignoreList)
 	if err != nil {
 		return false, nil, fmt.Errorf("could not evaluate the success on at least one test: %v", err)
 	}

--- a/plugins/reporters/targetsuccess/targetsuccess_test.go
+++ b/plugins/reporters/targetsuccess/targetsuccess_test.go
@@ -73,7 +73,7 @@ func (suite *TargetSuccessSuite) TestTargetSuccessSuccessfulJob() {
 	tsr := TargetSuccessReporter{}
 
 	ev := storage.NewTestEventFetcher()
-	success, _, err := tsr.Report(cancel, tsp, []*test.TestResult{&suite.sampleTestResult}, ev)
+	success, _, err := tsr.Report(cancel, tsp, &suite.sampleTestResult, ev)
 	if err != nil {
 		suite.T().Errorf("reporting should not fail: %v", err)
 	}
@@ -89,7 +89,7 @@ func (suite *TargetSuccessSuite) TestTargetSuccessFailedJob(t *testing.T) {
 	tsr := TargetSuccessReporter{}
 
 	ev := storage.NewTestEventFetcher()
-	success, _, err := tsr.Report(cancel, tsp, []*test.TestResult{&suite.sampleTestResult}, ev)
+	success, _, err := tsr.Report(cancel, tsp, &suite.sampleTestResult, ev)
 	if err != nil {
 		suite.T().Errorf("reporting should not fail: %v", err)
 	}


### PR DESCRIPTION
This commit fixes an issue where reporting was called at the end of the
job (i.e. after all the desired runs) instead of after every run. The
final reporting will be done through final reporters, which are
currently being implemented.

Before this change, a job with number of runs != 1 would call the
reporter only at the very end (and plugins like TargetSuccess would fail
because it supports only one result, while it will be fed more than
one).
After this change, the reporter will run once per run.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>