### PR TITLE
Moved from Gophers Slack to OSF Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Limitations:
 
 * Website: https://github.com/facebookincubator/contest . Please use issues and
   pull requests!
-* IM: we are on the #ConTest channel on the Gophers Slack team. Get your invite on https://invite.slack.golangbridge.org/ if you're not there already!
+* IM: we are on the #ConTest channel on the OSF (Open Source Firmware) Slack team. Get your invite on http://u-root.tk if you're not there already!
 * See the CONTRIBUTING file for how to help out.
 
 ## License


### PR DESCRIPTION
We are moving the #contest Slack channel from the Gophers team to the
OSF team, because this is where our main target audience already
resides. This will make the chat and the project more discoverable for
potential project users.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>