### PR TITLE
Merge job events interfaces

### DIFF
--- a/docker/contest/tests.sh
+++ b/docker/contest/tests.sh
@@ -9,7 +9,9 @@
 # See https://github.com/codecov/example-go#caveat-multiple-files
 # and https://github.com/insomniacslk/dhcp/tree/master/.travis/tests.sh
 
-set -e
+set -eu
+
+CI=${CI:-false}
 
 # Wait until mysql instance is up and running.
 attempts=0
@@ -48,7 +50,13 @@ done
 
 # Distinguish between coverage for unit tests and integration tests
 # Report coverage for unit tests and clear workspace afterwards (-c)
-[[ ! -z ${TRAVIS} ]] && bash <(curl -s https://codecov.io/bash) -c -F unittests
+if [ "${CI}" == "true" ]
+then
+    echo "Uploading coverage profile for unit tests"
+    [[ ! -z ${CI} ]] && bash <(curl -s https://codecov.io/bash) -c -F unittests
+else
+    echo "Skipping upload of coverage profile for unit tests because not running in a CI"
+fi
 
 # Run integration tests collecting coverage only for the business logic (pkg directory)
 for tag in integration integration_storage; do
@@ -75,5 +83,10 @@ for tag in integration integration_storage; do
     done
 done
 
-echo "Uploading coverage profile"
-[[ ! -z ${TRAVIS} ]] && bash <(curl -s https://codecov.io/bash) -c -F integration
+if [ "${CI}" == "true" ]
+then
+    echo "Uploading coverage profile for integration tests"
+    bash <(curl -s https://codecov.io/bash) -c -F integration
+else
+    echo "Skipping upload of coverage profile for integration tests because not running in a CI"
+fi

--- a/pkg/job/eventmanager.go
+++ b/pkg/job/eventmanager.go
@@ -1,0 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package job
+
+// EventEmitterFetcher wraps various job event interfaces
+type EventEmitterFetcher interface {
+	RequestEmitterFetcher
+	ReportEmitterFetcher
+}

--- a/pkg/job/report.go
+++ b/pkg/job/report.go
@@ -40,12 +40,12 @@ func (r *Report) ToJSON() ([]byte, error) {
 
 // ReportEmitter is an interface implemented by objects that implement report emission logic
 type ReportEmitter interface {
-	Emit(jobReport *JobReport) error
+	EmitReport(jobReport *JobReport) error
 }
 
 // ReportFetcher is an interface implemented by objects that implement report fetching logic
 type ReportFetcher interface {
-	Fetch(jobID types.JobID) (*JobReport, error)
+	FetchReport(jobID types.JobID) (*JobReport, error)
 }
 
 // ReportEmitterFetcher is an interface implemented by objects the implement report emission

--- a/pkg/job/request.go
+++ b/pkg/job/request.go
@@ -26,13 +26,13 @@ type Request struct {
 // RequestEmitter is an interface implemented by creator objects that
 // create Request objects
 type RequestEmitter interface {
-	Emit(jobRequest *Request) (types.JobID, error)
+	EmitRequest(jobRequest *Request) (types.JobID, error)
 }
 
 // RequestFetcher is an interface implemented by fetcher objects that fetch
 // job requests objects and the associated test step descriptors.
 type RequestFetcher interface {
-	Fetch(id types.JobID) (*Request, error)
+	FetchRequest(id types.JobID) (*Request, error)
 }
 
 // RequestEmitterFetcher is an interface implemented by objects that implement both

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -52,8 +52,7 @@ type JobManager struct {
 	jobsMu sync.Mutex
 	jobsWg sync.WaitGroup
 
-	jobRequestManager  job.RequestEmitterFetcher
-	jobReportManager   job.ReportEmitterFetcher
+	jobEventManager    job.EventEmitterFetcher
 	frameworkEvManager frameworkevent.EmitterFetcher
 	testEvManager      testevent.Fetcher
 
@@ -207,8 +206,7 @@ func New(l api.Listener, pr *pluginregistry.PluginRegistry) (*JobManager, error)
 	if pr == nil {
 		return nil, errors.New("plugin registry cannot be nil")
 	}
-	jobRequestManager := storage.NewJobRequestEmitterFetcher()
-	jobReportManager := storage.NewJobReportEmitterFetcher()
+	jobEventManager := storage.NewJobEventEmitterFetcher()
 
 	frameworkEvManager := storage.NewFrameworkEventEmitterFetcher()
 	testEvManager := storage.NewTestEventFetcher()
@@ -217,8 +215,7 @@ func New(l api.Listener, pr *pluginregistry.PluginRegistry) (*JobManager, error)
 		apiListener:        l,
 		pluginRegistry:     pr,
 		jobs:               make(map[types.JobID]*job.Job),
-		jobRequestManager:  jobRequestManager,
-		jobReportManager:   jobReportManager,
+		jobEventManager:    jobEventManager,
 		frameworkEvManager: frameworkEvManager,
 		testEvManager:      testEvManager,
 		apiCancel:          make(chan struct{}),

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -29,7 +29,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 		JobDescriptor:   msg.JobDescriptor,
 		TestDescriptors: j.TestDescriptors,
 	}
-	jobID, err := jm.jobRequestManager.Emit(&request)
+	jobID, err := jm.jobEventManager.EmitRequest(&request)
 	if err != nil {
 		return &api.EventResponse{
 			Requestor: ev.Msg.Requestor(),
@@ -91,7 +91,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 			RunReports:   runReports,
 			FinalReports: finalReports,
 		}
-		err = jm.jobReportManager.Emit(&jobReport)
+		err = jm.jobEventManager.EmitReport(&jobReport)
 		if err != nil {
 			log.Warningf("Could not emit job report: %v", err)
 		}

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -19,7 +19,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 	msg := ev.Msg.(api.EventStatusMsg)
 	jobID := msg.JobID
 
-	report, err := jm.jobReportManager.Fetch(jobID)
+	report, err := jm.jobEventManager.FetchReport(jobID)
 	if err != nil {
 		return &api.EventResponse{
 			JobID:     jobID,

--- a/pkg/storage/jobevents.go
+++ b/pkg/storage/jobevents.go
@@ -1,0 +1,21 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package storage
+
+import (
+	"github.com/facebookincubator/contest/pkg/job"
+)
+
+// JobEventEmitterFetcher wraps all the job-related emitters and fetchers.
+type JobEventEmitterFetcher struct {
+	JobRequestEmitterFetcher
+	JobReportEmitterFetcher
+}
+
+// NewJobEventEmitterFetcher creates a new emitter/fetcher object for job events
+func NewJobEventEmitterFetcher() job.EventEmitterFetcher {
+	return JobEventEmitterFetcher{}
+}

--- a/pkg/storage/report.go
+++ b/pkg/storage/report.go
@@ -26,16 +26,16 @@ type JobReportEmitterFetcher struct {
 	JobReportFetcher
 }
 
-// Emit emits the report using the selected storage layer
-func (e JobReportEmitter) Emit(jobReport *job.JobReport) error {
+// EmitReport emits the report using the selected storage layer
+func (e JobReportEmitter) EmitReport(jobReport *job.JobReport) error {
 	if err := storage.StoreJobReport(jobReport); err != nil {
 		return fmt.Errorf("could not persist job report: %v", err)
 	}
 	return nil
 }
 
-// Fetch retrieves job report objects based on JobID
-func (ev JobReportFetcher) Fetch(jobID types.JobID) (*job.JobReport, error) {
+// FetchReport retrieves job report objects based on JobID
+func (ev JobReportFetcher) FetchReport(jobID types.JobID) (*job.JobReport, error) {
 	report, err := storage.GetJobReport(jobID)
 	if err != nil {
 		return nil, err
@@ -55,8 +55,5 @@ func NewJobReportFetcher() job.ReportFetcher {
 
 // NewJobReportEmitterFetcher creates a new EmitterFetcher object for Job reports
 func NewJobReportEmitterFetcher() job.ReportEmitterFetcher {
-	return JobReportEmitterFetcher{
-		JobReportEmitter{},
-		JobReportFetcher{},
-	}
+	return JobReportEmitterFetcher{}
 }

--- a/pkg/storage/request.go
+++ b/pkg/storage/request.go
@@ -27,8 +27,8 @@ type JobRequestEmitterFetcher struct {
 	JobRequestFetcher
 }
 
-// Emit persists a new job request into storage
-func (rc JobRequestEmitter) Emit(request *job.Request) (types.JobID, error) {
+// EmitRequest persists a new job request into storage
+func (rc JobRequestEmitter) EmitRequest(request *job.Request) (types.JobID, error) {
 	var jobID types.JobID
 	jobID, err := storage.StoreJobRequest(request)
 	if err != nil {
@@ -37,8 +37,8 @@ func (rc JobRequestEmitter) Emit(request *job.Request) (types.JobID, error) {
 	return jobID, nil
 }
 
-// Fetch fetches a Job request from storage based on job id
-func (rf JobRequestFetcher) Fetch(jobID types.JobID) (*job.Request, error) {
+// FetchRequest fetches a Job request from storage based on job id
+func (rf JobRequestFetcher) FetchRequest(jobID types.JobID) (*job.Request, error) {
 	request, err := storage.GetJobRequest(jobID)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch job request: %w", err)
@@ -58,8 +58,5 @@ func NewJobRequestFetcher() job.RequestFetcher {
 
 // NewJobRequestEmitterFetcher creates a JobRequestEmitterFetcher object
 func NewJobRequestEmitterFetcher() job.RequestEmitterFetcher {
-	return JobRequestEmitterFetcher{
-		JobRequestEmitter{},
-		JobRequestFetcher{},
-	}
+	return JobRequestEmitterFetcher{}
 }


### PR DESCRIPTION
This commit simplifies the amount of interfaces we use for emitting and
retrieving job-related events. This is in preparation of adding more
methods to access more job-related data.

Signed-off-by: Andrea Barberio <barberio@fb.com>