### PR TITLE
Added plugin information to errors in job events

### DIFF
--- a/.travis/linters.sh
+++ b/.travis/linters.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -exu
 
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-go install github.com/golangci/golangci-lint/cmd/golangci-lint
+GO111MODULE=on
+# installing golangci-lint as recommended on the project page
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 cd "${TRAVIS_BUILD_DIR}"
+go mod download
 golangci-lint run --disable typecheck --enable deadcode --enable varcheck --enable staticcheck
 
 # check license headers

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can look at the tools implemented under [cmds/*](cmds/) for usage examples.
 ## Requirements
 
 ConTest is developed on Linux. It may work on other platforms, but it is only being actively tested on Linux.
-You will also need a recent version of Go (we recommend at least Go 1.12 at the
+You will also need a recent version of Go (we recommend at least Go 1.13 at the
 moment).
 
 

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,7 @@ github.com/tommy-muehle/go-mnd v1.2.0/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaoz
 github.com/tommy-muehle/go-mnd v1.3.0/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa h1:RC4maTWLKKwb7p1cnoygsbKIgNlJqSYBeAFON3Ar8As=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
+github.com/u-root/u-root v1.0.0 h1:3hJy0CG3mXIZtWRE+yrghG/3H0v8L1qEeZBlPr5nS9s=
 github.com/u-root/u-root v6.0.0+incompatible h1:YqPGmRoRyYmeg17KIWFRSyVq6LX5T6GSzawyA6wG6EE=
 github.com/u-root/u-root v6.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -121,7 +121,8 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 			case err := <-errCh:
 				targets = <-targetsCh
 				if err != nil {
-					jobLog.Warningf("Run #%d: cannot fetch targets for test '%s': %v", run+1, t.Name, err)
+					err = fmt.Errorf("run #%d: cannot fetch targets for test '%s': %v", run+1, t.Name, err)
+					jobLog.Errorf(err.Error())
 					return nil, nil, err
 				}
 				// Associate the targets with the job for later retrievel
@@ -173,9 +174,9 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 
 			// Emit events tracking targets acquisition
 			header := testevent.Header{JobID: j.ID, RunID: types.RunID(run + 1), TestName: t.Name}
-			testEvenEmitter := storage.NewTestEventEmitter(header)
+			testEventEmitter := storage.NewTestEventEmitter(header)
 
-			if runErr = jr.emitAcquiredTargets(testEvenEmitter, targets); runErr == nil {
+			if runErr = jr.emitAcquiredTargets(testEventEmitter, targets); runErr == nil {
 				jobLog.Infof("Run #%d: running test #%d for job '%s' (job ID: %d) on %d targets", run+1, idx, j.Name, j.ID, len(targets))
 				testRunner := NewTestRunner()
 				runErr = testRunner.Run(j.CancelCh, j.PauseCh, t, targets, j.ID, types.RunID(run+1))

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -548,9 +548,15 @@ func (tr *TestRunner) WaitPipelineCompletion(terminate <-chan struct{}, ch compl
 			return nil
 		case res := <-ch.routingResultCh:
 			err = res.err
+			if err != nil {
+				err = fmt.Errorf("error at test step '%s' (label: '%s'): %w", res.bundle.TestStep.Name(), res.bundle.TestStepLabel, err)
+			}
 			tr.state.SetRouting(res.bundle.TestStepLabel, res.err)
 		case res := <-ch.stepResultCh:
 			err = res.err
+			if err != nil {
+				err = fmt.Errorf("error at test step '%s' (label: '%s'): %w", res.bundle.TestStep.Name(), res.bundle.TestStepLabel, err)
+			}
 			tr.state.SetStep(res.bundle.TestStepLabel, res.err)
 		case targetErr := <-ch.targetErr:
 			tr.state.SetTarget(targetErr.Target, targetErr.Err)

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -395,7 +395,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCrash() {
 	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobFailed, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
-	require.Equal(suite.T(), string(*ev[0].Payload), "{\"Err\":\"TestStep crashed\"}")
+	require.Equal(suite.T(), "{\"Err\":\"error at test step 'Crash' (label: 'crash_label'): TestStep crashed\"}", string(*ev[0].Payload))
 	jobReport, err := suite.jobEventManager.FetchReport(types.JobID(jobID))
 
 	require.NoError(suite.T(), err)

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -8,6 +8,7 @@
 package tests
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -303,8 +304,8 @@ func TestStepClosesChannels(t *testing.T) {
 	testTimeout := 2 * time.Second
 	select {
 	case err = <-errCh:
-		if _, ok := err.(*cerrors.ErrTestStepClosedChannels); !ok {
-			errString := fmt.Sprintf("Error returned by TestRunner should be of type ErrTestStepClosedChannels: %v", err)
+		if _, ok := errors.Unwrap(err).(*cerrors.ErrTestStepClosedChannels); !ok {
+			errString := fmt.Sprintf("Error returned by TestRunner should be of type ErrTestStepClosedChannels, got %T(%v)", err, err)
 			assert.FailNow(t, errString)
 		}
 	case <-time.After(testTimeout):


### PR DESCRIPTION
With this, it's possible to know how a job failed if a plugin returns an
error.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>