### PR TITLE
Honor go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ global:
 env:
   global:
     - COMPOSE_VERSION=1.25.4
+    - GO111MODULE=on
   jobs:
     - TEST_SUITE=tests
     - TEST_SUITE=linters

--- a/.travis/linters.sh
+++ b/.travis/linters.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exu
 
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.3
 go install github.com/golangci/golangci-lint/cmd/golangci-lint
 cd "${TRAVIS_BUILD_DIR}"
 golangci-lint run --disable typecheck --enable deadcode --enable varcheck --enable staticcheck

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
                     - 8080:8080
                 depends_on:
                     - mysql
-
         mysql:
                 environment:
                     - MYSQL_RANDOM_ROOT_PASSWORD=true

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,6 @@ require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gogo/protobuf v1.3.1 // indirect
-	github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d // indirect
-	github.com/golangci/golangci-lint v1.23.3 // indirect
-	github.com/golangci/revgrep v0.0.0-20180812185044-276a5c0a1039 // indirect
 	github.com/gostaticanalysis/analysisutil v0.0.3 // indirect
 	github.com/insomniacslk/termhook v0.0.0-20190716141402-454368e885ec
 	github.com/insomniacslk/xjson v0.0.0-20190510162823-f016a4991179


### PR DESCRIPTION
I realize only now that by default go modules is ignored:

```
go get: warning: modules disabled by GO111MODULE=auto in GOPATH/src;
	ignoring go.mod;
	see 'go help modules'
```

staticcheck v2020.1.3 introduces one additional failure on possible
nil pointer dereferece which I would like to fix separately wrt #73
(putting a guard for nil value before the reference does not seem
to make the linter happy).

In any case, we shoud honor go.mod and update depdencies in a controlled
manner.