### PR TITLE
Fix IsZero() check for go < 1.13

### DIFF
--- a/pkg/event/internal/reflecttools/is_zero_other.go
+++ b/pkg/event/internal/reflecttools/is_zero_other.go
@@ -11,6 +11,22 @@ import (
 	"reflect"
 )
 
-func IsZero(v interface{}) bool {
-	return reflect.ValueOf(v) == reflect.Zero(reflect.TypeOf(v))
+func IsZero(i interface{}) bool {
+
+	v := reflect.ValueOf(i)
+	 switch v.Kind() {
+	    case reflect.Array, reflect.String:
+		return v.Len() == 0
+	    case reflect.Bool:
+		return !v.Bool()
+	    case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	    case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	    case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	    case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	    }
+	 return false
 }


### PR DESCRIPTION
From the documentation:

To compare two Values, compare the results of the Interface method.
Using == on two Values does not compare the underlying values they
represent.

Also, QueryFields might not be comparable objects, so resort to
doing a check based on the type. We should be able to get rid
of this with go1.13 and value.IsZero()