### PR TITLE
Make EndTime optional

### DIFF
--- a/pkg/job/status.go
+++ b/pkg/job/status.go
@@ -82,9 +82,8 @@ type Status struct {
 	// started yet"
 	StartTime time.Time
 
-	// EndTime indicates when the job started. This value should be ignored if
-	// `Finished` is false.
-	EndTime time.Time
+	// EndTime indicates when the job ended.
+	EndTime *time.Time
 
 	// RunStatuses represents the status of the current run of the job
 	RunStatus RunStatus

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -53,7 +53,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 	// Lookup job starting time and job termination time based on the events emitted
 	var (
 		startTime time.Time
-		endTime   time.Time
+		endTime   *time.Time
 	)
 
 	completionEvents := make(map[event.Name]bool)
@@ -66,10 +66,10 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 			startTime = ev.EmitTime
 		} else if _, ok := completionEvents[ev.EventName]; ok {
 			// A completion event has been seen for this Job. Only one completion event can be associated to the job
-			if !endTime.IsZero() {
+			if endTime != nil && !endTime.IsZero() {
 				log.Warningf("Job %d is associated to multiple completion events", jobID)
 			}
-			endTime = ev.EmitTime
+			endTime = &ev.EmitTime
 		}
 	}
 


### PR DESCRIPTION
Since we removed the Finished flag, when a job has not ended its EndTime
is the zero-value of time.Time, and it is confusing. With this change I
am making EndTime optional, so it will result as null in the status
instead of "0001-01-01T00:00:00Z".

Test plan:
* run a job, and before it finishes, get its status
* EndTime is null, not "0001-01-01T00:00:00Z"
```
$ go run . status 16 2> /dev/null | jq '.Data.Status.EndTime'
null
```
* after the job is over, EndTime has the right value
```
$ go run . status 16 2> /dev/null | jq '.Data.Status.EndTime'
2020-04-24T13:12:55Z
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>