### PR TITLE
bugfix(storage/memory): Filter events by RunID

### DIFF
--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -64,6 +64,13 @@ func eventJobMatch(queryJobID types.JobID, jobID types.JobID) bool {
 	return true
 }
 
+func eventRunMatch(queryRunID, runID types.RunID) bool {
+	if queryRunID != 0 && runID != queryRunID {
+		return false
+	}
+	return true
+}
+
 func eventNameMatch(queryEventNames []event.Name, eventName event.Name) bool {
 	if len(queryEventNames) == 0 {
 		// If no criteria was specified for matching the name of the event,
@@ -115,6 +122,7 @@ func (m *Memory) GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, 
 
 	for _, event := range m.testEvents {
 		if eventJobMatch(eventQuery.JobID, event.Header.JobID) &&
+			eventRunMatch(eventQuery.RunID, event.Header.RunID) &&
 			eventNameMatch(eventQuery.EventNames, event.Data.EventName) &&
 			eventTimeMatch(eventQuery.EmittedStartTime, eventQuery.EmittedEndTime, event.EmitTime) &&
 			eventTestMatch(eventQuery.TestName, event.Header.TestName) &&

--- a/plugins/storage/memory/memory_test.go
+++ b/plugins/storage/memory/memory_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemory_GetTestEvents(t *testing.T) {
+	stor, err := New()
+	require.NoError(t, err)
+
+	ev0 := testevent.Event{
+		EmitTime: time.Now(),
+		Header: &testevent.Header{
+			JobID:         1,
+			RunID:         2,
+			TestName:      "3",
+			TestStepLabel: "4",
+		},
+		Data: &testevent.Data{},
+	}
+	err = stor.StoreTestEvent(ev0)
+	require.NoError(t, err)
+
+	ev1 := testevent.Event{
+		EmitTime: time.Now(),
+		Header: &testevent.Header{
+			JobID:         1,
+			RunID:         5,
+			TestName:      "3",
+			TestStepLabel: "4",
+		},
+		Data: &testevent.Data{},
+	}
+	err = stor.StoreTestEvent(ev1)
+	require.NoError(t, err)
+
+	query, err := testevent.BuildQuery(
+		testevent.QueryRunID(2),
+		testevent.QueryTestName("3"),
+	)
+	require.NoError(t, err)
+
+	evs, err := stor.GetTestEvents(query)
+	require.NoError(t, err)
+
+	require.Len(t, evs, 1)
+	ev := evs[0]
+
+	require.Equal(t, ev0, ev)
+}


### PR DESCRIPTION
These events are used while generating final reports.

Without this additional condition-filter events from all runs are returned for report of each run. So if there were two runs, then there will be 2 events for each target on every single run in final reports.

The patch fixes this problem.

# Test Plan

## was 

```
--- FAIL: TestMemory_GetTestEvents (0.00s)
    memory_test.go:55: 
                Error Trace:    memory_test.go:55
                Error:          "[{2020-05-13 13:47:33.836198122 +0000 UTC m=+0.000624434 %!s(*testevent.Header=&{1 2 3 4}) %!s(*testevent.Data=&{ <nil> <nil>})} {2020-05-13 13:47:33.836200697 +0000 UTC m=+0.000627005 %!s(*testevent.Header=&{1 5 3 4}) %!s(*testevent.Data=&{ <nil> <nil>})}]" should have 1 item(s), but has 2
                Test:           TestMemory_GetTestEvents
FAIL
FAIL    github.com/facebookincubator/contest/plugins/storage/memory     0.002s
```

## became

```
ok      github.com/facebookincubator/contest/plugins/storage/memory     0.002s
```