### PR TITLE
Fix several linter warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/tommy-muehle/go-mnd v1.2.0 // indirect
 	github.com/u-root/u-root v6.0.0+incompatible // indirect
+	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -200,9 +201,11 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96d
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.0 h1:Iw5WCbBcaAAd0fpRb1c9r5YCylv4XDoCSigm1zLevwU=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
@@ -303,6 +306,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
+github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -332,6 +337,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -386,6 +392,7 @@ golang.org/x/tools v0.0.0-20200203023011-6f24f261dadb/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74 h1:KW20qMcLRWuIgjdCpHFJbVZA7zsDKtFXPNcm7/eI5ZA=
 golang.org/x/tools v0.0.0-20200204074204-1cc6d1ef6c74/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -397,12 +404,14 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.52.0 h1:j+Lt/M1oPPejkniCg1TkWE2J3Eh1oZTsHSXzMTzUXn4=
 gopkg.in/ini.v1 v1.52.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/config/timeouts.go
+++ b/pkg/config/timeouts.go
@@ -24,10 +24,10 @@ var TestRunnerMsgTimeout = 5 * time.Second
 // wait for all the TestStep to complete after a cancellation signal has been
 // delivered
 
-// TODO This timeout controls a block of the TestRunner which works as a watchdog,
-// i.e. if there are multiple steps that need to return, the timeout is reset
-// every time a step returns. The timeout should be handled so that it doesn't
-// reset when a TestStep returns.
+// TestRunnerShutdownTimeout controls a block of the TestRunner which works as a
+// watchdog, i.e. if there are multiple steps that need to return, the timeout is
+// reset every time a step returns. The timeout should be handled so that it
+// doesn't reset when a TestStep returns.
 var TestRunnerShutdownTimeout = 30 * time.Second
 
 // TestRunnerStepShutdownTimeout represents the maximum time that the TestRunner
@@ -35,8 +35,8 @@ var TestRunnerShutdownTimeout = 30 * time.Second
 // of the pipeline. This timeout is only relevant if a cancellation signal is *not*
 // delivered.
 
-// TODO This timeout controls a block of the TestRunner which worksas a watchdog,
-// i.e. if there are multiple steps that need to return, the timeout is reset
-// every time a step returns. The timeout should be handled so that it doesn't
-// reset when a TestStep returns.
+// TestRunnerStepShutdownTimeout controls a block of the TestRunner which worksas
+// a watchdog, i.e. if there are multiple steps that need to return, the timeout
+// is reset every time a step returns. The timeout should be handled so that it
+// doesn't reset when a TestStep returns.
 var TestRunnerStepShutdownTimeout = 5 * time.Second

