### PR TITLE
[pkg/runner] Do not `Run()` a TestStep until first Target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/pkg/runner/wait_for_first_target.go
+++ b/pkg/runner/wait_for_first_target.go
@@ -1,0 +1,59 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package runner
+
+import (
+	"github.com/facebookincubator/contest/pkg/target"
+)
+
+// waitForFirstTarget copies targets from `in` to `out` and also
+// signals on first target or if `in` is closed and there was no targets
+// at all.
+//
+// To solve the initial problem there're two approaches:
+// * Just wait for a target in `stepCh.stepIn` and then insert
+// it back to the channel.
+// * Create substitute `stepCh.stepIn` with a new channel and just
+// copy all targets from original `stepCh.stepIn` to this new channel.
+// And we may detect when we receive the first target in the original
+// channel.
+//
+// The first approach is much simpler, but the second preserves
+// the order of targets (which is handy and not misleading
+// while reading logs). Here we implement the second one:
+func waitForFirstTarget(
+	in <-chan *target.Target,
+	cancel, pause <-chan struct{},
+) (out chan *target.Target, onFirstTarget, onNoTargets <-chan struct{}) {
+	onFirstTargetCh := make(chan struct{})
+	onNoTargetsCh := make(chan struct{})
+	onFirstTarget, onNoTargets = onFirstTargetCh, onNoTargetsCh
+
+	out = make(chan *target.Target)
+	go func() {
+		select {
+		case t, ok := <-in:
+			if !ok {
+				close(out)
+				close(onNoTargetsCh)
+				return
+			}
+			close(onFirstTargetCh)
+			out <- t
+		case <-cancel:
+			return
+		case <-pause:
+			return
+		}
+
+		for t := range in {
+			out <- t
+		}
+		close(out)
+	}()
+
+	return
+}

--- a/pkg/runner/wait_for_first_target_test.go
+++ b/pkg/runner/wait_for_first_target_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package runner
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForFirstTarget(t *testing.T) {
+	t.Run("100targets", func(t *testing.T) {
+		ch0 := make(chan *target.Target)
+		ch1, onFirstTargetChan, onNoTargetsChan := waitForFirstTarget(ch0, nil, nil)
+
+		var wgBeforeFirstTarget, wgAfterSecondTarget sync.WaitGroup
+		wgBeforeFirstTarget.Add(1)
+		wgAfterSecondTarget.Add(1)
+
+		go func() {
+			wgBeforeFirstTarget.Wait()
+			for i := 0; i < 100; i++ {
+				ch0 <- &target.Target{
+					ID: fmt.Sprintf("%d", i),
+				}
+				if i == 1 {
+					// to avoid race conditions in this test we verify
+					// if there's a "onFirstTarget" signal after the second
+					// target
+					wgAfterSecondTarget.Done()
+				}
+			}
+		}()
+
+		runtime.Gosched()
+		select {
+		case <-onFirstTargetChan:
+			t.Fatal("should not happen")
+		case <-onNoTargetsChan:
+			t.Fatal("should not happen")
+		default:
+		}
+
+		wgBeforeFirstTarget.Done()
+
+		var wgReader sync.WaitGroup
+		wgReader.Add(1)
+		go func() {
+			defer wgReader.Done()
+			// Checking quantity and order
+			for i := 0; i < 100; i++ {
+				_target := <-ch1
+				require.Equal(t, &target.Target{
+					ID: fmt.Sprintf("%d", i),
+				}, _target)
+			}
+		}()
+
+		wgAfterSecondTarget.Wait()
+
+		select {
+		case <-onFirstTargetChan:
+		case <-onNoTargetsChan:
+			t.Fatal("should not happen")
+		default:
+			t.Fatal("should not happen") // see wgAfterSecondTarget.Wait() above
+		}
+
+		wgReader.Wait()
+
+		runtime.Gosched()
+		require.Len(t, ch1, 0)
+	})
+
+	t.Run("no_target", func(t *testing.T) {
+		ch0 := make(chan *target.Target)
+		ch1, onFirstTargetChan, onNoTargetsChan := waitForFirstTarget(ch0, nil, nil)
+
+		runtime.Gosched()
+		select {
+		case <-onFirstTargetChan:
+			t.Fatal("should not happen")
+		case <-onNoTargetsChan:
+			t.Fatal("should not happen")
+		default:
+		}
+
+		close(ch0)
+
+		select {
+		case <-onFirstTargetChan:
+			t.Fatal("should not happen")
+		case <-onNoTargetsChan:
+		}
+
+		runtime.Gosched()
+		require.Len(t, ch1, 0)
+		_, isOpened := <-ch1
+		require.False(t, isOpened)
+	})
+
+	t.Run("cancel", func(t *testing.T) {
+		cancelCh := make(chan struct{})
+		ch0 := make(chan *target.Target)
+		ch1, onFirstTargetChan, onNoTargetsChan := waitForFirstTarget(ch0, cancelCh, nil)
+
+		runtime.Gosched()
+		select {
+		case <-onFirstTargetChan:
+			t.Fatal("should not happen") // see wgBeforeFirstTarget.Wait() above
+		case <-onNoTargetsChan:
+			t.Fatal("should not happen")
+		default:
+		}
+
+		close(cancelCh)
+
+		runtime.Gosched()
+		select {
+		case <-onFirstTargetChan:
+			t.Fatal("should not happen")
+		case <-onNoTargetsChan:
+			t.Fatal("should not happen")
+		default:
+		}
+
+		require.Len(t, ch1, 0)
+		select {
+		case <-ch1:
+			t.Fatal("should not happen")
+		default:
+		}
+	})
+}


