### PR TITLE
Reintroduce test statuses in status report

### DIFF
--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -44,7 +44,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 		evResp.Err = fmt.Errorf("failed to fetch request for job ID %d: %w", jobID, err)
 		return &evResp
 	}
-	currentJob, err := NewJobFromRequest(req)
+	currentJob, err := NewJobFromRequest(jm.pluginRegistry, req)
 	if err != nil {
 		evResp.Err = fmt.Errorf("failed to build job object from job request: %w", err)
 		return &evResp


### PR DESCRIPTION
In https://github.com/facebookincubator/contest/pull/84 I introduced a
regression that caused a bug when reporting job status, i.e. that the
list of test statuses was not rebuilt. This PR fixes the bug.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>