### PR TITLE
bugfix(pkg/target): Do not panic on (*Target)(nil).String()

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -39,5 +39,8 @@ type Target struct {
 }
 
 func (t *Target) String() string {
+	if t == nil {
+		return "(*Target)(nil)"
+	}
 	return fmt.Sprintf("Target{Name: \"%s\", ID: \"%s\", FQDN: \"%s\"}", t.Name, t.ID, t.FQDN)
 }

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package target
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNilTarget(t *testing.T) {
+	var recoverResult interface{}
+	func() {
+		defer func() {
+			recoverResult = recover()
+		}()
+		_ = (*Target)(nil).String()
+	}()
+	require.Nil(t, recoverResult)
+}


### PR DESCRIPTION
In a private version of ConTest on steroids I receive a null-dereference error without clear traceback. However the panic is in `(*Target).String()`, so it is most likely in a debugging or/and reporting. And it makes sense to add this defensive code to prevent ConTest from panicking on debugging/reporting. In other words, inability to print a target in a human-readable way does not seems to be a strong enough reason to panic.
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==3652806==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x000001c97ba9 bp 0x10c0003f81f8 sp 0x10c0003f8180 T12)
==3652806==The signal is caused by a READ memory access.
==3652806==Hint: address points to the zero page.
SCARINESS: 10 (null-deref)
    #0 0x1c97ba8 in github.com/facebookincubator/contest/pkg/target.(*Target).String third-party-source/go/github.com/facebookincubator/contest/pkg/target/target.go:42

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV third-party-source/go/github.com/facebookincubator/contest/pkg/target/target.go:42 in github.com/facebookincubator/contest/pkg/target.(*Target).String
Thread T12 created by T11 here:
    #0 0x280b394 in pthread_create ([...]/contest/cmds/contest/contest/contest+0x280b394)
    #1 0x27dc7d8 in _cgo_try_pthread_create /home/engshare/third-party2/go/1.13.1/src/build-centos7-native/build/src/runtime/cgo/gcc_libinit.c:100
    #2 0x7fffff in __libc_start_main ([...]/contest/cmds/contest/contest/contest+0x7fffff)

Thread T11 created by T8 here:
    #0 0x280b394 in pthread_create ([...]/contest/cmds/contest/contest/contest+0x280b394)
    #1 0x27dc7d8 in _cgo_try_pthread_create /home/engshare/third-party2/go/1.13.1/src/build-centos7-native/build/src/runtime/cgo/gcc_libinit.c:100
    #2 0x7fffff in __libc_start_main ([...]/contest/cmds/contest/contest/contest+0x7fffff)

Thread T8 created by T6 here:
    #0 0x280b394 in pthread_create ([...]/contest/cmds/contest/contest/contest+0x280b394)
    #1 0x27dc7d8 in _cgo_try_pthread_create /home/engshare/third-party2/go/1.13.1/src/build-centos7-native/build/src/runtime/cgo/gcc_libinit.c:100
    #2 0x7fffff in __libc_start_main ([...]/contest/cmds/contest/contest/contest+0x7fffff)

Thread T6 created by T2 here:
    #0 0x280b394 in pthread_create ([...]/contest/cmds/contest/contest/contest+0x280b394)
    #1 0x27dc7d8 in _cgo_try_pthread_create /home/engshare/third-party2/go/1.13.1/src/build-centos7-native/build/src/runtime/cgo/gcc_libinit.c:100
    #2 0x7fffff in __libc_start_main ([...]/contest/cmds/contest/contest/contest+0x7fffff)

Thread T2 created by T0 here:
    #0 0x280b394 in pthread_create ([...]/contest/cmds/contest/contest/contest+0x280b394)
    #1 0x27dc7d8 in _cgo_try_pthread_create /home/engshare/third-party2/go/1.13.1/src/build-centos7-native/build/src/runtime/cgo/gcc_libinit.c:100
    #2 0x7fffff in __libc_start_main ([...]/contest/cmds/contest/contest/contest+0x7fffff)

==3652806==ABORTING
```
# Test Plan

## was

```
--- FAIL: TestNilTarget (0.00s)
    target_test.go:17: 
                Error Trace:    target_test.go:17
                Error:          Expected nil, but got: "invalid memory address or nil pointer dereference"
                Test:           TestNilTarget
FAIL
FAIL    github.com/facebookincubator/contest/pkg/target 0.002s
```

## became

```
ok      github.com/facebookincubator/contest/pkg/target 0.030s
```
