### PR TITLE
Allow passing custom server ID via server CLI

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/facebookincubator/contest/pkg/api"
 	"github.com/facebookincubator/contest/pkg/config"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/jobmanager"
@@ -42,7 +43,8 @@ import (
 const defaultDBURI = "contest:contest@tcp(localhost:3306)/contest?parseTime=true"
 
 var (
-	flagDBURI = flag.String("dbURI", defaultDBURI, "Database URI")
+	flagDBURI    = flag.String("dbURI", defaultDBURI, "Database URI")
+	flagServerID = flag.String("serverID", "", "Set a static server ID, e.g. the host name or another unique identifier. If unset, will use the listener's default")
 )
 
 var targetManagers = []target.TargetManagerLoader{
@@ -139,7 +141,11 @@ func main() {
 	// spawn JobManager
 	listener := httplistener.HTTPListener{}
 
-	jm, err := jobmanager.New(&listener, pluginRegistry)
+	var serverIDFunc api.ServerIDFunc
+	if *flagServerID != "" {
+		serverIDFunc = func() string { return *flagServerID }
+	}
+	jm, err := jobmanager.New(&listener, serverIDFunc, pluginRegistry)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,9 @@ const CurrentAPIVersion uint32 = 5
 // event on the events channel.
 var DefaultEventTimeout = 3 * time.Second
 
+// ServerIDFunc is used to return a custom server ID in api responses.
+type ServerIDFunc func() string
+
 // The API structure implements the communication between clients and the
 // JobManager. It enables several operations like starting, stopping,
 // retrying a job, and getting a job status.
@@ -33,18 +36,12 @@ type API struct {
 	Events chan *Event
 	// serverIDFunc is used by ServerID() to return a custom server ID in API
 	// responses.
-	serverIDFunc func() string
+	serverIDFunc ServerIDFunc
 }
 
-// New returns an initialized instance of an API struct with a default server ID
-// generation function.
-func New() *API {
-	return NewWithServerIDFunc(nil)
-}
-
-// NewWithServerIDFunc is like New, but it lets the user specify a function to
-// generate the server ID.
-func NewWithServerIDFunc(serverIDFunc func() string) *API {
+// New returns an initialized instance of an API struct with the specified
+// server ID generation function.
+func New(serverIDFunc func() string) *API {
 	return &API{
 		Events:       make(chan *Event),
 		serverIDFunc: serverIDFunc,

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -213,7 +213,7 @@ func (suite *TestJobManagerSuite) SetupTest() {
 	pluginRegistry.RegisterTestStep(noreturn.Name, noreturn.New, noreturn.Events)
 	pluginRegistry.RegisterTestStep(slowecho.Name, slowecho.New, slowecho.Events)
 
-	jm, err := jobmanager.New(&testListener, pluginRegistry)
+	jm, err := jobmanager.New(&testListener, nil, pluginRegistry)
 	require.NoError(suite.T(), err)
 
 	suite.jm = jm


### PR DESCRIPTION
Currently the ServerID is generated from os.Hostname(), if possible.
This commit allows passing a custom string for the server ID.
If more flexibility is required, the server ID function in
cmds/contest/main.go can be modified instead.

Fixes #86

Signed-off-by: Andrea Barberio <barberio@fb.com>