### PR TITLE
Change lock timeout from 10s to 1m

### DIFF
--- a/pkg/config/timeouts.go
+++ b/pkg/config/timeouts.go
@@ -42,4 +42,4 @@ var TestRunnerShutdownTimeout = 30 * time.Second
 var TestRunnerStepShutdownTimeout = 5 * time.Second
 
 // LockTimeout represent the amount of time that a lock is held for a target
-var LockTimeout = 10 * time.Second
+var LockTimeout = 1 * time.Minute

--- a/plugins/targetlocker/inmemory/inmemory.go
+++ b/plugins/targetlocker/inmemory/inmemory.go
@@ -21,7 +21,7 @@ import (
 // Name is the name used to look this plugin up.
 var Name = "InMemory"
 
-var log = logging.GetLogger("teststeps/" + strings.ToLower(Name))
+var log = logging.GetLogger("targetlocker/" + strings.ToLower(Name))
 
 type request struct {
 	targets []*target.Target


### PR DESCRIPTION
Changed to a more reasonable value. Side benefit: logs are a lot less
spammy.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>