### PR TITLE
Read job status entirely from the database

### DIFF
--- a/docker/mysql/create_contest_db.sql
+++ b/docker/mysql/create_contest_db.sql
@@ -51,6 +51,7 @@ CREATE TABLE jobs (
 	job_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
 	name VARCHAR(32) NOT NULL,
 	requestor VARCHAR(32) NOT NULL,
+	server_id VARCHAR(64) NOT NULL,
 	request_time TIMESTAMP NOT NULL,
 	descriptor TEXT NOT NULL,
 	teststeps TEXT,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -144,15 +144,16 @@ func (a *API) SendReceiveEvent(ev *Event, timeout *time.Duration) (*EventRespons
 // This method should return an error if the job description is malformed or
 // invalid, and if the API version is incompatible.
 func (a *API) Start(requestor EventRequestor, jobDescriptor string) (Response, error) {
+	resp := a.newResponse(ResponseTypeStart)
 	ev := &Event{
-		Type: EventTypeStart,
+		Type:     EventTypeStart,
+		ServerID: resp.ServerID,
 		Msg: EventStartMsg{
 			requestor:     requestor,
 			JobDescriptor: jobDescriptor,
 		},
 		RespCh: make(chan *EventResponse, 1),
 	}
-	resp := a.newResponse(ResponseTypeStart)
 	respEv, err := a.SendReceiveEvent(ev, nil)
 	if err != nil {
 		return resp, err
@@ -166,15 +167,16 @@ func (a *API) Start(requestor EventRequestor, jobDescriptor string) (Response, e
 
 // Stop requests a job cancellation by the given job ID.
 func (a *API) Stop(requestor EventRequestor, jobID types.JobID) (Response, error) {
+	resp := a.newResponse(ResponseTypeStop)
 	ev := &Event{
-		Type: EventTypeStop,
+		Type:     EventTypeStop,
+		ServerID: resp.ServerID,
 		Msg: EventStopMsg{
 			requestor: requestor,
 			JobID:     jobID,
 		},
 		RespCh: make(chan *EventResponse, 1),
 	}
-	resp := a.newResponse(ResponseTypeStop)
 	respEv, err := a.SendReceiveEvent(ev, nil)
 	if err != nil {
 		return resp, err
@@ -187,15 +189,16 @@ func (a *API) Stop(requestor EventRequestor, jobID types.JobID) (Response, error
 // Status polls the status of a job by its ID, and returns a contest.Status
 //object
 func (a *API) Status(requestor EventRequestor, jobID types.JobID) (Response, error) {
+	resp := a.newResponse(ResponseTypeStatus)
 	ev := &Event{
-		Type: EventTypeStatus,
+		Type:     EventTypeStatus,
+		ServerID: resp.ServerID,
 		Msg: EventStatusMsg{
 			requestor: requestor,
 			JobID:     jobID,
 		},
 		RespCh: make(chan *EventResponse, 1),
 	}
-	resp := a.newResponse(ResponseTypeStatus)
 	respEv, err := a.SendReceiveEvent(ev, nil)
 	if err != nil {
 		return resp, err
@@ -210,15 +213,16 @@ func (a *API) Status(requestor EventRequestor, jobID types.JobID) (Response, err
 // Retry will retry a job identified by its ID, using the same job
 // description. If the job is still running, an error is returned.
 func (a *API) Retry(requestor EventRequestor, jobID types.JobID) (Response, error) {
+	resp := a.newResponse(ResponseTypeRetry)
 	ev := &Event{
-		Type: EventTypeRetry,
+		Type:     EventTypeRetry,
+		ServerID: resp.ServerID,
 		Msg: EventRetryMsg{
 			requestor: requestor,
 			JobID:     jobID,
 		},
 		RespCh: make(chan *EventResponse, 1),
 	}
-	resp := a.newResponse(ResponseTypeRetry)
 	respEv, err := a.SendReceiveEvent(ev, nil)
 	if err != nil {
 		return resp, err

--- a/pkg/api/event.go
+++ b/pkg/api/event.go
@@ -46,9 +46,10 @@ const (
 // Event represents an event that the API can generate. This is used by the API
 // listener to enable event handling.
 type Event struct {
-	Type EventType
-	Err  error
-	Msg  EventMsg
+	Type     EventType
+	ServerID string
+	Err      error
+	Msg      EventMsg
 	// RespCh is a channel where the JobManager can send the responses back to
 	// what generated the event. E.g. if a job status is requested, the answer
 	// goes back to the caller in an EventResponse via this channel.

--- a/pkg/job/eventmanager.go
+++ b/pkg/job/eventmanager.go
@@ -9,4 +9,5 @@ package job
 type EventEmitterFetcher interface {
 	RequestEmitterFetcher
 	ReportEmitterFetcher
+	InfoFetcher
 }

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -85,3 +85,10 @@ func (j *Job) IsCancelled() bool {
 		return false
 	}
 }
+
+// InfoFetcher defines how to fetch job information
+type InfoFetcher interface {
+	FetchJob(types.JobID) (*Job, error)
+	FetchJobs([]types.JobID) ([]*Job, error)
+	FetchJobIDsByServerID(serverID string) ([]types.JobID, error)
+}

--- a/pkg/job/request.go
+++ b/pkg/job/request.go
@@ -16,6 +16,7 @@ type Request struct {
 	JobID         types.JobID
 	JobName       string
 	Requestor     string
+	ServerID      string
 	RequestTime   time.Time
 	JobDescriptor string
 	// TestDescriptors are the fetched test steps as per the test fetcher

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -25,6 +25,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 	request := job.Request{
 		JobName:         j.Name,
 		Requestor:       string(ev.Msg.Requestor()),
+		ServerID:        ev.ServerID,
 		RequestTime:     time.Now(),
 		JobDescriptor:   msg.JobDescriptor,
 		TestDescriptors: j.TestDescriptors,

--- a/pkg/storage/jobevents.go
+++ b/pkg/storage/jobevents.go
@@ -13,6 +13,7 @@ import (
 type JobEventEmitterFetcher struct {
 	JobRequestEmitterFetcher
 	JobReportEmitterFetcher
+	JobInfoFetcher
 }
 
 // NewJobEventEmitterFetcher creates a new emitter/fetcher object for job events

--- a/pkg/storage/jobs.go
+++ b/pkg/storage/jobs.go
@@ -1,0 +1,39 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package storage
+
+import (
+	"errors"
+
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/types"
+)
+
+// JobInfoFetcher implements job.JobInfoFetcher to retrieve job information from
+// the database.
+type JobInfoFetcher struct{}
+
+// FetchJob returns a job object after rebuilding it from the database.
+// If the job doesn't exist or cannot be rebuilt, an error is returned.
+func (jf JobInfoFetcher) FetchJob(jobID types.JobID) (*job.Job, error) {
+	return nil, errors.New("not implemented yet")
+}
+
+// FetchJobs works like FetchJob, but it operates on multiple job IDs. If a job
+// doesn't exist or cannot be rebuilt, an error is returned.
+func (jf JobInfoFetcher) FetchJobs(jobIDs []types.JobID) ([]*job.Job, error) {
+	return nil, errors.New("not implemented yet")
+}
+
+// FetchJobIDsByServerID returns all the job IDs belonging to the provided server ID.
+func (jf JobInfoFetcher) FetchJobIDsByServerID(serverID string) ([]types.JobID, error) {
+	return nil, errors.New("not implemented yet")
+}
+
+// NewJobInfoFetcher creates a JobRequestEmitterFetcher object
+func NewJobInfoFetcher() job.InfoFetcher {
+	return JobInfoFetcher{}
+}

--- a/plugins/storage/rdbms/request.go
+++ b/plugins/storage/rdbms/request.go
@@ -23,8 +23,8 @@ func (r *RDBMS) StoreJobRequest(request *job.Request) (types.JobID, error) {
 	defer r.unlockTx()
 
 	// store job descriptor
-	insertStatement := "insert into jobs (name, descriptor, teststeps, requestor, request_time) values (?, ?, ?, ?, ?)"
-	result, err := r.db.Exec(insertStatement, request.JobName, request.JobDescriptor, request.TestDescriptors, request.Requestor, request.RequestTime)
+	insertStatement := "insert into jobs (name, descriptor, teststeps, requestor, server_id, request_time) values (?, ?, ?, ?, ?, ?)"
+	result, err := r.db.Exec(insertStatement, request.JobName, request.JobDescriptor, request.TestDescriptors, request.Requestor, request.ServerID, request.RequestTime)
 	if err != nil {
 		return jobID, fmt.Errorf("could not store job request in database: %w", err)
 	}
@@ -43,7 +43,7 @@ func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, error) {
 	r.lockTx()
 	defer r.unlockTx()
 
-	selectStatement := "select job_id, name, requestor, request_time, descriptor, teststeps from jobs where job_id = ?"
+	selectStatement := "select job_id, name, requestor, server_id, request_time, descriptor, teststeps from jobs where job_id = ?"
 	log.Debugf("Executing query: %s", selectStatement)
 	rows, err := r.db.Query(selectStatement, jobID)
 	if err != nil {
@@ -71,6 +71,7 @@ func (r *RDBMS) GetJobRequest(jobID types.JobID) (*job.Request, error) {
 			&currRequest.JobID,
 			&currRequest.JobName,
 			&currRequest.Requestor,
+			&currRequest.ServerID,
 			&currRequest.RequestTime,
 			&currRequest.JobDescriptor,
 			&currRequest.TestDescriptors,


### PR DESCRIPTION
Currently we cache job information in memory. However if the ConTest
instance is restarted, or if it's not the owner of a specific job, it
will not be able to reply to a status request.
Reading the database directly will allow any instance with access to the
database to report the status of a job, regardless of the above
conditions. This will enable reliable access to historical data, and
sharding of the ConTest instances. This is also a building block to
enable job resumption.
This introduces a harder dependency on the DB, which should be fair as
the status ownership should always be in the DB, especially valid for
sharded deployments.

Signed-off-by: Andrea Barberio <barberio@fb.com>