### PR TITLE
Add test step index to event data

### DIFF
--- a/docker/mysql/create_contest_db.sql
+++ b/docker/mysql/create_contest_db.sql
@@ -8,6 +8,7 @@ CREATE TABLE test_events (
 	job_id BIGINT(20) NOT NULL,
 	test_name VARCHAR(32) NULL,
 	test_step_label VARCHAR(32) NULL,
+	test_step_index BIGINT(20) NULL,
 	event_name VARCHAR(32) NULL,
 	target_name VARCHAR(64) NULL,
 	target_id VARCHAR(64) NULL,

--- a/pkg/event/testevent/test.go
+++ b/pkg/event/testevent/test.go
@@ -25,9 +25,10 @@ type Header struct {
 
 // Data models the data of a test event. It is populated by the TestStep
 type Data struct {
-	EventName event.Name
-	Target    *target.Target
-	Payload   *json.RawMessage
+	EventName     event.Name
+	TestStepIndex uint
+	Target        *target.Target
+	Payload       *json.RawMessage
 }
 
 // Event models an event object that can be emitted by a TestStep

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -135,14 +135,16 @@ func NewJob(pr *pluginregistry.PluginRegistry, jobDescriptor string) (*job.Job, 
 		// look up test step plugins in the plugin registry
 		var stepBundles []test.TestStepBundle
 		labels := make(map[string]bool)
-		for _, testStepDesc := range testStepDescs {
+		for idx, testStepDesc := range testStepDescs {
 			tse, err := pr.NewTestStepEvents(testStepDesc.Name)
 			if err != nil {
 				return nil, err
 			}
-			tsb, err := pr.NewTestStepBundle(*testStepDesc, tse)
+			// test step index is incremented by 1 so we can use 0 to signal an
+			// anomaly.
+			tsb, err := pr.NewTestStepBundle(*testStepDesc, uint(idx)+1, tse)
 			if err != nil {
-				return nil, fmt.Errorf("NewTestStepBundle for test step '%s' failed: %v", testStepDesc.Name, err)
+				return nil, fmt.Errorf("NewTestStepBundle for test step '%s' with index %d failed: %v", testStepDesc.Name, idx, err)
 			}
 			if _, ok := labels[tsb.TestStepLabel]; ok {
 				// validate that the label associated to the test step does not clash

--- a/pkg/pluginregistry/bundles.go
+++ b/pkg/pluginregistry/bundles.go
@@ -15,7 +15,7 @@ import (
 )
 
 // NewTestStepBundle creates a TestStepBundle from a TestStepDescriptor
-func (r *PluginRegistry) NewTestStepBundle(testStepDescriptor test.TestStepDescriptor, allowedEvents map[event.Name]bool) (*test.TestStepBundle, error) {
+func (r *PluginRegistry) NewTestStepBundle(testStepDescriptor test.TestStepDescriptor, stepIndex uint, allowedEvents map[event.Name]bool) (*test.TestStepBundle, error) {
 	testStep, err := r.NewTestStep(testStepDescriptor.Name)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the desired TestStep (%s): %v", testStepDescriptor.Name, err)
@@ -29,6 +29,7 @@ func (r *PluginRegistry) NewTestStepBundle(testStepDescriptor test.TestStepDescr
 	}
 	testStepBundle := test.TestStepBundle{
 		TestStep:      testStep,
+		TestStepIndex: stepIndex,
 		TestStepLabel: label,
 		Parameters:    testStepDescriptor.Parameters,
 		AllowedEvents: allowedEvents,

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -191,7 +191,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 				}
 				break
 			}
-			targetInEv := testevent.Data{EventName: target.EventTargetIn, Target: injectionResult.target}
+			targetInEv := testevent.Data{EventName: target.EventTargetIn, TestStepIndex: bundle.TestStepIndex, Target: injectionResult.target}
 			if err := ev.Emit(targetInEv); err != nil {
 				log.Warningf("Could not emit %v event for Target: %v", targetInEv, *injectionResult.target)
 			}
@@ -227,7 +227,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 					break
 				}
 				// Emit an event signaling that the target has lef the TestStep
-				targetOutEv := testevent.Data{EventName: target.EventTargetOut, Target: t}
+				targetOutEv := testevent.Data{EventName: target.EventTargetOut, TestStepIndex: bundle.TestStepIndex, Target: t}
 				if err := ev.Emit(targetOutEv); err != nil {
 					log.Warningf("Could not emit %v event for Target: %v", targetOutEv, *t)
 				}
@@ -247,7 +247,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 				}
 				// Emit an event signaling that the target has lef the TestStep with an error
 				payload := json.RawMessage(fmt.Sprintf(`{"error": "%s"}`, targetError.Err))
-				targetErrEv := testevent.Data{EventName: target.EventTargetErr, Target: targetError.Target, Payload: &payload}
+				targetErrEv := testevent.Data{EventName: target.EventTargetErr, Target: targetError.Target, TestStepIndex: bundle.TestStepIndex, Payload: &payload}
 				if err := ev.Emit(targetErrEv); err != nil {
 					log.Warningf("Could not emit %v event for Target: %v", targetErrEv, *targetError.Target)
 				}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -80,6 +80,7 @@ type TestStepDescriptor struct {
 type TestStepBundle struct {
 	TestStep      TestStep
 	TestStepLabel string
+	TestStepIndex uint
 	Parameters    TestStepParameters
 	AllowedEvents map[event.Name]bool
 }

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -131,6 +131,14 @@ func TestEventTestStepLabel(ev testevent.Event) interface{} {
 	return ev.Header.TestStepLabel
 }
 
+// TestEventTestStepIndex returns the test step index from a events.TestEvent object
+func TestEventTestStepIndex(ev testevent.Event) interface{} {
+	if ev.Data == nil {
+		return nil
+	}
+	return ev.Data.TestStepIndex
+}
+
 // TestEventName returns the event name from a events.TestEvent object
 func TestEventName(ev testevent.Event) interface{} {
 	if ev.Data == nil {
@@ -199,13 +207,14 @@ func (r *RDBMS) FlushTestEvents() error {
 		return nil
 	}
 
-	insertStatement := "insert into test_events (job_id, test_name, test_step_label, event_name, target_name, target_id, payload, emit_time) values (?, ?, ?, ?, ?, ?, ?, ?)"
+	insertStatement := "insert into test_events (job_id, test_name, test_step_label, test_step_index, event_name, target_name, target_id, payload, emit_time) values (?, ?, ?, ?, ?, ?, ?, ?, ?)"
 	for _, event := range r.buffTestEvents {
 		_, err := r.db.Exec(
 			insertStatement,
 			TestEventJobID(event),
 			TestEventTestName(event),
 			TestEventTestStepLabel(event),
+			TestEventTestStepIndex(event),
 			TestEventName(event),
 			TestEventTargetName(event),
 			TestEventTargetID(event),


### PR DESCRIPTION
Knowing the sequence number of a test step can be useful to reporters.
This change adds a field called test_step_index that acts in fact as a
squence number of the test step, counting from 1.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>