### PR TITLE
Unify job and test descriptors in job structures

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -54,6 +54,10 @@ type Job struct {
 	// unlimited, are specified.
 	RunInterval time.Duration
 
+	// TestDescriptors is the string form of the fetched test step
+	// descriptors.
+	TestDescriptors string
+	// Tests is the parsed form of the above TestDescriptors
 	Tests []*test.Test
 	// RunReporterBundles and FinalReporterBundles wrap the reporter instances
 	// chosen for the Job and its associated parameters, which have already

--- a/pkg/job/request.go
+++ b/pkg/job/request.go
@@ -8,7 +8,6 @@ package job
 import (
 	"time"
 
-	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
@@ -19,18 +18,21 @@ type Request struct {
 	Requestor     string
 	RequestTime   time.Time
 	JobDescriptor string
+	// TestDescriptors are the fetched test steps as per the test fetcher
+	// defined in the JobDescriptor above.
+	TestDescriptors string
 }
 
 // RequestEmitter is an interface implemented by creator objects that
 // create Request objects
 type RequestEmitter interface {
-	Emit(jobRequest *Request, testDescriptors [][]*test.TestStepDescriptor) (types.JobID, error)
+	Emit(jobRequest *Request) (types.JobID, error)
 }
 
 // RequestFetcher is an interface implemented by fetcher objects that fetch
 // job requests objects and the associated test step descriptors.
 type RequestFetcher interface {
-	Fetch(id types.JobID) (*Request, [][]*test.TestStepDescriptor, error)
+	Fetch(id types.JobID) (*Request, error)
 }
 
 // RequestEmitterFetcher is an interface implemented by objects that implement both

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -16,19 +16,20 @@ import (
 
 func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 	msg := ev.Msg.(api.EventStartMsg)
-	j, testDescriptors, err := NewJob(jm.pluginRegistry, msg.JobDescriptor)
+	j, err := NewJob(jm.pluginRegistry, msg.JobDescriptor)
 	if err != nil {
 		return &api.EventResponse{Err: err}
 	}
 	// The job descriptor has been validated correctly, now use the JobRequestEmitter
 	// interface to obtain a JobRequest object with a valid id
 	request := job.Request{
-		JobName:       j.Name,
-		Requestor:     string(ev.Msg.Requestor()),
-		RequestTime:   time.Now(),
-		JobDescriptor: msg.JobDescriptor,
+		JobName:         j.Name,
+		Requestor:       string(ev.Msg.Requestor()),
+		RequestTime:     time.Now(),
+		JobDescriptor:   msg.JobDescriptor,
+		TestDescriptors: j.TestDescriptors,
 	}
-	jobID, err := jm.jobRequestManager.Emit(&request, testDescriptors)
+	jobID, err := jm.jobRequestManager.Emit(&request)
 	if err != nil {
 		return &api.EventResponse{
 			Requestor: ev.Msg.Requestor(),

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -45,7 +45,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 		return &api.EventResponse{
 			JobID:     jobID,
 			Requestor: ev.Msg.Requestor(),
-			Err:       fmt.Errorf("job manager is not owner of job id: %v", jobID),
+			Err:       fmt.Errorf("job manager is not owner of job id %d", jobID),
 		}
 	}
 

--- a/pkg/storage/jobs.go
+++ b/pkg/storage/jobs.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/facebookincubator/contest/pkg/job"
-	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
@@ -29,9 +28,9 @@ type JobRequestEmitterFetcher struct {
 }
 
 // Emit persists a new job request into storage
-func (rc JobRequestEmitter) Emit(request *job.Request, testDescriptors [][]*test.TestStepDescriptor) (types.JobID, error) {
+func (rc JobRequestEmitter) Emit(request *job.Request) (types.JobID, error) {
 	var jobID types.JobID
-	jobID, err := storage.StoreJobRequest(request, testDescriptors)
+	jobID, err := storage.StoreJobRequest(request)
 	if err != nil {
 		return jobID, fmt.Errorf("could not store job request: %w", err)
 	}
@@ -39,12 +38,12 @@ func (rc JobRequestEmitter) Emit(request *job.Request, testDescriptors [][]*test
 }
 
 // Fetch fetches a Job request from storage based on job id
-func (rf JobRequestFetcher) Fetch(jobID types.JobID) (*job.Request, [][]*test.TestStepDescriptor, error) {
-	request, testDescriptors, err := storage.GetJobRequest(jobID)
+func (rf JobRequestFetcher) Fetch(jobID types.JobID) (*job.Request, error) {
+	request, err := storage.GetJobRequest(jobID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not fetch job request: %w", err)
+		return nil, fmt.Errorf("could not fetch job request: %w", err)
 	}
-	return request, testDescriptors, nil
+	return request, nil
 }
 
 // NewJobRequestEmitter creates a JobRequestEmitter object

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -9,7 +9,6 @@ import (
 	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/job"
-	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
@@ -28,8 +27,8 @@ type Storage interface {
 	GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]frameworkevent.Event, error)
 
 	// Job request interface
-	StoreJobRequest(request *job.Request, testDescriptors [][]*test.TestStepDescriptor) (types.JobID, error)
-	GetJobRequest(jobID types.JobID) (*job.Request, [][]*test.TestStepDescriptor, error)
+	StoreJobRequest(request *job.Request) (types.JobID, error)
+	GetJobRequest(jobID types.JobID) (*job.Request, error)
 
 	// Job report interface
 	StoreJobReport(report *job.JobReport) error

--- a/plugins/storage/rdbms/request.go
+++ b/plugins/storage/rdbms/request.go
@@ -15,21 +15,16 @@ import (
 )
 
 // StoreJobRequest stores a new job request in the database
-func (r *RDBMS) StoreJobRequest(request *job.Request, testDescriptors [][]*test.TestStepDescriptor) (types.JobID, error) {
+func (r *RDBMS) StoreJobRequest(request *job.Request) (types.JobID, error) {
 
 	var jobID types.JobID
 
 	r.lockTx()
 	defer r.unlockTx()
 
-	jsonTestDescs, err := json.Marshal(testDescriptors)
-	if err != nil {
-		return jobID, fmt.Errorf("failed to marshal test descriptors: %w", err)
-	}
-
 	// store job descriptor
 	insertStatement := "insert into jobs (name, descriptor, teststeps, requestor, request_time) values (?, ?, ?, ?, ?)"
-	result, err := r.db.Exec(insertStatement, request.JobName, request.JobDescriptor, jsonTestDescs, request.Requestor, request.RequestTime)
+	result, err := r.db.Exec(insertStatement, request.JobName, request.JobDescriptor, request.TestDescriptors, request.Requestor, request.RequestTime)
 	if err != nil {
 		return jobID, fmt.Errorf("could not store job request in database: %w", err)
 	}
@@ -38,13 +33,12 @@ func (r *RDBMS) StoreJobRequest(request *job.Request, testDescriptors [][]*test.
 		return jobID, fmt.Errorf("could not extract id of last request inserted into db")
 	}
 	jobID = types.JobID(lastID)
-	log.Infof("Got JOB ID %d", jobID)
 
 	return jobID, nil
 }
 
 // GetJobRequest retrieves a JobRequest from the database
-func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, [][]*test.TestStepDescriptor, error) {
+func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, error) {
 
 	r.lockTx()
 	defer r.unlockTx()
@@ -53,7 +47,7 @@ func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, [][]*test.TestSt
 	log.Debugf("Executing query: %s", selectStatement)
 	rows, err := r.db.Query(selectStatement, jobID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not get job request with id %v: %v", jobID, err)
+		return nil, fmt.Errorf("could not get job request with id %v: %v", jobID, err)
 	}
 	defer func() {
 		if err := rows.Close(); err != nil {
@@ -62,16 +56,14 @@ func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, [][]*test.TestSt
 	}()
 
 	var (
-		req               *job.Request
-		testStepDescsJSON []byte
-		testStepDescs     [][]*test.TestStepDescriptor
+		req *job.Request
 	)
 	found := false
 	for rows.Next() {
 		if req != nil {
 			// We have already found a matching request. If we find more than one,
 			// then we have a problem
-			return nil, nil, fmt.Errorf("multiple requests found with job id %v", jobID)
+			return nil, fmt.Errorf("multiple requests found with job id %v", jobID)
 		}
 		found = true
 		currRequest := job.Request{}
@@ -81,22 +73,29 @@ func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, [][]*test.TestSt
 			&currRequest.Requestor,
 			&currRequest.RequestTime,
 			&currRequest.JobDescriptor,
-			&testStepDescsJSON,
+			&currRequest.TestDescriptors,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("could not get job request with job id %v: %v", jobID, err)
+			return nil, fmt.Errorf("could not get job request with job id %v: %v", jobID, err)
 		}
 		req = &currRequest
 	}
 	if !found {
-		return nil, nil, fmt.Errorf("no job request found for job ID %d", jobID)
+		return nil, fmt.Errorf("no job request found for job ID %d", jobID)
 	}
-	if err := json.Unmarshal(testStepDescsJSON, &testStepDescs); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal test step descriptors: %w", err)
+	// check that job descriptor is valid JSON
+	var jobDesc job.JobDescriptor
+	if err := json.Unmarshal([]byte(req.JobDescriptor), &jobDesc); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal job descriptor: %w", err)
+	}
+	// check that test step descriptors are valid JSON
+	var testStepDescs [][]*test.TestStepDescriptor
+	if err := json.Unmarshal([]byte(req.TestDescriptors), &testStepDescs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal test step descriptors: %w", err)
 	}
 
 	if req == nil {
-		return nil, nil, fmt.Errorf("could not find request with JobID %d", jobID)
+		return nil, fmt.Errorf("could not find request with JobID %d", jobID)
 	}
-	return req, testStepDescs, nil
+	return req, nil
 }

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -259,13 +259,12 @@ func (suite *TestJobManagerSuite) TestJobManagerJobStartSingle() {
 	jobID, err := suite.startJob(jobDescriptorNoop)
 	require.NoError(suite.T(), err)
 
-	_, _, err = suite.jobRequestManager.Fetch(types.JobID(jobID))
+	_, err = suite.jobRequestManager.Fetch(types.JobID(jobID))
 	require.NoError(suite.T(), err)
 
-	r, steps, err := suite.jobRequestManager.Fetch(types.JobID(jobID + 1))
+	r, err := suite.jobRequestManager.Fetch(types.JobID(jobID + 1))
 	require.Error(suite.T(), err)
 	require.NotEqual(suite.T(), nil, r)
-	require.NotEqual(suite.T(), nil, steps)
 
 	// JobManager will emit an EventJobStarted when the Job is started
 	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobStarted, types.JobID(jobID))


### PR DESCRIPTION
In this commit I've unified job and test descriptors in the `job.Request` object, as also hinted by @xaionaro in #76.