### PR TITLE
Add sample lspci job descriptor

### DIFF
--- a/cmds/clients/contestcli-http/descriptors/fwtesting/lspci.json
+++ b/cmds/clients/contestcli-http/descriptors/fwtesting/lspci.json
@@ -1,0 +1,47 @@
+{
+    "JobName": "lspci test job",
+    "Runs": 1,
+    "RunInterval": "3s",
+    "Tags": ["lscpi"],
+    "TestDescriptors": [
+        {
+            "TargetManagerName": "TargetList",
+            "TargetManagerAcquireParameters": {
+                "Targets": [
+                    {
+                        "Name": "dut1",
+                        "ID": "12345"
+                    }
+                ]
+            },
+            "TargetManagerReleaseParameters": {
+            },
+            "TestFetcherName": "literal",
+            "TestFetcherFetchParameters": {
+                "TestName": "Literal test",
+                "Steps": [
+                    {
+                        "name": "sshcmd",
+                        "parameters": {
+                                "user": ["sesame"],
+                                "host": ["{{ .Name }}"],
+                                "password": [""],
+                                "executable": ["lspci"],
+                                "expect": ["DDRIO Global Broadcast"]
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "Reporting": {
+        "RunReporters": [
+            {
+                "Name": "TargetSuccess",
+                "Parameters": {
+                    "SuccessExpression": ">80%"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Testing `sshcmd` with `expect` parameters.