### PR TITLE
make locker configurable

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/facebookincubator/contest/pkg/config"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/jobmanager"
 	"github.com/facebookincubator/contest/pkg/logging"
@@ -23,6 +24,7 @@ import (
 	"github.com/facebookincubator/contest/plugins/reporters/noop"
 	"github.com/facebookincubator/contest/plugins/reporters/targetsuccess"
 	"github.com/facebookincubator/contest/plugins/storage/rdbms"
+	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 	"github.com/facebookincubator/contest/plugins/targetmanagers/csvtargetmanager"
 	"github.com/facebookincubator/contest/plugins/targetmanagers/targetlist"
 	"github.com/facebookincubator/contest/plugins/testfetchers/literal"
@@ -119,6 +121,9 @@ func main() {
 	// storage initialization
 	log.Infof("Using database URI: %s", *flagDBURI)
 	storage.SetStorage(rdbms.New(*flagDBURI))
+
+	// set Locker engine
+	target.SetLocker(inmemory.New(config.LockTimeout))
 
 	// user-defined function registration
 	for name, fn := range userFunctions {

--- a/pkg/config/timeouts.go
+++ b/pkg/config/timeouts.go
@@ -40,3 +40,6 @@ var TestRunnerShutdownTimeout = 30 * time.Second
 // is reset every time a step returns. The timeout should be handled so that it
 // doesn't reset when a TestStep returns.
 var TestRunnerStepShutdownTimeout = 5 * time.Second
+
+// LockTimeout represent the amount of time that a lock is held for a target
+var LockTimeout = 10 * time.Second

--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -17,7 +17,6 @@ import (
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/types"
-	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 )
 
 var jobLog = logging.GetLogger("pkg/runner")
@@ -63,9 +62,7 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 	} else {
 		jobLog.Infof("Running job '%s' %d times", j.Name, j.Runs)
 	}
-	// TODO make this configurable
-	lockTimeout := 10 * time.Second
-	tl := inmemory.New(lockTimeout)
+	tl := target.GetLocker()
 	ev := storage.NewTestEventFetcher()
 	var (
 		allRunsReports [][]*job.Report
@@ -157,7 +154,7 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 						}
 					}
 				}
-			}(j, tl, targets, lockTimeout)
+			}(j, tl, targets, config.LockTimeout)
 
 			// Run the job
 			jobLog.Infof("Run #%d: running test #%d for job '%s' (job ID: %d) on %d targets", run+1, idx, j.Name, j.ID, len(targets))

--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -6,8 +6,17 @@
 package target
 
 import (
+	"time"
+
 	"github.com/facebookincubator/contest/pkg/types"
 )
+
+// locker defines the locking engine used by ConTest.
+var locker Locker
+
+// LockerFactory is a type representing a function which builds
+// a Locker.
+type LockerFactory func(time.Duration) Locker
 
 // Locker defines an interface to lock and unlock targets. It is passed
 // to TargetManager's Acquire and Release methods, and the target manager
@@ -32,4 +41,14 @@ type Locker interface {
 	// CheckLocks returns whether all the targets are locked by the given job ID,
 	// an array of locked targets, and an array of not-locked targets.
 	CheckLocks(types.JobID, []*Target) (bool, []*Target, []*Target)
+}
+
+// SetLocker sets the desired lock engine for targets.
+func SetLocker(targetLocker Locker) {
+	locker = targetLocker
+}
+
+// GetLocker gets the desired lock engine for targets.
+func GetLocker() Locker {
+	return locker
 }

--- a/tests/integ/jobmanager/jobmanager_memory_test.go
+++ b/tests/integ/jobmanager/jobmanager_memory_test.go
@@ -9,9 +9,13 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/facebookincubator/contest/pkg/storage"
+	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/plugins/storage/memory"
+	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,6 +26,9 @@ func TestJobManagerSuiteMemoryStorage(t *testing.T) {
 	storagelayer := memory.New()
 	testSuite.storage = storagelayer
 	storage.SetStorage(storagelayer)
+
+	targetLocker := inmemory.New(10 * time.Second)
+	target.SetLocker(targetLocker)
 
 	suite.Run(t, &testSuite)
 }

--- a/tests/integ/jobmanager/jobmanager_rdbms_test.go
+++ b/tests/integ/jobmanager/jobmanager_rdbms_test.go
@@ -12,7 +12,9 @@ import (
 	"time"
 
 	"github.com/facebookincubator/contest/pkg/storage"
+	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/plugins/storage/rdbms"
+	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 	"github.com/facebookincubator/contest/tests/integ/common"
 
 	"github.com/stretchr/testify/suite"
@@ -28,6 +30,9 @@ func TestJobManagerSuiteRdbmsStorage(t *testing.T) {
 	storageLayer := common.NewStorage(opts...)
 	storage.SetStorage(storageLayer)
 	testSuite.storage = storageLayer
+
+	targetLocker := inmemory.New(10 * time.Second)
+	target.SetLocker(targetLocker)
 
 	suite.Run(t, &testSuite)
 }


### PR DESCRIPTION
Moving the lock engine instantiation from the job runner to the main, so that it can be customized.