### PR TITLE
Add initial support for run id in Status

### DIFF
--- a/cmds/clients/contestcli-http/start.json
+++ b/cmds/clients/contestcli-http/start.json
@@ -1,6 +1,6 @@
 {
     "JobName": "test job",
-    "Runs": 1,
+    "Runs": 3,
     "RunInterval": "5s",
     "Tags": ["test", "csv"],
     "TestDescriptors": [
@@ -17,8 +17,26 @@
             },
             "TestFetcherName": "URI",
             "TestFetcherFetchParameters": {
-                "TestName": "MyTestName",
+                "TestName": "RackSwitchProvisioning",
                 "URI": "test_samples/randecho.json"
+            }
+        },
+
+        {
+            "TargetManagerName": "CSVFileTargetManager",
+            "TargetManagerAcquireParameters": {
+                "FileURI": "hosts02.csv",
+                "MinNumberDevices": 2,
+                "MaxNumberDevices": 4,
+                "HostPrefixes": [
+                ]
+            },
+            "TargetManagerReleaseParameters": {
+            },
+            "TestFetcherName": "URI",
+            "TestFetcherFetchParameters": {
+                "TestName": "CyborgProvisioning",
+                "URI": "test_samples/slowecho.json"
             }
         }
     ],

--- a/cmds/contest/test_samples/randecho.json
+++ b/cmds/contest/test_samples/randecho.json
@@ -2,6 +2,7 @@
     "steps": [
         {
             "name": "randecho",
+	    "label": "thefirstrandecho",
             "parameters": {
                 "text": ["some very random text"]
             }

--- a/cmds/contest/test_samples/slowecho.json
+++ b/cmds/contest/test_samples/slowecho.json
@@ -1,0 +1,12 @@
+{
+    "steps": [
+        {
+            "name": "slowecho",
+	        "label": "aslowecho",
+            "parameters": {
+                "sleep": ["3"],
+		"text": ["nel mezzo del cammin"] }
+        }
+    ]
+}
+

--- a/docker/contest/tests.sh
+++ b/docker/contest/tests.sh
@@ -75,4 +75,5 @@ for tag in integration integration_storage; do
     done
 done
 
+echo "Uploading coverage profile"
 [[ ! -z ${TRAVIS} ]] && bash <(curl -s https://codecov.io/bash) -c -F integration

--- a/docker/mysql/create_contest_db.sql
+++ b/docker/mysql/create_contest_db.sql
@@ -8,7 +8,6 @@ CREATE TABLE test_events (
 	job_id BIGINT(20) NOT NULL,
 	test_name VARCHAR(32) NULL,
 	test_step_label VARCHAR(32) NULL,
-	test_step_index BIGINT(20) NULL,
 	event_name VARCHAR(32) NULL,
 	target_name VARCHAR(64) NULL,
 	target_id VARCHAR(64) NULL,

--- a/pkg/event/testevent/test.go
+++ b/pkg/event/testevent/test.go
@@ -25,10 +25,9 @@ type Header struct {
 
 // Data models the data of a test event. It is populated by the TestStep
 type Data struct {
-	EventName     event.Name
-	TestStepIndex uint
-	Target        *target.Target
-	Payload       *json.RawMessage
+	EventName event.Name
+	Target    *target.Target
+	Payload   *json.RawMessage
 }
 
 // Event models an event object that can be emitted by a TestStep

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -48,12 +48,13 @@ type Job struct {
 	// A "run" is the execution of a sequence of tests. For example, setting
 	// Runs to 2 will execute all the tests defined in `Tests` once, and then
 	// will execute them again.
-	// TODO clarify further details of how Runs will work
 	Runs uint
+
 	// RunInterval is the interval between multiple runs, if more than one, or
 	// unlimited, are specified.
 	RunInterval time.Duration
-	Tests       []*test.Test
+
+	Tests []*test.Test
 	// RunReporterBundles and FinalReporterBundles wrap the reporter instances
 	// chosen for the Job and its associated parameters, which have already
 	// gone through validation

--- a/pkg/job/status.go
+++ b/pkg/job/status.go
@@ -11,7 +11,14 @@ import (
 
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/types"
 )
+
+// The hierarchy of status objects is the following
+// (jobID,)                                -> []RunStatus [within a job, there might be multiple runs]
+// (jobID, runID)                          -> []TestStatus [within a run, there might be multiple tests]
+// (jobID, runID, testName)                -> []TestStepStatus [within a test there might be multiple steps]
+// (jobID, runID, testName, testStepLabel) -> []TargetStatus [within a step, multiple targets have been tested]
 
 // TargetStatus bundles the input time and the output time of a target through a TestStep.
 type TargetStatus struct {
@@ -24,16 +31,23 @@ type TargetStatus struct {
 // TestStepStatus bundles together all the TargetStatus for a specific TestStep (represented via
 // its name and label)
 type TestStepStatus struct {
-	TestStepName  string
-	TestStepLabel string
-	Events        []testevent.Event
-	TargetStatus  []TargetStatus
+	TestStepName   string
+	TestStepLabel  string
+	Events         []testevent.Event
+	TargetStatuses []TargetStatus
 }
 
-// TestStatus bundles together all TestStepStatus for a specific Test
+// TestStatus bundles together all TestStepStatus for a specific Test within the run
 type TestStatus struct {
-	TestName       string
-	TestStepStatus []TestStepStatus
+	TestName         string
+	TestStepStatuses []TestStepStatus
+}
+
+// RunStatus bundles together all TestStatus for a specific run within the job
+type RunStatus struct {
+	RunID        types.RunID
+	StartTime    time.Time
+	TestStatuses []TestStatus
 }
 
 // Status contains information about a job's current status which is conveyed
@@ -53,8 +67,8 @@ type Status struct {
 	// `Finished` is false.
 	EndTime time.Time
 
-	// TestStatus represents a list of status objects for each test in the job
-	TestStatus []TestStatus
+	// RunStatuses represents the status of the current run of the job
+	RunStatus RunStatus
 
 	// Job report information
 	JobReport *JobReport

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -85,16 +85,14 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 			}
 			_ = jm.emitEvent(jobID, eventToEmit)
 		}
-		if err == nil {
-			jobReport := job.JobReport{
-				JobID:        j.ID,
-				RunReports:   runReports,
-				FinalReports: finalReports,
-			}
-			err := jm.jobReportManager.Emit(&jobReport)
-			if err != nil {
-				log.Warningf("Could not emit job report: %v", err)
-			}
+		jobReport := job.JobReport{
+			JobID:        j.ID,
+			RunReports:   runReports,
+			FinalReports: finalReports,
+		}
+		err = jm.jobReportManager.Emit(&jobReport)
+		if err != nil {
+			log.Warningf("Could not emit job report: %v", err)
 		}
 	}()
 

--- a/pkg/pluginregistry/bundles.go
+++ b/pkg/pluginregistry/bundles.go
@@ -29,7 +29,6 @@ func (r *PluginRegistry) NewTestStepBundle(testStepDescriptor test.TestStepDescr
 	}
 	testStepBundle := test.TestStepBundle{
 		TestStep:      testStep,
-		TestStepIndex: stepIndex,
 		TestStepLabel: label,
 		Parameters:    testStepDescriptor.Parameters,
 		AllowedEvents: allowedEvents,

--- a/pkg/runner/event.go
+++ b/pkg/runner/event.go
@@ -1,0 +1,19 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package runner
+
+import (
+	"github.com/facebookincubator/contest/pkg/event"
+	"github.com/facebookincubator/contest/pkg/types"
+)
+
+// Payload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
+type runStartedPayload struct {
+	RunID types.RunID
+}
+
+// EventRunStarted indicates that a run has begun
+var EventRunStarted = event.Name("RunStarted")

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -191,7 +191,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 				}
 				break
 			}
-			targetInEv := testevent.Data{EventName: target.EventTargetIn, TestStepIndex: bundle.TestStepIndex, Target: injectionResult.target}
+			targetInEv := testevent.Data{EventName: target.EventTargetIn, Target: injectionResult.target}
 			if err := ev.Emit(targetInEv); err != nil {
 				log.Warningf("Could not emit %v event for Target: %v", targetInEv, *injectionResult.target)
 			}
@@ -227,7 +227,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 					break
 				}
 				// Emit an event signaling that the target has lef the TestStep
-				targetOutEv := testevent.Data{EventName: target.EventTargetOut, TestStepIndex: bundle.TestStepIndex, Target: t}
+				targetOutEv := testevent.Data{EventName: target.EventTargetOut, Target: t}
 				if err := ev.Emit(targetOutEv); err != nil {
 					log.Warningf("Could not emit %v event for Target: %v", targetOutEv, *t)
 				}
@@ -247,7 +247,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 				}
 				// Emit an event signaling that the target has lef the TestStep with an error
 				payload := json.RawMessage(fmt.Sprintf(`{"error": "%s"}`, targetError.Err))
-				targetErrEv := testevent.Data{EventName: target.EventTargetErr, Target: targetError.Target, TestStepIndex: bundle.TestStepIndex, Payload: &payload}
+				targetErrEv := testevent.Data{EventName: target.EventTargetErr, Target: targetError.Target, Payload: &payload}
 				if err := ev.Emit(targetErrEv); err != nil {
 					log.Warningf("Could not emit %v event for Target: %v", targetErrEv, *targetError.Target)
 				}
@@ -563,7 +563,7 @@ func (tr *TestRunner) WaitPipelineCompletion(terminate <-chan struct{}, ch compl
 	// in a "domino" sequence, so seeing the last channel closed indicates that the
 	// sequence of close operations has completed). If `ch.out` is still open,
 	// there are still TestSteps that might have not returned. Wait for all
-	// TestSteps to complete or `StepShutdownTimeout` to occurr.
+	// TestSteps to complete or `StepShutdownTimeout` to occur.
 	log.Printf("Waiting for all TestSteps to complete")
 	err = tr.WaitTestStep(ch, bundles)
 	return err

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -80,7 +80,6 @@ type TestStepDescriptor struct {
 type TestStepBundle struct {
 	TestStep      TestStep
 	TestStepLabel string
-	TestStepIndex uint
 	Parameters    TestStepParameters
 	AllowedEvents map[event.Name]bool
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,3 +7,6 @@ package types
 
 // JobID represents a unique job identifier
 type JobID uint64
+
+// RunID represents the id of a run within the Job
+type RunID uint64

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -131,14 +131,6 @@ func TestEventTestStepLabel(ev testevent.Event) interface{} {
 	return ev.Header.TestStepLabel
 }
 
-// TestEventTestStepIndex returns the test step index from a events.TestEvent object
-func TestEventTestStepIndex(ev testevent.Event) interface{} {
-	if ev.Data == nil {
-		return nil
-	}
-	return ev.Data.TestStepIndex
-}
-
 // TestEventName returns the event name from a events.TestEvent object
 func TestEventName(ev testevent.Event) interface{} {
 	if ev.Data == nil {
@@ -207,14 +199,13 @@ func (r *RDBMS) FlushTestEvents() error {
 		return nil
 	}
 
-	insertStatement := "insert into test_events (job_id, test_name, test_step_label, test_step_index, event_name, target_name, target_id, payload, emit_time) values (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+	insertStatement := "insert into test_events (job_id, test_name, test_step_label, event_name, target_name, target_id, payload, emit_time) values (?, ?, ?, ?, ?, ?, ?, ?)"
 	for _, event := range r.buffTestEvents {
 		_, err := r.db.Exec(
 			insertStatement,
 			TestEventJobID(event),
 			TestEventTestName(event),
 			TestEventTestStepLabel(event),
-			TestEventTestStepIndex(event),
 			TestEventName(event),
 			TestEventTargetName(event),
 			TestEventTargetID(event),

--- a/plugins/teststeps/slowecho/slowecho.go
+++ b/plugins/teststeps/slowecho/slowecho.go
@@ -105,12 +105,12 @@ processing:
 				log.Infof("Waiting %v for target %s", sleep, t.Name)
 				select {
 				case <-cancel:
-					log.Debug("Returning because cancellation is requested")
+					log.Infof("Returning because cancellation is requested")
 					return
 				case <-pause:
-					log.Debug("Returning because pause is requested")
+					log.Infof("Returning because pause is requested")
 					return
-				case <-time.After(sleep * time.Second):
+				case <-time.After(sleep):
 				}
 				log.Infof("target %s: %s", t, params.GetOne("text"))
 				select {


### PR DESCRIPTION
This patch adds support for building a status report that takes into
consideration the run id. The events API still does not know anything
about the run id, so the support is not complete, but as soon as it
is added to the query interface, it would be just a matter of adding
a new query parameter. 

Also, the concept of test step index has been removed.