### PR TITLE
Emit test event for plugin errors

### DIFF
--- a/pkg/runner/event.go
+++ b/pkg/runner/event.go
@@ -10,10 +10,13 @@ import (
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
-// Payload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
+// RunStartedPayload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
 type RunStartedPayload struct {
 	RunID types.RunID
 }
 
 // EventRunStarted indicates that a run has begun
 var EventRunStarted = event.Name("RunStarted")
+
+// EventTestError indicates that a test failed.
+var EventTestError = event.Name("TestError")


### PR DESCRIPTION
Currently errors are emitted as framework events, but they are not
accessible in reports and status. This patch emits a test event with the
plugin error, to make it possible to debug a failing job.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>