### PR TITLE
Fixed event name for EventJobCancellationFailed

### DIFF
--- a/pkg/jobmanager/event.go
+++ b/pkg/jobmanager/event.go
@@ -26,7 +26,7 @@ var EventJobCancelling = event.Name("JobStateCancelling")
 var EventJobCancelled = event.Name("JobStateCancelled")
 
 // EventJobCancellationFailed indicates that the cancellation was not completed correctly
-var EventJobCancellationFailed = event.Name("JobStateCancelled")
+var EventJobCancellationFailed = event.Name("JobStateCancellationFailed")
 
 // JobCompletionEvents gather all event that mark the end of a job
 var JobCompletionEvents = []event.Name{

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -439,7 +439,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellationFailure() {
 	// completed cancellation successfully (completing cancellation successfully
 	// means that the TestRunner returns within the timeout and that
 	// TargetManage.Release() all targets)
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancellationFailed, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancelling, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 


### PR DESCRIPTION
It was using the value of another event.

Signed-off-by: Andrea Barberio <barberio@fb.com>