### PR TITLE
Fix the integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/pkg/jobmanager/event.go
+++ b/pkg/jobmanager/event.go
@@ -26,7 +26,7 @@ var EventJobCancelling = event.Name("JobStateCancelling")
 var EventJobCancelled = event.Name("JobStateCancelled")
 
 // EventJobCancellationFailed indicates that the cancellation was not completed correctly
-var EventJobCancellationFailed = event.Name("JobStateCancelled")
+var EventJobCancellationFailed = event.Name("JobStateCancellationFailed")
 
 // JobCompletionEvents gather all event that mark the end of a job
 var JobCompletionEvents = []event.Name{

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -439,7 +439,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellationFailure() {
 	// completed cancellation successfully (completing cancellation successfully
 	// means that the TestRunner returns within the timeout and that
 	// TargetManage.Release() all targets)
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancellationFailed, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancelled, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 


### PR DESCRIPTION
Fix a typo in integration test "TestJobManagerJobCancellation".
Comment says the cancellation should be successful, but in the code it was expected an unsuccessful cancellation.