### PR TITLE
Expose events that have no target associated

### DIFF
--- a/pkg/job/status.go
+++ b/pkg/job/status.go
@@ -45,12 +45,17 @@ type TargetStatus struct {
 	InTime  time.Time
 	OutTime time.Time
 	Error   string
+	// these are events that have an associated target. For events
+	// that are not associated to a target, see TestStepStatus.Events .
+	Events []testevent.Event
 }
 
 // TestStepStatus bundles together all the TargetStatus for a specific TestStep (represented via
 // its name and label)
 type TestStepStatus struct {
 	TestStepCoordinates
+	// these are events that have no target associated. For events
+	// associated to a target, see TargetStatus.TargetEvents .
 	Events         []testevent.Event
 	TargetStatuses []TargetStatus
 }

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -395,7 +395,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCrash() {
 	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobFailed, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
-	require.Equal(suite.T(), "{\"Err\":\"error at test step 'Crash' (label: 'crash_label'): TestStep crashed\"}", string(*ev[0].Payload))
+	require.Equal(suite.T(), "{\"Err\":\"TestStep crashed\"}", string(*ev[0].Payload))
 	jobReport, err := suite.jobStorageManager.GetJobReport(types.JobID(jobID))
 
 	require.NoError(suite.T(), err)

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -8,7 +8,6 @@
 package tests
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -304,7 +303,7 @@ func TestStepClosesChannels(t *testing.T) {
 	testTimeout := 2 * time.Second
 	select {
 	case err = <-errCh:
-		if _, ok := errors.Unwrap(err).(*cerrors.ErrTestStepClosedChannels); !ok {
+		if _, ok := err.(*cerrors.ErrTestStepClosedChannels); !ok {
 			errString := fmt.Sprintf("Error returned by TestRunner should be of type ErrTestStepClosedChannels, got %T(%v)", err, err)
 			assert.FailNow(t, errString)
 		}


### PR DESCRIPTION
This patch exposes test step events that have no targets associated, for
example events conveying plugin errors (as opposed to target failures).
These events are visible in the status report.
Note that previously events associated to a target were exposed in the
test step status. Now these events are exposed in the target status (a
sub-field of the test step status), while events that have no target are
exposd in the test step status.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>