--- a/pkg/event/frameworkevent/framework.go
+++ b/pkg/event/frameworkevent/framework.go
@@ -13,7 +13,7 @@ import (
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
-// FrameworkEvent represents an event emitted by the framework
+// Event represents an event emitted by the framework
 type Event struct {
 	JobID     types.JobID
 	EventName event.Name

--- a/pkg/job/request.go
+++ b/pkg/job/request.go
@@ -6,8 +6,9 @@
 package job
 
 import (
-	"github.com/facebookincubator/contest/pkg/types"
 	"time"
+
+	"github.com/facebookincubator/contest/pkg/types"
 )
 
 // Request represents an incoming Job request which should be persisted in storage
@@ -31,7 +32,7 @@ type RequestFetcher interface {
 	Fetch(id types.JobID) (*Request, error)
 }
 
-// RequestFetcher is an interface implemented by objects that implement both
+// RequestEmitterFetcher is an interface implemented by objects that implement both
 // request creator and request fetcher interface
 type RequestEmitterFetcher interface {
 	RequestEmitter

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -298,7 +298,7 @@ func (jm *JobManager) CancelJob(jobID types.JobID) error {
 	return nil
 }
 
-// Cancel sends a cancellation request to the API listener and to every running
+// CancelAll sends a cancellation request to the API listener and to every running
 // job.
 func (jm *JobManager) CancelAll() {
 	// TODO This doesn't see the right thing to do, if the listener fails we should

--- a/pkg/lib/comparison/comparison.go
+++ b/pkg/lib/comparison/comparison.go
@@ -5,7 +5,7 @@
 
 package comparison
 
-// Package comparison implements support for parsing comparision expressions of the following type:
+// Package comparison implements support for parsing comparison expressions of the following type:
 // * Greater than, ">"
 // * Greater or equal, ">="
 // * Less than, "<"
@@ -134,15 +134,15 @@ func (c Eq) Operator() Operator {
 type Result struct {
 	Pass bool
 	Expr string
-	Lhs  string
-	Rhs  string
+	LHS  string
+	RHS  string
 	Type Type
 	Op   Operator
 }
 
 // Expression is a struct that represents the deserialization of a string expression.
 // The deserialization includes the following:
-// * The comparision type (absolute, relative)
+// * The comparison type (absolute, relative)
 // * The comparison function and operator
 // * The right hand side operator
 type Expression struct {
@@ -152,7 +152,7 @@ type Expression struct {
 	RHS  float64
 }
 
-// Compare invokes the Compare function of the internal Comparator object
+// EvaluateSuccess invokes the Compare function of the internal Comparator object
 func (e Expression) EvaluateSuccess(success, total uint64) (*Result, error) {
 	var lhs float64
 	if e.Type == TypePercentage {
@@ -168,11 +168,11 @@ func (e Expression) EvaluateSuccess(success, total uint64) (*Result, error) {
 	pass := e.Cmp.Compare(lhs, e.RHS)
 	cmpRes := &Result{Type: e.Type, Op: e.Cmp.Operator()}
 	if e.Type == TypePercentage {
-		cmpRes.Lhs = fmt.Sprintf("%.2f%%", lhs)
-		cmpRes.Rhs = fmt.Sprintf("%.2f%%", e.RHS)
+		cmpRes.LHS = fmt.Sprintf("%.2f%%", lhs)
+		cmpRes.RHS = fmt.Sprintf("%.2f%%", e.RHS)
 	} else {
-		cmpRes.Lhs = fmt.Sprintf("%.2f", lhs)
-		cmpRes.Rhs = fmt.Sprintf("%.2f", e.RHS)
+		cmpRes.LHS = fmt.Sprintf("%.2f", lhs)
+		cmpRes.RHS = fmt.Sprintf("%.2f", e.RHS)
 	}
 	var expr string
 	if pass {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -6,9 +6,10 @@
 package logging
 
 import (
+	"io/ioutil"
+
 	log_prefixed "github.com/chappjc/logrus-prefix"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
 )
 
 var (
@@ -20,6 +21,7 @@ func GetLogger(prefix string) *logrus.Entry {
 	return log.WithField("prefix", prefix)
 }
 
+// Disable sends all logging output to the bit bucket.
 func Disable() {
 	log.SetOutput(ioutil.Discard)
 }

--- a/pkg/pluginregistry/pluginregistry.go
+++ b/pkg/pluginregistry/pluginregistry.go
@@ -169,7 +169,7 @@ func (r *PluginRegistry) NewTestStep(pluginName string) (test.TestStep, error) {
 	return testStep, nil
 }
 
-// NewTestStepsEvents returns a map of events.EventName which can be emitted by the TestStep
+// NewTestStepEvents returns a map of events.EventName which can be emitted by the TestStep
 func (r *PluginRegistry) NewTestStepEvents(pluginName string) (map[event.Name]bool, error) {
 	pluginName = strings.ToLower(pluginName)
 	var (

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -347,7 +347,7 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, bundle test.Tes
 	}()
 
 	// Run the TestStep and defer to the return path the handling of panic
-	// conditions. If multiple error conditions occurr, send downstream only
+	// conditions. If multiple error conditions occur, send downstream only
 	// the first error encountered.
 	channels := test.TestStepChannels{
 		In:  stepCh.stepIn,
@@ -494,7 +494,7 @@ wait_test_step:
 }
 
 // WaitPipelineTermination reads results coming from result channels waiting
-// for the pipeline to completely shutdown before `ShutdownTimeout` occurrs. A
+// for the pipeline to completely shutdown before `ShutdownTimeout` occurs. A
 // "complete shutdown" means that all TestSteps and routing blocks have sent
 // downstream their results.
 func (tr *TestRunner) WaitPipelineTermination(ch completionCh, bundles []test.TestStepBundle) error {

--- a/pkg/runner/test_runner_state.go
+++ b/pkg/runner/test_runner_state.go
@@ -17,6 +17,7 @@ type RunnerState struct {
 	completedTargets map[*target.Target]error
 }
 
+// NewRunnerState initializes a RunnerState object.
 func NewRunnerState() *RunnerState {
 	r := RunnerState{}
 	r.completedSteps = make(map[string]error)

--- a/pkg/storage/events.go
+++ b/pkg/storage/events.go
@@ -43,7 +43,7 @@ func (ev TestEventFetcher) Fetch(fields []testevent.QueryField) ([]testevent.Eve
 	for _, field := range fields {
 		field(&eventQuery)
 	}
-	return storage.GetTestEvent(&eventQuery)
+	return storage.GetTestEvents(&eventQuery)
 }
 
 // NewTestEventEmitter creates a new Emitter object associated with a Header
@@ -68,7 +68,7 @@ func NewTestEventEmitterFetcher(header testevent.Header) testevent.EmitterFetche
 type FrameworkEventEmitter struct {
 }
 
-// FrameworkEventsFetcher implements the Fetcher interface from the frameworkevent package
+// FrameworkEventFetcher implements the Fetcher interface from the frameworkevent package
 type FrameworkEventFetcher struct {
 }
 

--- a/pkg/storage/jobs.go
+++ b/pkg/storage/jobs.go
@@ -26,7 +26,7 @@ type JobRequestEmitterFetcher struct {
 	JobRequestFetcher
 }
 
-// Create persists a new job request into storage
+// Emit persists a new job request into storage
 func (rc JobRequestEmitter) Emit(request *job.Request) (types.JobID, error) {
 	var jobID types.JobID
 	jobID, err := storage.StoreJobRequest(request)

--- a/pkg/storage/report.go
+++ b/pkg/storage/report.go
@@ -2,6 +2,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+
 package storage
 
 import (
@@ -52,7 +53,7 @@ func NewJobReportFetcher() job.ReportFetcher {
 	return JobReportFetcher{}
 }
 
-// NewEventsEmitterFetcher creates a new EmitterFetcher object for Job reports
+// NewJobReportEmitterFetcher creates a new EmitterFetcher object for Job reports
 func NewJobReportEmitterFetcher() job.ReportEmitterFetcher {
 	return JobReportEmitterFetcher{
 		JobReportEmitter{},

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -21,7 +21,7 @@ var storage Storage
 type Storage interface {
 	// Test events storage interface
 	StoreTestEvent(event testevent.Event) error
-	GetTestEvent(eventQuery *testevent.Query) ([]testevent.Event, error)
+	GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, error)
 
 	// Framework events storage interface
 	StoreFrameworkEvent(event frameworkevent.Event) error

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -11,16 +11,16 @@ import (
 	"github.com/facebookincubator/contest/pkg/event"
 )
 
-// TargetIn indicates that a target has entered a TestStep
+// EventTargetIn indicates that a target has entered a TestStep
 var EventTargetIn = event.Name("TargetIn")
 
-// TargetInErr indicates that a target has encountered an error while entering a TestStep
+// EventTargetInErr indicates that a target has encountered an error while entering a TestStep
 var EventTargetInErr = event.Name("TargetInErr")
 
-// TargetOut indicates that a target has left a TestStep
+// EventTargetOut indicates that a target has left a TestStep
 var EventTargetOut = event.Name("TargetOut")
 
-// TargetErr indicates that a target has encountered an error in a TestStep
+// EventTargetErr indicates that a target has encountered an error in a TestStep
 var EventTargetErr = event.Name("TargetErr")
 
 // Target represents a target to run tests on

--- a/pkg/test/parameter.go
+++ b/pkg/test/parameter.go
@@ -33,7 +33,7 @@ func (p *Param) UnmarshalJSON(b []byte) error {
 	// the string should be passed with the enclosing double-quotes, so strip
 	// them first
 	if len(b) < 2 {
-		return fmt.Errorf("expected quoted string of lenght >=2, got %d", len(b))
+		return fmt.Errorf("expected quoted string of length >=2, got %d", len(b))
 	}
 	if b[0] != '"' || b[len(b)-1] != '"' {
 		return fmt.Errorf("expected quoted string, surrounding characters are not double-quotes")

--- a/pkg/test/result.go
+++ b/pkg/test/result.go
@@ -2,6 +2,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+
 package test
 
 import (
@@ -16,8 +17,8 @@ import (
 type Result struct {
 	Pass bool
 	Expr string
-	Lhs  string
-	Rhs  string
+	LHS  string
+	RHS  string
 	Type comparison.Type
 	Op   comparison.Operator
 }
@@ -39,7 +40,7 @@ func (r *TestResult) Targets() map[*target.Target]error {
 	return r.results
 }
 
-// EvaluateSuccessRate evaluates the success of a TestResult object based on a string
+// GetResult evaluates the success of a TestResult object based on a string
 // comparison expression
 func (r TestResult) GetResult(expression string, ignore []*target.Target) (*comparison.Result, error) {
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,6 +2,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+
 package types
 
 // JobID represents a unique job identifier

--- a/plugins/reporters/targetsuccess/targetsuccess.go
+++ b/plugins/reporters/targetsuccess/targetsuccess.go
@@ -31,6 +31,7 @@ type TargetSuccessParameters struct {
 type TargetSuccessReporter struct {
 }
 
+// TargetSuccessReport wraps a report with target success information.
 type TargetSuccessReport struct {
 	Message         string
 	AchievedSuccess string
@@ -53,7 +54,7 @@ func (ts *TargetSuccessReporter) ValidateParameters(params []byte) (interface{},
 func (ts *TargetSuccessReporter) Report(cancel <-chan struct{}, parameters interface{}, result *test.TestResult, ev testevent.Fetcher) (bool, interface{}, error) {
 	reportParameters, ok := parameters.(TargetSuccessParameters)
 	if !ok {
-		return false, nil, fmt.Errorf("report parameteres should be of type TargetSuccessParameters")
+		return false, nil, fmt.Errorf("report parameters should be of type TargetSuccessParameters")
 	}
 
 	if result == nil {
@@ -68,14 +69,14 @@ func (ts *TargetSuccessReporter) Report(cancel <-chan struct{}, parameters inter
 		return false, nil, fmt.Errorf("could not evaluate the success on at least one test: %v", err)
 	}
 	report := TargetSuccessReport{}
-	report.DesiredSuccess = fmt.Sprintf("%s%s", res.Op, res.Rhs)
+	report.DesiredSuccess = fmt.Sprintf("%s%s", res.Op, res.RHS)
 	if !res.Pass {
 		report.Message = fmt.Sprintf("Test does not pass success criteria: %s", res.Expr)
-		report.AchievedSuccess = res.Lhs
+		report.AchievedSuccess = res.LHS
 		return false, report, nil
 	}
 	report.Message = fmt.Sprintf("All tests pass success criteria: %s", res.Expr)
-	report.AchievedSuccess = res.Lhs
+	report.AchievedSuccess = res.LHS
 	return true, report, nil
 }
 

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -49,6 +49,7 @@ func emptyTestEventQuery(eventQuery *testevent.Query) bool {
 	return emptyEventQuery(&eventQuery.Query) && eventQuery.TestName == "" && eventQuery.TestStepLabel == ""
 }
 
+// Reset resets the content of the in-memory storage.
 func (m *Memory) Reset() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
@@ -113,7 +114,8 @@ func eventTestStepMatch(queryTestStepLabel, testStepLabel string) bool {
 	return true
 }
 
-func (m *Memory) GetTestEvent(eventQuery *testevent.Query) ([]testevent.Event, error) {
+// GetTestEvents returns all test events that match the given query.
+func (m *Memory) GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -219,8 +219,8 @@ func (r *RDBMS) FlushTestEvents() error {
 	return nil
 }
 
-// GetTestEvent retrieves test events matching the query fields provided
-func (r *RDBMS) GetTestEvent(eventQuery *testevent.Query) ([]testevent.Event, error) {
+// GetTestEvents retrieves test events matching the query fields provided
+func (r *RDBMS) GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, error) {
 
 	if err := r.init(); err != nil {
 		return nil, fmt.Errorf("could not initialize database: %v", err)
@@ -301,7 +301,7 @@ func (r *RDBMS) GetTestEvent(eventQuery *testevent.Query) ([]testevent.Event, er
 // FrameworkEventField is a function type which retrieves information from a FrameworkEvent object
 type FrameworkEventField func(ev frameworkevent.Event) interface{}
 
-// TestEventJobID returns the JobID from a events.TestEvent object
+// FrameworkEventJobID returns the JobID from a events.TestEvent object
 func FrameworkEventJobID(ev frameworkevent.Event) interface{} {
 	return ev.JobID
 }

--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -2,6 +2,7 @@
 //
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
+
 package teststeps
 
 import (

--- a/tests/integ/events/testevents/common.go
+++ b/tests/integ/events/testevents/common.go
@@ -93,7 +93,7 @@ func (suite *TestEventsSuite) TestRetrieveSingleTestEvent() {
 
 	testEventQuery := &testevent.Query{}
 	testevent.QueryTestName("ATestName")(testEventQuery)
-	results, err := suite.storage.GetTestEvent(testEventQuery)
+	results, err := suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 1, len(results))
@@ -109,7 +109,7 @@ func (suite *TestEventsSuite) TestRetrieveMultipleTestEvents() {
 
 	testEventQuery := &testevent.Query{}
 	testevent.QueryTestStepLabel("TestStepLabel")(testEventQuery)
-	results, err := suite.storage.GetTestEvent(testEventQuery)
+	results, err := suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 2, len(results))
@@ -129,7 +129,7 @@ func (suite *TestEventsSuite) TestRetrievesSingleTestEventByEmitTime() {
 
 	testEventQuery := &testevent.Query{}
 	testevent.QueryEmittedStartTime(emitTime)(testEventQuery)
-	results, err := suite.storage.GetTestEvent(testEventQuery)
+	results, err := suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 2, len(results))
@@ -137,7 +137,7 @@ func (suite *TestEventsSuite) TestRetrievesSingleTestEventByEmitTime() {
 
 	testEventQuery = &testevent.Query{}
 	testevent.QueryEmittedStartTime(emitTime.Add(-delta))(testEventQuery)
-	results, err = suite.storage.GetTestEvent(testEventQuery)
+	results, err = suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 4, len(results))
@@ -155,7 +155,7 @@ func (suite *TestEventsSuite) TestRetrievesMultipleTestEventsByName() {
 	testEventQuery := &testevent.Query{}
 	eventNames := []event.Name{event.Name("AEventName"), event.Name("BEventName")}
 	testevent.QueryEventNames(eventNames)(testEventQuery)
-	results, err := suite.storage.GetTestEvent(testEventQuery)
+	results, err := suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 2, len(results))
@@ -170,7 +170,7 @@ func (suite *TestEventsSuite) TestRetrieveSingleTestEventsByName() {
 
 	testEventQuery := &testevent.Query{}
 	testevent.QueryEventName(event.Name("AEventName"))(testEventQuery)
-	results, err := suite.storage.GetTestEvent(testEventQuery)
+	results, err := suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 1, len(results))
@@ -186,7 +186,7 @@ func (suite *TestEventsSuite) TestRetrieveSingleTestEventsByNameAndJobID() {
 	testEventQuery := &testevent.Query{}
 	testevent.QueryEventName(event.Name("AEventName"))(testEventQuery)
 	testevent.QueryJobID(1)(testEventQuery)
-	results, err := suite.storage.GetTestEvent(testEventQuery)
+	results, err := suite.storage.GetTestEvents(testEventQuery)
 
 	require.NoError(suite.T(), err)
 	assert.Equal(suite.T(), 1, len(results))

--- a/tests/integ/testrunner_test.go
+++ b/tests/integ/testrunner_test.go
@@ -247,7 +247,7 @@ func TestNoReturnStepWithoutTargetForwarding(t *testing.T) {
 	select {
 	case err = <-errCh:
 		// The TestRunner should never return and should instead time out
-		assert.FailNow(t, "TestRunner should not return")
+		assert.FailNow(t, "TestRunner should not return, received an error instead: %v", err)
 	case <-time.After(testTimeout):
 		// Assert cancellation signal and expect the TestRunner to return within
 		// testShutdownTimeout


### PR DESCRIPTION
This helps documentation accuracy and readability.
Also renamed GetTestEvent to GetTestEvents to better reflect what it
does.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>