### PR TITLE
Change type of test step Param to wrap json.RawMessage

### DIFF
--- a/pkg/test/parameter.go
+++ b/pkg/test/parameter.go
@@ -15,15 +15,16 @@ import (
 	"github.com/facebookincubator/contest/pkg/target"
 )
 
-// NewParam inititalizes a new Param object from a string
-func NewParam(s string) Param {
+// NewParam inititalizes a new Param object directly from a string.
+// Note that no validation is performed if the input is actually valid JSON.
+func NewParam(s string) *Param {
 	var p Param
 	p.RawMessage = json.RawMessage(s)
-	return p
+	return &p
 }
 
 // Param represents a test step parameter. It is initialized from JSON,
-// and can be either a strings or more complex JSON structures.
+// and can be a string or a more complex JSON structure.
 // Plugins are expected to know which one they expect and use the
 // provided convenience functions to obtain either the string or
 // json.RawMessage representation.
@@ -36,6 +37,9 @@ func (p Param) IsEmpty() bool {
 	return p.String() == ""
 }
 
+// String returns the parameter as a string. This helper never fails.
+// If the underlying JSON cannot be unmarshalled into a simple string,
+// this function returns a string representation of the JSON structure.
 func (p Param) String() string {
 	var str string
 	if json.Unmarshal(p.RawMessage, &str) == nil {
@@ -44,9 +48,10 @@ func (p Param) String() string {
 	// can't unmarshal to string, return raw json
 	return string(p.RawMessage)
 }
-
-func (p *Param) UnmarshalJSON(data []byte) error {
-	return json.Unmarshal(data, &p.RawMessage)
+// JSON returns the parameter as json.RawMessage for further
+// unmarshalling by the test plugin.
+func (p Param) JSON() json.RawMessage {
+	return p.RawMessage
 }
 
 // Expand evaluates the raw expression and applies the necessary manipulation,

--- a/pkg/test/parameter.go
+++ b/pkg/test/parameter.go
@@ -15,6 +15,13 @@ import (
 	"github.com/facebookincubator/contest/pkg/target"
 )
 
+// NewParam inititalizes a new Param object from a string
+func NewParam(s string) Param {
+	var p Param
+	p.RawMessage = json.RawMessage(s)
+	return p
+}
+
 // Param represents a test step parameter. It is initialized from JSON,
 // and can be either a strings or more complex JSON structures.
 // Plugins are expected to know which one they expect and use the

--- a/pkg/test/parameter.go
+++ b/pkg/test/parameter.go
@@ -7,6 +7,7 @@ package test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"text/template"
@@ -14,16 +15,36 @@ import (
 	"github.com/facebookincubator/contest/pkg/target"
 )
 
-// Param represents a test step parameter. It is initialized from a string,
-// which can be either a host name, a function expression, or just any regular
-// string. It enables hostname and function expression validation and a few
-// other validation operations. This is meant to simplify the way plugin access
-// and use test step parameters.
-type Param string
+// Param represents a test step parameter. It is initialized from JSON,
+// and can be either a strings or more complex JSON structures.
+// Plugins are expected to know which one they expect and use the
+// provided convenience functions to obtain either the string or
+// json.RawMessage representation.
+// Simple strings can contain simple function expressions that can
+// be expanded, for example to include the hostname of the test target.
+type Param json.RawMessage
 
 // IsEmpty returns true if the original raw string is empty, false otherwise.
 func (p Param) IsEmpty() bool {
-	return p == ""
+	return p.String() == ""
+}
+
+// String returns the parameter as a string. This helper never fails.
+// If the underlying JSON cannot be unmarshalled into a simple string,
+// this function returns a string representation of the JSON structure.
+func (p Param) String() string {
+	var s string
+	if err := json.Unmarshal(p, &s); err == nil {
+		return s
+	}
+	// full JSON
+	return string(p)
+}
+
+// JSON returns the parameter as json.RawMessage for further
+// unmarshalling by the plugin.
+func (p Param) JSON() json.RawMessage {
+	return json.RawMessage(p)
 }
 
 // Expand evaluates the raw expression and applies the necessary manipulation,

--- a/pkg/test/parameter_test.go
+++ b/pkg/test/parameter_test.go
@@ -6,6 +6,7 @@
 package test
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -23,7 +24,8 @@ func TestParameterExpand(t *testing.T) {
 		[4]string{"name={{ .Name }}, id={{ .ID }}", "blah", "12345", "name=blah, id=12345"},
 	}
 	for _, x := range validExprs {
-		p := Param(x[0])
+		var p Param
+		p.RawMessage = json.RawMessage(x[0])
 		res, err := p.Expand(&target.Target{Name: x[1], ID: x[2]})
 		require.NoError(t, err, x[0])
 		require.Equal(t, x[3], res, x[0])
@@ -45,7 +47,8 @@ func TestParameterExpandUserFunctions(t *testing.T) {
 		[4]string{"{{ Title .ID }}", "slackware.it", "a1234a", "A1234a"},
 	}
 	for _, x := range validExprs {
-		p := Param(x[0])
+		var p Param
+		p.RawMessage = json.RawMessage(x[0])
 		res, err := p.Expand(&target.Target{Name: x[1], ID: x[2]})
 		require.NoError(t, err, x[0])
 		require.Equal(t, x[3], res, x[0])

--- a/pkg/test/parameter_test.go
+++ b/pkg/test/parameter_test.go
@@ -6,7 +6,6 @@
 package test
 
 import (
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -24,8 +23,7 @@ func TestParameterExpand(t *testing.T) {
 		[4]string{"name={{ .Name }}, id={{ .ID }}", "blah", "12345", "name=blah, id=12345"},
 	}
 	for _, x := range validExprs {
-		var p Param
-		p.RawMessage = json.RawMessage(x[0])
+		p := NewParam(x[0])
 		res, err := p.Expand(&target.Target{Name: x[1], ID: x[2]})
 		require.NoError(t, err, x[0])
 		require.Equal(t, x[3], res, x[0])
@@ -47,8 +45,7 @@ func TestParameterExpandUserFunctions(t *testing.T) {
 		[4]string{"{{ Title .ID }}", "slackware.it", "a1234a", "A1234a"},
 	}
 	for _, x := range validExprs {
-		var p Param
-		p.RawMessage = json.RawMessage(x[0])
+		p := NewParam(x[0])
 		res, err := p.Expand(&target.Target{Name: x[1], ID: x[2]})
 		require.NoError(t, err, x[0])
 		require.Equal(t, x[3], res, x[0])

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -45,7 +45,7 @@ func (t TestStepParameters) GetOne(k string) Param {
 // and returns an error if this fails.
 func (t TestStepParameters) GetInt(k string) (int64, error) {
 	v := t.GetOne(k)
-	if v == "" {
+	if v.IsEmpty() {
 		return 0, errors.New("expected an integer string, got an empty string")
 	}
 	n, err := strconv.ParseInt(string(v), 10, 64)

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -36,7 +36,7 @@ func (t TestStepParameters) Get(k string) []Param {
 func (t TestStepParameters) GetOne(k string) Param {
 	v, ok := t[k]
 	if !ok || len(v) == 0 {
-		return Param("")
+		return Param{}
 	}
 	return v[0]
 }
@@ -45,10 +45,10 @@ func (t TestStepParameters) GetOne(k string) Param {
 // and returns an error if this fails.
 func (t TestStepParameters) GetInt(k string) (int64, error) {
 	v := t.GetOne(k)
-	if v.IsEmpty() {
+	if v.String() == "" {
 		return 0, errors.New("expected an integer string, got an empty string")
 	}
-	n, err := strconv.ParseInt(string(v), 10, 64)
+	n, err := strconv.ParseInt(v.String(), 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("cannot convert '%s' to int: %v", v, err)
 	}

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -33,12 +33,12 @@ func (t TestStepParameters) Get(k string) []Param {
 
 // GetOne returns the first value of the requested parameter. If the parameter
 // is missing, an empty string is returned.
-func (t TestStepParameters) GetOne(k string) Param {
+func (t TestStepParameters) GetOne(k string) *Param {
 	v, ok := t[k]
 	if !ok || len(v) == 0 {
-		return Param{}
+		return &Param{}
 	}
-	return v[0]
+	return &v[0]
 }
 
 // GetInt works like GetOne, but also tries to convert the string to an int64,

--- a/pkg/test/step_test.go
+++ b/pkg/test/step_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type paramSubStructure struct {
+	Val1 		 string
+	Val2 		 string
+	More_nesting map[string]string
+}
+
+func TestTestStepParametersUnmarshalNested(t *testing.T) {
+	descriptor := `{
+		"str": ["some string"],
+		"num": [12],
+		"substruct": [{
+			"Val1": "foo",
+			"Val2": "bar",
+			"More_nesting": {
+				"foobar": "baz"
+			}
+		}]
+	}`
+
+	var params TestStepParameters
+	err := json.Unmarshal([]byte(descriptor), &params)
+	require.NoError(t, err)
+	require.Equal(t, "some string", params.GetOne("str").String())
+	num, err := params.GetInt("num")
+	require.NoError(t, err)
+	require.Equal(t, int64(12), num)
+
+	// must be able to unmarshal substruct futher
+	var substruct paramSubStructure
+	err = json.Unmarshal(params.GetOne("substruct").JSON(), &substruct)
+	require.NoError(t, err)
+	require.Equal(t, "foo", substruct.Val1)
+	require.Equal(t, "bar", substruct.Val2)
+	require.Equal(t, "baz", substruct.More_nesting["foobar"])
+}

--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -86,7 +86,7 @@ func (ts *Cmd) validateAndPopulate(params test.TestStepParameters) error {
 	if param.IsEmpty() {
 		return errors.New("invalid or missing 'executable' parameter, must be exactly one string")
 	}
-	ex := string(param)
+	ex := param.String()
 	if filepath.IsAbs(ex) {
 		ts.executable = ex
 	} else {

--- a/plugins/teststeps/slowecho/slowecho.go
+++ b/plugins/teststeps/slowecho/slowecho.go
@@ -73,10 +73,10 @@ func (e *Step) ValidateParameters(params test.TestStepParameters) error {
 	}
 
 	// no expression expansion here
-	if len(secStr) != 1 {
+	if len(secStr.String()) != 1 {
 		return fmt.Errorf("invalid empty 'sleep' parameter: %v", secStr)
 	}
-	_, err := sleepTime(string(secStr))
+	_, err := sleepTime(secStr.String())
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (e *Step) ValidateParameters(params test.TestStepParameters) error {
 
 // Run executes the step
 func (e *Step) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
-	sleep, err := sleepTime(string(params.GetOne("sleep")))
+	sleep, err := sleepTime(params.GetOne("sleep").String())
 	if err != nil {
 		return err
 	}

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -17,7 +17,6 @@ package sshcmd
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -224,7 +223,7 @@ func (ts *SSHCmd) validateAndPopulate(params test.TestStepParameters) error {
 		return errors.New("invalid or missing 'host' parameter, must be exactly one string")
 	}
 	if params.GetOne("port").IsEmpty() {
-		ts.Port.RawMessage = json.RawMessage(strconv.Itoa(defaultSSHPort))
+		ts.Port = test.NewParam(strconv.Itoa(defaultSSHPort))
 	} else {
 		var port int64
 		port, err = params.GetInt("port")

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -17,6 +17,7 @@ package sshcmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -223,7 +224,7 @@ func (ts *SSHCmd) validateAndPopulate(params test.TestStepParameters) error {
 		return errors.New("invalid or missing 'host' parameter, must be exactly one string")
 	}
 	if params.GetOne("port").IsEmpty() {
-		ts.Port = test.Param(strconv.Itoa(defaultSSHPort))
+		ts.Port.RawMessage = json.RawMessage(strconv.Itoa(defaultSSHPort))
 	} else {
 		var port int64
 		port, err = params.GetInt("port")

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -51,14 +51,14 @@ const defaultSSHPort = 22
 
 // SSHCmd is used to run arbitrary commands as test steps.
 type SSHCmd struct {
-	Host           test.Param
-	Port           test.Param
-	User           test.Param
-	PrivateKeyFile test.Param
-	Password       test.Param
-	Executable     test.Param
+	Host           *test.Param
+	Port           *test.Param
+	User           *test.Param
+	PrivateKeyFile *test.Param
+	Password       *test.Param
+	Executable     *test.Param
 	Args           []test.Param
-	Expect         test.Param
+	Expect         *test.Param
 }
 
 // Name returns the plugin name.

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -191,7 +191,7 @@ func (ts *SSHCmd) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, p
 			log.Infof("Stdout of command '%s' is '%s'", cmd, stdout.Bytes())
 			if err == nil {
 				// Execute expectations
-				expect := string(ts.Expect)
+				expect := ts.Expect.String()
 				if expect == "" {
 					log.Warningf("no expectations specified")
 				} else {

--- a/plugins/teststeps/terminalexpect/terminalexpect.go
+++ b/plugins/teststeps/terminalexpect/terminalexpect.go
@@ -92,7 +92,7 @@ func (ts *TerminalExpect) validateAndPopulate(params test.TestStepParameters) er
 	if port.IsEmpty() {
 		return errors.New("invalid or missing 'port' parameter, must be exactly one string")
 	}
-	ts.Port = string(port)
+	ts.Port = port.String()
 	speed, err := params.GetInt("speed")
 	if err != nil {
 		return fmt.Errorf("invalid or missing 'speed' parameter: %v", err)
@@ -102,12 +102,12 @@ func (ts *TerminalExpect) validateAndPopulate(params test.TestStepParameters) er
 	if match.IsEmpty() {
 		return errors.New("invalid or missing 'match' parameter, must be exactly one string")
 	}
-	ts.Match = string(match)
+	ts.Match = match.String()
 	timeoutStr := params.GetOne("timeout")
 	if timeoutStr.IsEmpty() {
 		return errors.New("invalid or missing 'timeout' parameter, must be exactly one string")
 	}
-	timeout, err := time.ParseDuration(string(timeoutStr))
+	timeout, err := time.ParseDuration(timeoutStr.String())
 	if err != nil {
 		return fmt.Errorf("invalid terminal timeout %s", timeoutStr)
 	}

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -322,10 +322,10 @@ func TestCmdPlugin(t *testing.T) {
 
 	params := make(test.TestStepParameters)
 	params["executable"] = []test.Param{
-		test.NewParam("sleep"),
+		*test.NewParam("sleep"),
 	}
 	params["args"] = []test.Param{
-		test.NewParam("5"),
+		*test.NewParam("5"),
 	}
 
 	testSteps := []test.TestStepBundle{

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -322,10 +322,10 @@ func TestCmdPlugin(t *testing.T) {
 
 	params := make(test.TestStepParameters)
 	params["executable"] = []test.Param{
-		test.Param("sleep"),
+		test.NewParam("sleep"),
 	}
 	params["args"] = []test.Param{
-		test.Param("5"),
+		test.NewParam("5"),
 	}
 
 	testSteps := []test.TestStepBundle{


### PR DESCRIPTION
The goal is to allow JSON structures as parameters, which are further
unmarshalled by the specific plugin using them. This can be useful for a multitude of reasons.
In my case, the plugin needs to make calls to another service, and this service as a ton of parameters, and new ones get added all the time. It would be very cumbersome to manually add support for all of them in my plugin. If we allow structures, we can validate the input at job ingestion time in the plugin, but don't have to hardcode any specific params.