### PR TITLE
Calculate run status only for runs which have been executed

### DIFF
--- a/pkg/runner/event.go
+++ b/pkg/runner/event.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Payload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
-type runStartedPayload struct {
+type RunStartedPayload struct {
 	RunID types.RunID
 }
 

--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -81,7 +81,7 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 
 		// If we can't emit the run start event, we ignore the error. The framework will
 		// try to rebuild the status if it detects that an event might have gone missing
-		payload := runStartedPayload{RunID: types.RunID(run + 1)}
+		payload := RunStartedPayload{RunID: types.RunID(run + 1)}
 		err := jr.emitEvent(j.ID, EventRunStarted, payload)
 		if err != nil {
 			jobLog.Warningf("Could not emit event run (run %d) start for job %d: %v", run+1, j.ID, err)
@@ -316,7 +316,7 @@ func (jr *JobRunner) GetCurrentRun(jobID types.JobID) (types.RunID, error) {
 	}
 
 	lastEvent := runEvents[len(runEvents)-1]
-	payload := runStartedPayload{}
+	payload := RunStartedPayload{}
 	if err := json.Unmarshal([]byte(*lastEvent.Payload), &payload); err != nil {
 		return runID, fmt.Errorf("could not fetch last run id for job %d: %v", jobID, err)
 	}

--- a/pkg/runner/job_status.go
+++ b/pkg/runner/job_status.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/facebookincubator/contest/pkg/event"
+	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -212,8 +213,31 @@ func (jr *JobRunner) BuildRunStatus(coordinates job.RunCoordinates, currentJob *
 // BuildRunStatuses builds the status of all runs belonging to the job
 func (jr *JobRunner) BuildRunStatuses(currentJob *job.Job) ([]job.RunStatus, error) {
 
-	runStatuses := make([]job.RunStatus, 0, currentJob.Runs)
-	for runID := uint(0); runID < currentJob.Runs; runID++ {
+	// Calculate the status only for the runs which effectively were executed
+	runStartEvents, err := jr.frameworkEventManager.Fetch(frameworkevent.QueryEventName(EventRunStarted))
+	if err != nil {
+		return nil, fmt.Errorf("could not determine how many runs were executed: %v", err)
+	}
+	numRuns := uint(0)
+	if len(runStartEvents) == 0 {
+		return make([]job.RunStatus, 0, currentJob.Runs), nil
+	}
+
+	payload, err := runStartEvents[len(runStartEvents)-1].Payload.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("could not extract JSON payload from RunStart event: %v", err)
+	}
+
+	payloadUnmarshaled := RunStartedPayload{}
+
+	if err := json.Unmarshal(payload, &payloadUnmarshaled); err != nil {
+		return nil, fmt.Errorf("could not unmarshal RunStarted event payload")
+	}
+	numRuns = uint(payloadUnmarshaled.RunID)
+
+	runStatuses := make([]job.RunStatus, 0, numRuns)
+
+	for runID := uint(0); runID < numRuns; runID++ {
 		runCoordinates := job.RunCoordinates{JobID: currentJob.ID, RunID: types.RunID(runID)}
 		runStatus, err := jr.BuildRunStatus(runCoordinates, currentJob)
 		if err != nil {

--- a/plugins/storage/rdbms/report.go
+++ b/plugins/storage/rdbms/report.go
@@ -36,7 +36,7 @@ func (r *RDBMS) StoreJobReport(jobReport *job.JobReport) error {
 		}
 	}
 	for _, report := range jobReport.FinalReports {
-		insertStatement := "insert into final_reports (job_id, reporter_name, success, report_time, data) values (?, ?, ?, ?)"
+		insertStatement := "insert into final_reports (job_id, reporter_name, success, report_time, data) values (?, ?, ?, ?, ?)"
 		reportJSON, err := report.ToJSON()
 		if err != nil {
 			return fmt.Errorf("could not serialize final report for job %v: %v", jobReport.JobID, err)


### PR DESCRIPTION
We should not try to build run reports for runs which have not executed.
Also, we'll need somehow to define a limit on how many runs we can
calculate a run report.