### PR DESCRIPTION
Added logic to postpone calling `Run()` of a TestStep until
the first Target will be received. If no targets are received
and the channel is closed, then cancel running of the TestStep

Related: https://github.com/facebookincubator/contest/issues/101

# Test Plan

```
[xaionaro@void contest]$ go test ./... -tags integration
?       github.com/facebookincubator/contest/cmds/clients/contestcli-http       [no test files]
?       github.com/facebookincubator/contest/cmds/contest       [no test files]
?       github.com/facebookincubator/contest/pkg/api    [no test files]
?       github.com/facebookincubator/contest/pkg/cerrors        [no test files]
?       github.com/facebookincubator/contest/pkg/config [no test files]
?       github.com/facebookincubator/contest/pkg/event  [no test files]
?       github.com/facebookincubator/contest/pkg/event/frameworkevent   [no test files]
?       github.com/facebookincubator/contest/pkg/event/internal/querytools      [no test files]
?       github.com/facebookincubator/contest/pkg/event/internal/reflecttools    [no test files]
ok      github.com/facebookincubator/contest/pkg/event/testevent        (cached)
?       github.com/facebookincubator/contest/pkg/job    [no test files]
?       github.com/facebookincubator/contest/pkg/jobmanager     [no test files]
ok      github.com/facebookincubator/contest/pkg/lib/comparison (cached)
?       github.com/facebookincubator/contest/pkg/logging        [no test files]
ok      github.com/facebookincubator/contest/pkg/pluginregistry (cached)
ok      github.com/facebookincubator/contest/pkg/runner (cached)
?       github.com/facebookincubator/contest/pkg/storage        [no test files]
?       github.com/facebookincubator/contest/pkg/target [no test files]
ok      github.com/facebookincubator/contest/pkg/test   (cached)
?       github.com/facebookincubator/contest/pkg/types  [no test files]
?       github.com/facebookincubator/contest/plugins/listeners/httplistener     [no test files]
?       github.com/facebookincubator/contest/plugins/reporters/noop     [no test files]
?       github.com/facebookincubator/contest/plugins/reporters/targetsuccess    [no test files]
?       github.com/facebookincubator/contest/plugins/storage/memory     [no test files]
?       github.com/facebookincubator/contest/plugins/storage/rdbms      [no test files]
ok      github.com/facebookincubator/contest/plugins/targetlocker/inmemory      (cached)
ok      github.com/facebookincubator/contest/plugins/targetlocker/noop  (cached)
?       github.com/facebookincubator/contest/plugins/targetmanagers/csvtargetmanager    [no test files]
?       github.com/facebookincubator/contest/plugins/targetmanagers/targetlist  [no test files]
?       github.com/facebookincubator/contest/plugins/testfetchers/literal       [no test files]
?       github.com/facebookincubator/contest/plugins/testfetchers/uri   [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps  [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/cmd      [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/echo     [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/example  [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/randecho [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/slowecho [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/sshcmd   [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/terminalexpect   [no test files]
?       github.com/facebookincubator/contest/tests/integ/common [no test files]
ok      github.com/facebookincubator/contest/tests/integ/events/frameworkevents 0.003s
ok      github.com/facebookincubator/contest/tests/integ/events/testevents      0.003s
ok      github.com/facebookincubator/contest/tests/integ/job    0.004s
ok      github.com/facebookincubator/contest/tests/integ/jobmanager     12.017s
ok      github.com/facebookincubator/contest/tests/integ/test   6.015s
?       github.com/facebookincubator/contest/tests/plugins/teststeps/channels   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/crash      [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/fail       [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/hanging    [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/noop       [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/noreturn   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/panicstep  [no test files]
```