### PR TITLE
[test_runner] Refactor, prepare for cleanup pipeline

### DIFF
--- a/cmds/clients/contestcli-http/start.json
+++ b/cmds/clients/contestcli-http/start.json
@@ -1,6 +1,6 @@
 {
     "JobName": "test job",
-    "Runs": 3,
+    "Runs": 1,
     "RunInterval": "5s",
     "Tags": ["test", "csv"],
     "TestDescriptors": [

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d
 	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d // indirect
 	golang.org/x/tools v0.0.0-20200317184713-827390e9012e // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect
 	mvdan.cc/unparam v0.0.0-20200314162735-0ac8026f7d06 // indirect
 	sourcegraph.com/sqs/pbtypes v1.0.0 // indirect

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -21,6 +21,24 @@ func GetLogger(prefix string) *logrus.Entry {
 	return log.WithField("prefix", prefix)
 }
 
+// AddField add a field to an existing logrus.Entry
+func AddField(e *logrus.Entry, name string, value interface{}) *logrus.Entry {
+	l := log.WithField(name, value)
+	for k, v := range e.Data {
+		l = l.WithField(k, v)
+	}
+	return l
+}
+
+// AddFields adds multiple fields to an existing logrus.Entry
+func AddFields(e *logrus.Entry, fields map[string]interface{}) *logrus.Entry {
+	l := e
+	for k, v := range fields {
+		l = AddField(l, k, v)
+	}
+	return l
+}
+
 // Disable sends all logging output to the bit bucket.
 func Disable() {
 	log.SetOutput(ioutil.Discard)

--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -149,24 +149,24 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 					case <-j.CancelCh:
 						// unlock targets
 						if err := tl.Unlock(j.ID, targets); err != nil {
-							log.Warningf("Failed to unlock targets (%v) for job ID %d: %v", targets, j.ID, err)
+							jobLog.Warningf("Failed to unlock targets (%v) for job ID %d: %v", targets, j.ID, err)
 						}
 						return
 					case <-j.PauseCh:
 						// do not unlock targets, we can resume later, or let
 						// them expire
-						log.Debugf("Received pause request, NOT releasing targets so the job can be resumed")
+						jobLog.Debugf("Received pause request, NOT releasing targets so the job can be resumed")
 						return
 					case <-done:
 						if err := tl.Unlock(j.ID, targets); err != nil {
-							log.Warningf("Failed to unlock %d target(s) (%v): %v", len(targets), targets, err)
+							jobLog.Warningf("Failed to unlock %d target(s) (%v): %v", len(targets), targets, err)
 						}
-						log.Infof("Unlocked %d target(s) for job ID %d", len(targets), j.ID)
+						jobLog.Infof("Unlocked %d target(s) for job ID %d", len(targets), j.ID)
 						return
 					case <-time.After(lockTimeout):
 						// refresh the locks before the timeout expires
 						if err := tl.RefreshLocks(j.ID, targets); err != nil {
-							log.Warningf("Failed to refresh %d locks for job ID %d: %v", len(targets), j.ID, err)
+							jobLog.Warningf("Failed to refresh %d locks for job ID %d: %v", len(targets), j.ID, err)
 						}
 					}
 				}

--- a/pkg/runner/job_status.go
+++ b/pkg/runner/job_status.go
@@ -97,7 +97,7 @@ func (jr *JobRunner) buildTestStepStatus(coordinates job.TestStepCoordinates) (*
 			// we don't want target routing events in step events, but we want
 			// them in target events below
 			if _, skip := targetRoutingEvents[event.Data.EventName]; skip {
-				log.Warningf("Found routing event '%s' with no target associated, this could indicate a bug", event.Data.EventName)
+				jobLog.Warningf("Found routing event '%s' with no target associated, this could indicate a bug", event.Data.EventName)
 				continue
 			}
 			// this goes into TestStepStatus.Events

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -21,9 +21,8 @@ import (
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/sirupsen/logrus"
 )
-
-var log = logging.GetLogger("pkg/test")
 
 // TestRunnerTimeouts collects all the timeouts values that the test runner uses
 type TestRunnerTimeouts struct {
@@ -87,24 +86,64 @@ type stepResult struct {
 	err    error
 }
 
-// completionCh represents multiple result channels that the TestRunner consumes to
-// collect results from routing blocks, TestSteps and Targets completing the test
-type completionCh struct {
+// pipelineCtrlCh represents multiple result and control channels that the pipeline uses
+// to collect results from routing blocks, steps and target completing the test and to
+//  signa cancellation to various pipeline subsystems
+type pipelineCtrlCh struct {
 	routingResultCh <-chan routeResult
 	stepResultCh    <-chan stepResult
 	targetOut       <-chan *target.Target
 	targetErr       <-chan cerrors.TargetError
+	// cancelRouting is a control channel used to cancel routing blocks in the pipeline
+	cancelRoutingCh chan struct{}
+	// cancelStep is a control channel used to cancel the steps of the pipeline
+	cancelStepsCh chan struct{}
+	// pauseSteps is a control channel used to pause the steps of the pipeline
+	pauseStepsCh chan struct{}
 }
 
 // TestRunner is the main runner of TestSteps in ConTest. `results` collects
 // the results of the run. It is not safe to access `results` concurrently.
 type TestRunner struct {
-	state    *State
 	timeouts TestRunnerTimeouts
 }
 
-// WriteTargetErrorTimeout writes a TargetError object to a TargetError channel with timeout
-func (tr *TestRunner) WriteTargetErrorTimeout(terminate <-chan struct{}, ch chan<- cerrors.TargetError, targetError cerrors.TargetError, timeout time.Duration) error {
+// targetWriter is a helper object which exposes methods to write targets into step channels
+type targetWriter struct {
+	log      *logrus.Entry
+	timeouts TestRunnerTimeouts
+}
+
+func (w *targetWriter) writeTimeout(terminate <-chan struct{}, ch chan<- *target.Target, target *target.Target, timeout time.Duration) error {
+	w.log.Debugf("writing target %+v, timeout %v", target, timeout)
+	start := time.Now()
+	select {
+	case <-terminate:
+		w.log.Debugf("terminate requested while writing target %+v", target)
+	case ch <- target:
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout (%v) while writing target %+v", timeout, target)
+	}
+	w.log.Debugf("done writing target %+v, spent %v", target, time.Since(start))
+	return nil
+}
+
+// writeTargetWithResult attempts to deliver a Target on the input channel of a step,
+// returning the result of the operation on the result channel wrapped in the
+// injectionCh argument
+func (w *targetWriter) writeTargetWithResult(terminate <-chan struct{}, target *target.Target, ch injectionCh, wg *sync.WaitGroup) {
+	defer wg.Done()
+	err := w.writeTimeout(terminate, ch.stepIn, target, w.timeouts.StepInjectTimeout)
+	select {
+	case <-terminate:
+	case ch.resultCh <- injectionResult{target: target, err: err}:
+	case <-time.After(w.timeouts.MessageTimeout):
+		w.log.Panicf("timeout while writing result for target %+v after %v", target, w.timeouts.MessageTimeout)
+	}
+}
+
+// writeTargetError writes a TargetError object to a TargetError channel with timeout
+func (w *targetWriter) writeTargetError(terminate <-chan struct{}, ch chan<- cerrors.TargetError, targetError cerrors.TargetError, timeout time.Duration) error {
 	select {
 	case <-terminate:
 	case ch <- targetError:
@@ -114,31 +153,30 @@ func (tr *TestRunner) WriteTargetErrorTimeout(terminate <-chan struct{}, ch chan
 	return nil
 }
 
-// WriteTargetTimeout writes a Target object to a Target channel with timeout
-func (tr *TestRunner) WriteTargetTimeout(terminate <-chan struct{}, ch chan<- *target.Target, target *target.Target, timeout time.Duration) error {
-	select {
-	case <-terminate:
-	case ch <- target:
-	case <-time.After(timeout):
-		return fmt.Errorf("timeout while writing target %+v", target)
-	}
-	return nil
+func newTargetWriter(log *logrus.Entry, timeouts TestRunnerTimeouts) *targetWriter {
+	return &targetWriter{log: log, timeouts: timeouts}
 }
 
-// InjectTarget attempts to deliver a Target on the input channel of a TestStep,
-// returning the result of the operation on the result channel wrapped in the
-// injectionCh argument
-func (tr *TestRunner) InjectTarget(terminate <-chan struct{}, target *target.Target, ch injectionCh, wg *sync.WaitGroup) {
-	defer wg.Done()
+// pipeline represents a sequence of steps through which targets flow. A pipeline could implement
+// either a test sequence or a cleanup sequence
+type pipeline struct {
+	log *logrus.Entry
 
-	err := tr.WriteTargetTimeout(terminate, ch.stepIn, target, tr.timeouts.StepInjectTimeout)
+	bundles []test.TestStepBundle
+	targets []*target.Target
 
-	select {
-	case <-terminate:
-	case ch.resultCh <- injectionResult{target: target, err: err}:
-	case <-time.After(tr.timeouts.MessageTimeout):
-		log.Panic("could not communicate back with ConTest")
-	}
+	jobID types.JobID
+	runID types.RunID
+
+	state *State
+	t     *test.Test
+
+	timeouts TestRunnerTimeouts
+
+	// ctrlChannels represents a set of result and completion channels for this pipeline,
+	// used to collect the results of routing blocks, steps and targets completing
+	// the pipeline. It's available only after having initialized the pipeline
+	ctrlChannels *pipelineCtrlCh
 }
 
 // Route implements the routing block associated with a TestStep that routes Targets
@@ -147,9 +185,16 @@ func (tr *TestRunner) InjectTarget(terminate <-chan struct{}, target *target.Tar
 // * Asynchronously injects targets into the associated TestStep
 // * Consumes targets in output from the associated TestStep
 // * Asynchronously forwards targets to the following routing block
-func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStepBundle, routingCh routingCh, resultCh chan<- routeResult, ev testevent.EmitterFetcher) {
+func (p *pipeline) route(terminateRoute <-chan struct{}, bundle test.TestStepBundle, routingCh routingCh, resultCh chan<- routeResult, ev testevent.EmitterFetcher) {
 
-	terminateInjection := make(chan struct{})
+	stepLabel := bundle.TestStepLabel
+	log := logging.AddField(p.log, "step", stepLabel)
+	log = logging.AddField(log, "phase", "route")
+
+	log.Debugf("initializing routing for %s", stepLabel)
+	targetWriter := newTargetWriter(log, p.timeouts)
+
+	terminate := make(chan struct{})
 
 	tRouteIn := routingCh.routeIn
 	tStepOut := routingCh.stepOut
@@ -178,46 +223,52 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 	)
 
 	for {
+		log.Debugf("listening")
 		select {
 		case <-terminateRoute:
-			err = fmt.Errorf("termination requested")
+			err = fmt.Errorf("termination requested for routing into %s", stepLabel)
 			break
 		case injectionResult := <-injectResultCh:
+			log.Debugf("received injection result for %v", injectionResult.target)
 			ingressTarget[pendingTarget] = time.Now()
 			pendingTarget = nil
 			if injectionResult.err != nil {
-				err = fmt.Errorf("routing failed while injecting a target: %v", injectionResult.err)
+				err = fmt.Errorf("routing failed while injecting target %+v into %s", injectionResult.err, stepLabel)
 				targetInErrEv := testevent.Data{EventName: target.EventTargetInErr, Target: injectionResult.target}
 				if err := ev.Emit(targetInErrEv); err != nil {
-					log.Warningf("Could not emit %v event for Target: %v", targetInErrEv, *injectionResult.target)
+					log.Warningf("could not emit %v event for target: %+v", targetInErrEv, *injectionResult.target)
 				}
 				break
 			}
 			targetInEv := testevent.Data{EventName: target.EventTargetIn, Target: injectionResult.target}
 			if err := ev.Emit(targetInEv); err != nil {
-				log.Warningf("Could not emit %v event for Target: %v", targetInEv, *injectionResult.target)
+				log.Warningf("could not emit %v event for Target: %+v", targetInEv, *injectionResult.target)
 			}
 			if targets.Len() > 0 {
 				pendingTarget = targets.Back().Value.(*target.Target)
 				targets.Remove(targets.Back())
 				injectionWg.Add(1)
-				go tr.InjectTarget(terminateInjection, pendingTarget, injectionChannels, &injectionWg)
+				log.Debugf("writing target %v into test step", pendingTarget)
+				go targetWriter.writeTargetWithResult(terminate, pendingTarget, injectionChannels, &injectionWg)
 			}
 		case t, chanIsOpen := <-tRouteIn:
 			if !chanIsOpen {
 				// The previous routing block has closed our input channel, signaling that
 				// no more Targets will come through. Block reading from this channel
+				log.Debugf("routing input channel closed")
 				tRouteIn = nil
 			} else {
 				// Buffer the target and check if there is already an injection in progress.
 				// If so, pending targets will be dequeued only at the next result available
 				// on `injectResultCh`.
+				log.Debugf("received target %v in input", t)
 				targets.PushFront(t)
 				if pendingTarget == nil {
 					pendingTarget = targets.Back().Value.(*target.Target)
 					targets.Remove(targets.Back())
 					injectionWg.Add(1)
-					go tr.InjectTarget(terminateInjection, pendingTarget, injectionChannels, &injectionWg)
+					log.Debugf("writing target %v into test step", pendingTarget)
+					go targetWriter.writeTargetWithResult(terminate, pendingTarget, injectionChannels, &injectionWg)
 				}
 			}
 		case t, chanIsOpen := <-tStepOut:
@@ -228,15 +279,15 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 					err = fmt.Errorf("step %s returned target %+v multiple times", bundle.TestStepLabel, t)
 					break
 				}
-				// Emit an event signaling that the target has lef the TestStep
+				// Emit an event signaling that the target has left the TestStep
 				targetOutEv := testevent.Data{EventName: target.EventTargetOut, Target: t}
 				if err := ev.Emit(targetOutEv); err != nil {
-					log.Warningf("Could not emit %v event for Target: %v", targetOutEv, *t)
+					log.Warningf("could not emit %v event for target: %v", targetOutEv, *t)
 				}
 				// Register egress time and forward target to the next routing block
 				egressTarget[t] = time.Now()
-				if err := tr.WriteTargetTimeout(terminateRoute, routingCh.routeOut, t, tr.timeouts.MessageTimeout); err != nil {
-					log.Panicf("step %s: could not forward target to the TestRunner: %+v", bundle.TestStepLabel, err)
+				if err := targetWriter.writeTimeout(terminateRoute, routingCh.routeOut, t, p.timeouts.MessageTimeout); err != nil {
+					log.Panicf("could not forward target to the test runner: %+v", err)
 				}
 			}
 		case targetError, chanIsOpen := <-tStepErr:
@@ -247,7 +298,7 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 					err = fmt.Errorf("step %s returned target %+v multiple times", bundle.TestStepLabel, targetError.Target)
 					break
 				}
-				// Emit an event signaling that the target has lef the TestStep with an error
+				// Emit an event signaling that the target has left the TestStep with an error
 				targetErrPayload := target.ErrPayload{Error: targetError.Err.Error()}
 				payloadEncoded, err := json.Marshal(targetErrPayload)
 				if err != nil {
@@ -258,12 +309,12 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 
 				targetErrEv := testevent.Data{EventName: target.EventTargetErr, Target: targetError.Target, Payload: &rawPayload}
 				if err := ev.Emit(targetErrEv); err != nil {
-					log.Warningf("Could not emit %v event for Target: %v", targetErrEv, *targetError.Target)
+					log.Warningf("could not emit %v event for target: %v", targetErrEv, *targetError.Target)
 				}
 				// Register egress time and forward the failing target to the TestRunner
 				egressTarget[targetError.Target] = time.Now()
-				if err := tr.WriteTargetErrorTimeout(terminateRoute, routingCh.targetErr, targetError, tr.timeouts.MessageTimeout); err != nil {
-					log.Panicf("step %s: could not forward target to the TestRunner: %+v", bundle.TestStepLabel, err)
+				if err := targetWriter.writeTargetError(terminateRoute, routingCh.targetErr, targetError, p.timeouts.MessageTimeout); err != nil {
+					log.Panicf("could not forward target (%+v) to the test runner: %v", targetError.Target, err)
 				}
 			}
 		} // end of select statement
@@ -290,15 +341,15 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 	}
 
 	// If we are not handling an error condition, check if all the targets that we
-	// have injected have been returned by the TestStep.
+	// have injected have been returned by the TestStep. If that condition is met,
+	// we might have been asked to terminate via cancellation signal, or we might
+	// have terminated successfully. We close routing output channel to signal to
+	// the next routing block that no more targets will come through only in the latter
+	// case.
 	if err == nil {
 		if len(ingressTarget) != len(egressTarget) {
 			err = fmt.Errorf("step %s completed but did not return all injected Targets", bundle.TestStepLabel)
 		} else {
-			// Routing terminated without error. We might have been asked to terminate
-			// from outside, or we might have terminated successfully. Close routing
-			// output channel to signal to the next routing block that no more targets
-			// will come through only in the latter case.
 			select {
 			case <-terminateRoute:
 			default:
@@ -308,25 +359,24 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 	}
 
 	// Signal termination to the injection routines regardless of the result of the
-	// routing. If the routing completed successfully, this is a no-op
-	close(terminateInjection)
-
-	// If there is an injection goroutine running, wait for it to terminate, as we
-	// might have gotten here after a cancellation signal.
+	// routing. If the routing completed successfully, this is a no-op. If there is an
+	// injection goroutine running, wait for it to terminate, as we might have gotten
+	// here after a cancellation signal.
+	close(terminate)
 	injectionWg.Wait()
 
-	// Send the result to the TestRunner, which is guaranteed to be listening. If
+	// Send the result to the test runner, which is guaranteed to be listening. If
 	// the TestRunner is not responsive before `MessageTimeout`, we are either running
 	// on a system under heavy load which makes the runtime unable to properly schedule
 	// goroutines, or we are hitting a bug.
 	select {
 	case resultCh <- routeResult{bundle: bundle, err: err}:
-	case <-time.After(tr.timeouts.MessageTimeout):
-		log.Panicf("could not send routing block result for step %s", bundle.TestStepLabel)
+	case <-time.After(p.timeouts.MessageTimeout):
+		log.Panicf("could not send routing block result")
 	}
 }
 
-// RunTestStep runs synchronously a TestStep and peforms sanity checks on the status
+// runStep runs synchronously a TestStep and peforms sanity checks on the status
 // of the input/output channels on the defer control path. When the TestStep returns,
 // the associated output channels are closed. This signals to the routing subsytem
 // that this step of the pipeline will not be producing any more targets. The API
@@ -340,15 +390,21 @@ func (tr *TestRunner) Route(terminateRoute <-chan struct{}, bundle test.TestStep
 // indefinitely and does not respond to cancellation signals, the TestRunner will
 // flag it as misbehaving and return. If the TestStep returns once the TestRunner
 // has completed, it will timeout trying to write on the result channel.
-func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.JobID, runID types.RunID, bundle test.TestStepBundle, stepCh stepCh, resultCh chan<- stepResult, ev testevent.EmitterFetcher) {
+func (p *pipeline) runStep(cancel, pause <-chan struct{}, jobID types.JobID, runID types.RunID, bundle test.TestStepBundle, stepCh stepCh, resultCh chan<- stepResult, ev testevent.EmitterFetcher) {
 
+	stepLabel := bundle.TestStepLabel
+	log := logging.AddField(p.log, "step", stepLabel)
+	log = logging.AddField(log, "phase", "runStep")
+
+	log.Debugf("initializing step")
+	timeout := p.timeouts.MessageTimeout
 	defer func() {
 		if r := recover(); r != nil {
-			err := fmt.Errorf("step %s paniced (%v): %s", bundle.TestStepLabel, r, debug.Stack())
+			err := fmt.Errorf("step %s paniced (%v): %s", stepLabel, r, debug.Stack())
 			select {
 			case resultCh <- stepResult{jobID: jobID, runID: runID, bundle: bundle, err: err}:
-			case <-time.After(tr.timeouts.MessageTimeout):
-				log.Warningf("sending error back from TestStep runner timed out after %v. Error was: %v", tr.timeouts.MessageTimeout, err)
+			case <-time.After(p.timeouts.MessageTimeout):
+				log.Warningf("sending error back from test step runner timed out after %v: %v", timeout, err)
 				return
 			}
 			return
@@ -365,12 +421,12 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 	haveTargets := false
 	select {
 	case <-onFirstTargetChan:
-		log.Debugf("first target")
+		log.Debugf("first target received, will start step")
 		haveTargets = true
 	case <-cancel:
-		log.Debugf("cancel")
+		log.Debugf("cancelled")
 	case <-pause:
-		log.Debugf("pause")
+		log.Debugf("paused")
 	case <-onNoTargetsChan:
 		log.Debugf("no targets")
 	}
@@ -388,6 +444,7 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 		err = bundle.TestStep.Run(cancel, pause, channels, bundle.Parameters, ev)
 	}
 
+	log.Debugf("step %s returned", bundle.TestStepLabel)
 	var (
 		cancellationAsserted bool
 		pauseAsserted        bool
@@ -396,13 +453,14 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 	// channels but return immediately as the TestStep itself probably returned
 	// because it honored the termination signal.
 	select {
-
 	case <-cancel:
+		log.Debugf("cancelled")
 		cancellationAsserted = true
 		if err == nil {
 			err = fmt.Errorf("test step cancelled")
 		}
 	case <-pause:
+		log.Debugf("paused")
 		pauseAsserted = true
 	default:
 	}
@@ -410,8 +468,8 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 	if cancellationAsserted || pauseAsserted {
 		select {
 		case resultCh <- stepResult{jobID: jobID, runID: runID, bundle: bundle, err: err}:
-		case <-time.After(tr.timeouts.MessageTimeout):
-			log.Warningf("sending error back from TestStep runner timed out after %v. Error was: %v", tr.timeouts.MessageTimeout, err)
+		case <-time.After(timeout):
+			log.Warningf("sending error back from TestStep runner timed out after %v: %v", timeout, err)
 		}
 		return
 	}
@@ -421,8 +479,8 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 	if err != nil {
 		select {
 		case resultCh <- stepResult{jobID: jobID, runID: runID, bundle: bundle, err: err}:
-		case <-time.After(tr.timeouts.MessageTimeout):
-			log.Warningf("sending error back from TestStep runner timed out after %v. Error was: %v", tr.timeouts.MessageTimeout, err)
+		case <-time.After(timeout):
+			log.Warningf("sending error back from test step runner (%s) timed out after %v: %v", stepLabel, timeout, err)
 		}
 		return
 	}
@@ -439,13 +497,13 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 		// stepCh.stepIn is not closed, but the TestStep returned, which is a violation
 		// of the API. Record the error if no other error condition has been seen.
 		if err == nil {
-			err = fmt.Errorf("step returned, but input channel is not closed (api violation; case 0)")
+			err = fmt.Errorf("step %s returned, but input channel is not closed (api violation; case 0)", stepLabel)
 		}
 	default:
 		// stepCh.stepIn is not closed, and a read operation would block. The TestStep
 		// does not comply with the API (see above).
 		if err == nil {
-			err = fmt.Errorf("step returned, but input channel is not closed (api violation; case 1)")
+			err = fmt.Errorf("step %s returned, but input channel is not closed (api violation; case 1)", stepLabel)
 		}
 	}
 
@@ -455,7 +513,7 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 			// stepOutCh has been closed. This is a violation of the API. Record the error
 			// if no other error condition has been seen.
 			if err == nil {
-				err = &cerrors.ErrTestStepClosedChannels{StepName: bundle.TestStep.Name()}
+				err = &cerrors.ErrTestStepClosedChannels{StepName: stepLabel}
 			}
 		}
 	default:
@@ -470,7 +528,7 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 			// stepErrCh has been closed. This is a violation of the API. Record the error
 			// if no other error condition has been seen.
 			if err == nil {
-				err = &cerrors.ErrTestStepClosedChannels{StepName: bundle.TestStep.Name()}
+				err = &cerrors.ErrTestStepClosedChannels{StepName: stepLabel}
 			}
 		}
 	default:
@@ -481,112 +539,70 @@ func (tr *TestRunner) RunTestStep(cancel, pause <-chan struct{}, jobID types.Job
 
 	select {
 	case resultCh <- stepResult{jobID: jobID, runID: runID, bundle: bundle, err: err}:
-	case <-time.After(tr.timeouts.MessageTimeout):
-		log.Warningf("sending error back from TestStep runner timed out after %v. Error was: %v", tr.timeouts.MessageTimeout, err)
+	case <-time.After(timeout):
+		log.Warningf("sending error back from step runner (%s) timed out after %v: %v", stepLabel, timeout, err)
 		return
 	}
 }
 
-// WaitTestStep reads results coming from result channels until `StepShutdownTimeout`
-// occurs or an error is encountered. It then checks whether TestSteps and routing
-// blocks have all returned correctly. If not, it returns an error.
-func (tr *TestRunner) WaitTestStep(ch completionCh, bundles []test.TestStepBundle) error {
-	var err error
-
-wait_test_step:
-	for {
-		select {
-		case <-time.After(tr.timeouts.StepShutdownTimeout):
-			break wait_test_step
-		case res := <-ch.routingResultCh:
-			err = res.err
-			tr.state.SetRouting(res.bundle.TestStepLabel, res.err)
-		case res := <-ch.stepResultCh:
-			err = res.err
-			tr.state.SetStep(res.bundle.TestStepLabel, res.err)
-		}
-
-		if err != nil {
-			return err
-		}
-		stepsCompleted := len(tr.state.CompletedSteps()) == len(bundles)
-		routingCompleted := len(tr.state.CompletedRouting()) == len(bundles)
-		if stepsCompleted && routingCompleted {
-			break wait_test_step
-		}
-	}
-
-	incompleteSteps := tr.state.IncompleteSteps(bundles)
-	if len(incompleteSteps) > 0 {
-		err = &cerrors.ErrTestStepsNeverReturned{StepNames: incompleteSteps}
-	} else if len(tr.state.CompletedRouting()) != len(bundles) {
-		err = fmt.Errorf("not all routing completed")
-	}
-	return err
-}
-
-// WaitPipelineTermination reads results coming from result channels waiting
-// for the pipeline to completely shutdown before `ShutdownTimeout` occurs. A
-// "complete shutdown" means that all TestSteps and routing blocks have sent
-// downstream their results.
-func (tr *TestRunner) WaitPipelineTermination(ch completionCh, bundles []test.TestStepBundle) error {
-	log.Printf("Waiting for pipeline to terminate")
-	for {
-		select {
-		case <-time.After(tr.timeouts.ShutdownTimeout):
-			incompleteSteps := tr.state.IncompleteSteps(bundles)
-			if len(incompleteSteps) > 0 {
-				return &cerrors.ErrTestStepsNeverReturned{StepNames: tr.state.IncompleteSteps(bundles)}
-			}
-			return fmt.Errorf("pipeline did not return but all test steps completed")
-		case res := <-ch.routingResultCh:
-			tr.state.SetRouting(res.bundle.TestStepLabel, res.err)
-		case res := <-ch.stepResultCh:
-			tr.state.SetStep(res.bundle.TestStepLabel, res.err)
-		}
-
-		stepsCompleted := len(tr.state.CompletedSteps()) == len(bundles)
-		routingCompleted := len(tr.state.CompletedRouting()) == len(bundles)
-		if stepsCompleted && routingCompleted {
-			return nil
-		}
-	}
-}
-
-// WaitPipelineCompletion reads results coming from results channels until all Targets
+// waitTargets reads results coming from results channels until all Targets
 // have completed or an error occurs. If all Targets complete successfully, it checks
 // whether TestSteps and routing blocks have completed as well. If not, returns an
 // error. Termination is signalled via terminate channel.
-func (tr *TestRunner) WaitPipelineCompletion(terminate <-chan struct{}, ch completionCh, t *test.Test, bundles []test.TestStepBundle, targets []*target.Target) error {
-	var err error
+func (p *pipeline) waitTargets(terminate <-chan struct{}, ch *pipelineCtrlCh, completedCh chan<- *target.Target) error {
+
+	log := logging.AddField(p.log, "phase", "waitTargets")
+
+	var (
+		err                  error
+		completedTarget      *target.Target
+		completedTargetError error
+	)
+
+	writer := newTargetWriter(log, p.timeouts)
 	for {
-		if len(tr.state.CompletedTargets()) == len(targets) {
-			break
+
+		if completedTarget != nil {
+			p.state.SetTarget(completedTarget, completedTargetError)
+			log.Debugf("writing target %+v on the completed channel", completedTarget)
+			if err := writer.writeTimeout(terminate, completedCh, completedTarget, p.timeouts.MessageTimeout); err != nil {
+				log.Panicf("could not write completed target: %v", err)
+			}
+			completedTarget = nil
+			completedTargetError = nil
 		}
+
 		if err != nil {
 			return err
 		}
+
+		if len(p.state.CompletedTargets()) == len(p.targets) {
+			log.Debugf("all targets completed")
+			break
+		}
+
 		select {
 		case <-terminate:
-			// When termination is signaled just stop WaitPipelineCompletion. It is up
+			// When termination is signaled just stop wait. It is up
 			// to the caller to decide how to further handle pipeline termination.
+			log.Debugf("termination requested")
 			return nil
 		case res := <-ch.routingResultCh:
 			err = res.err
-			tr.state.SetRouting(res.bundle.TestStepLabel, res.err)
+			p.state.SetRouting(res.bundle.TestStepLabel, res.err)
 		case res := <-ch.stepResultCh:
 			err = res.err
 			if err != nil {
 				payload, jmErr := json.Marshal(err.Error())
 				if jmErr != nil {
-					log.Warningf("Failed to marshal error string to JSON: %v", jmErr)
+					log.Warningf("failed to marshal error string to JSON: %v", jmErr)
 					continue
 				}
 				rm := json.RawMessage(payload)
 				ev := storage.NewTestEventEmitterFetcher(testevent.Header{
 					JobID:         res.jobID,
 					RunID:         res.runID,
-					TestName:      t.Name,
+					TestName:      p.t.Name,
 					TestStepLabel: res.bundle.TestStepLabel,
 				})
 				errEv := testevent.Data{
@@ -598,20 +614,21 @@ func (tr *TestRunner) WaitPipelineCompletion(terminate <-chan struct{}, ch compl
 				}
 				// emit test event containing the completion error
 				if err := ev.Emit(errEv); err != nil {
-					log.Warningf("Could not emit completion error event %v", errEv)
+					log.Warningf("could not emit completion error event %v", errEv)
 				}
 			}
-			tr.state.SetStep(res.bundle.TestStepLabel, res.err)
+			p.state.SetStep(res.bundle.TestStepLabel, res.err)
+
 		case targetErr := <-ch.targetErr:
-			tr.state.SetTarget(targetErr.Target, targetErr.Err)
+			completedTarget = targetErr.Target
+			completedTargetError = targetErr.Err
 		case target, chanIsOpen := <-ch.targetOut:
 			if !chanIsOpen {
-				if len(tr.state.CompletedTargets()) != len(targets) {
+				if len(p.state.CompletedTargets()) != len(p.targets) {
 					err = fmt.Errorf("not all targets completed, but output channel is closed")
 				}
-			} else {
-				tr.state.SetTarget(target, nil)
 			}
+			completedTarget = target
 		}
 	}
 
@@ -621,30 +638,103 @@ func (tr *TestRunner) WaitPipelineCompletion(terminate <-chan struct{}, ch compl
 	// sequence of close operations has completed). If `ch.out` is still open,
 	// there are still TestSteps that might have not returned. Wait for all
 	// TestSteps to complete or `StepShutdownTimeout` to occur.
-	log.Printf("Waiting for all TestSteps to complete")
-	err = tr.WaitTestStep(ch, bundles)
+	log.Infof("waiting for all steps to complete")
+	return p.waitSteps(ch)
+}
+
+// waitTermination reads results coming from result channels waiting
+// for the pipeline to completely shutdown before `ShutdownTimeout` occurs. A
+// "complete shutdown" means that all TestSteps and routing blocks have sent
+// downstream their results.
+func (p *pipeline) waitTermination() error {
+
+	log := logging.AddField(p.log, "phase", "waitTermination")
+	log.Printf("waiting for pipeline to terminate")
+
+	for {
+		select {
+		case <-time.After(p.timeouts.ShutdownTimeout):
+			incompleteSteps := p.state.IncompleteSteps(p.bundles)
+			if len(incompleteSteps) > 0 {
+				return &cerrors.ErrTestStepsNeverReturned{StepNames: p.state.IncompleteSteps(p.bundles)}
+			}
+			return fmt.Errorf("pipeline did not return but all test steps completed")
+		case res := <-p.ctrlChannels.routingResultCh:
+			p.state.SetRouting(res.bundle.TestStepLabel, res.err)
+		case res := <-p.ctrlChannels.stepResultCh:
+			p.state.SetStep(res.bundle.TestStepLabel, res.err)
+		}
+
+		stepsCompleted := len(p.state.CompletedSteps()) == len(p.bundles)
+		routingCompleted := len(p.state.CompletedRouting()) == len(p.bundles)
+		if stepsCompleted && routingCompleted {
+			return nil
+		}
+	}
+}
+
+// waitSteps reads results coming from result channels until `StepShutdownTimeout`
+// occurs or an error is encountered. It then checks whether TestSteps and routing
+// blocks have all returned correctly. If not, it returns an error.
+func (p *pipeline) waitSteps(ch *pipelineCtrlCh) error {
+
+	log := logging.AddField(p.log, "phase", "waitSteps")
+
+	var err error
+
+wait_test_step:
+	for {
+		select {
+		case <-time.After(p.timeouts.StepShutdownTimeout):
+			log.Debugf("timed out waiting for steps to complete after %v", p.timeouts.StepShutdownTimeout)
+			break wait_test_step
+		case res := <-ch.routingResultCh:
+			log.Debugf("received result for %s", res.bundle.TestStepLabel)
+			err = res.err
+			p.state.SetRouting(res.bundle.TestStepLabel, res.err)
+		case res := <-ch.stepResultCh:
+			err = res.err
+			p.state.SetStep(res.bundle.TestStepLabel, res.err)
+		}
+
+		if err != nil {
+			return err
+		}
+		stepsCompleted := len(p.state.CompletedSteps()) == len(p.bundles)
+		routingCompleted := len(p.state.CompletedRouting()) == len(p.bundles)
+		if stepsCompleted && routingCompleted {
+			break wait_test_step
+		}
+	}
+
+	incompleteSteps := p.state.IncompleteSteps(p.bundles)
+	if len(incompleteSteps) > 0 {
+		err = &cerrors.ErrTestStepsNeverReturned{StepNames: incompleteSteps}
+	} else if len(p.state.CompletedRouting()) != len(p.bundles) {
+		err = fmt.Errorf("not all routing completed")
+	}
 	return err
 }
 
-// Run implements the main logic of the TestRunner, i.e. the instantiation and
-// connection of the TestSteps, routing blocks and pipeline runner.
-func (tr *TestRunner) Run(cancel, pause <-chan struct{}, t *test.Test, targets []*target.Target, jobID types.JobID, runID types.RunID) error {
-	testStepBundles := t.TestStepsBundles
-	if len(testStepBundles) == 0 {
-		return fmt.Errorf("no steps to run for test")
+// init initializes the pipeline by connecting steps and routing blocks. The result of pipeline
+// initialization is a set of control/result channels assigned to the pipeline object. The pipeline
+// input channel is returned.
+func (p *pipeline) init(cancel, pause <-chan struct{}) (routeInFirst chan *target.Target) {
+	p.log.Debugf("starting")
+
+	if p.ctrlChannels != nil {
+		p.log.Panicf("pipeline is already initialized, control channel are already configured")
 	}
 
 	var (
-		cancellationAsserted bool
-		pauseAsserted        bool
+		routeOut chan *target.Target
+		routeIn  chan *target.Target
 	)
 
-	pauseTestStep := make(chan struct{})
-	cancelTestStep := make(chan struct{})
 	// termination channels are used to signal termination to injection and routing
-	terminateWaitCompletion := make(chan struct{})
-	terminateInjection := make(chan struct{})
-	terminateRouting := make(chan struct{})
+	routingCancelCh := make(chan struct{})
+	stepsCancelCh := make(chan struct{})
+	stepsPauseCh := make(chan struct{})
 
 	// result channels used to communicate result information from the routing blocks
 	// and step executors
@@ -652,32 +742,20 @@ func (tr *TestRunner) Run(cancel, pause <-chan struct{}, t *test.Test, targets [
 	stepResultCh := make(chan stepResult)
 	targetErrCh := make(chan cerrors.TargetError)
 
-	var (
-		routeIn  chan *target.Target
-		routeOut chan *target.Target
-	)
+	routeIn = make(chan *target.Target)
+	for r, testStepBundle := range p.bundles {
 
-	for r, testStepBundle := range testStepBundles {
 		// Input and output channels for the TestStep
 		stepInCh := make(chan *target.Target)
 		stepOutCh := make(chan *target.Target)
 		stepErrCh := make(chan cerrors.TargetError)
 
-		// Output of the current routing block
 		routeOut = make(chan *target.Target)
 
-		// First step of the pipeline
+		// First step of the pipeline, keep track of the routeIn channel as this is
+		// going to be used to route channels into the pipeline from outside
 		if r == 0 {
-			routeIn = make(chan *target.Target)
-			// Spawn a goroutine which injects Targets into the first routing block
-			go func(terminate <-chan struct{}, inputChannel chan<- *target.Target) {
-				defer close(inputChannel)
-				for _, target := range targets {
-					if err := tr.WriteTargetTimeout(terminate, inputChannel, target, tr.timeouts.MessageTimeout); err != nil {
-						log.Panic(fmt.Sprintf("could not inject target %+v into first routing block: %+v", target, err))
-					}
-				}
-			}(terminateInjection, routeIn)
+			routeInFirst = routeIn
 		}
 
 		stepChannels := stepCh{stepIn: stepInCh, stepErr: stepErrCh, stepOut: stepOutCh}
@@ -692,81 +770,95 @@ func (tr *TestRunner) Run(cancel, pause <-chan struct{}, t *test.Test, targets [
 
 		// Build the Header that the the TestStep will be using for emitting events
 		Header := testevent.Header{
-			JobID:         jobID,
-			RunID:         runID,
-			TestName:      t.Name,
+			JobID:         p.jobID,
+			RunID:         p.runID,
+			TestName:      p.t.Name,
 			TestStepLabel: testStepBundle.TestStepLabel,
 		}
 		ev := storage.NewTestEventEmitterFetcher(Header)
-		go tr.Route(terminateRouting, testStepBundle, routingChannels, routingResultCh, ev)
-		go tr.RunTestStep(cancelTestStep, pauseTestStep, jobID, runID, testStepBundle, stepChannels, stepResultCh, ev)
+		go p.route(routingCancelCh, testStepBundle, routingChannels, routingResultCh, ev)
+		go p.runStep(stepsCancelCh, stepsPauseCh, p.jobID, p.runID, testStepBundle, stepChannels, stepResultCh, ev)
 		// The input of the next routing block is the output of the current routing block
 		routeIn = routeOut
 	}
 
-	var (
-		completionError  error
-		terminationError error
-	)
-
-	completionChannels := completionCh{
+	p.ctrlChannels = &pipelineCtrlCh{
 		routingResultCh: routingResultCh,
 		stepResultCh:    stepResultCh,
 		targetErr:       targetErrCh,
 		targetOut:       routeOut,
+
+		cancelRoutingCh: routingCancelCh,
+		cancelStepsCh:   stepsCancelCh,
+		pauseStepsCh:    stepsPauseCh,
 	}
 
-	// errCh collects errors coming from the routines which wait for the Test to complete
-	errCh := make(chan error)
+	return
+}
+
+// run is a blocking method which executes the pipeline until successful or failed termination
+func (p *pipeline) run(cancel, pause <-chan struct{}, completedTargets chan<- *target.Target) error {
+
+	p.log.Debugf("run")
+	if p.ctrlChannels == nil {
+		p.log.Panicf("pipeline is not initialized, control channels are not available")
+	}
 
 	// Wait for the pipeline to complete. If an error occurrs, cancel all TestSteps
 	// and routing blocks and wait again for completion until shutdown timeout occurrs.
-	log.Printf("TestRunner: waiting for test to complete")
+	p.log.Infof("waiting for pipeline to complete")
 
+	var (
+		completionError      error
+		terminationError     error
+		cancellationAsserted bool
+		pauseAsserted        bool
+	)
+
+	cancelWaitTargetsCh := make(chan struct{})
+	// errCh collects errors coming from the routines which wait for the Test to complete
+	errCh := make(chan error)
 	go func() {
-		errCh <- tr.WaitPipelineCompletion(terminateWaitCompletion, completionChannels, t, testStepBundles, targets)
+		errCh <- p.waitTargets(cancelWaitTargetsCh, p.ctrlChannels, completedTargets)
 	}()
 
 	select {
 	case completionError = <-errCh:
 	case <-cancel:
-		close(terminateWaitCompletion)
+		close(cancelWaitTargetsCh)
 		cancellationAsserted = true
 		completionError = <-errCh
 	case <-pause:
-		close(terminateWaitCompletion)
+		close(cancelWaitTargetsCh)
 		pauseAsserted = true
 		completionError = <-errCh
 	}
 
 	if completionError != nil || cancellationAsserted {
 		// If the Test has encountered an error or cancellation has been asserted,
-		// terminate routing and injection and propagate the cancel signal to the
-		// TestStep(s)
+		// terminate routing and and propagate the cancel signal to the steps
 		cancellationAsserted = true
 		if completionError != nil {
-			log.Printf("TestRunner: test failed to complete: %+v. Forcing cancellation.", completionError)
+			p.log.Warningf("test failed to complete: %v. Forcing cancellation.", completionError)
 		} else {
-			log.Printf("TestRunner: cancellation was asserted")
+			p.log.Infof("cancellation was asserted")
 		}
-		close(cancelTestStep)
-		close(terminateInjection)
-		close(terminateRouting)
+		close(p.ctrlChannels.cancelStepsCh)
+		close(p.ctrlChannels.cancelRoutingCh)
 	}
+
 	if pauseAsserted {
-		// If pause signal has been asserted, terminate routing and injection and
-		// propagate the pause signal to the TestStep(s).
-		log.Printf("TestRunner has received pause request")
-		close(pauseTestStep)
-		close(terminateInjection)
-		close(terminateRouting)
+		// If pause signal has been asserted, terminate routing and propagate the pause signal to the steps.
+		p.log.Warningf("received pause request")
+		close(p.ctrlChannels.pauseStepsCh)
+		close(p.ctrlChannels.cancelRoutingCh)
 	}
 
 	// If either cancellation or pause have been asserted, we need to wait for the
 	// pipeline to terminate
 	if cancellationAsserted || pauseAsserted {
 		go func() {
-			errCh <- tr.WaitPipelineTermination(completionChannels, testStepBundles)
+			errCh <- p.waitTermination()
 		}()
 		signal := "cancellation"
 		if pauseAsserted {
@@ -774,18 +866,84 @@ func (tr *TestRunner) Run(cancel, pause <-chan struct{}, t *test.Test, targets [
 		}
 		terminationError = <-errCh
 		if terminationError != nil {
-			log.Printf("TestRunner: test did not terminate correctly after %s signal: %+v", signal, terminationError)
+			p.log.Infof("test did not terminate correctly after %s signal: %v", signal, terminationError)
 		} else {
-			log.Printf("TestRunner: test terminated correctly after %s signal", signal)
+			p.log.Infof("test terminated correctly after %s signal", signal)
 		}
 	} else {
-		log.Printf("TestRunner completed")
+		p.log.Infof("completed")
 	}
 
 	if completionError != nil {
 		return completionError
 	}
 	return terminationError
+
+}
+
+func newPipeline(log *logrus.Entry, bundles []test.TestStepBundle, t *test.Test, targets []*target.Target, jobID types.JobID, runID types.RunID, timeouts TestRunnerTimeouts) *pipeline {
+	p := pipeline{log: log, bundles: bundles, targets: targets, jobID: jobID, runID: runID, t: t, timeouts: timeouts}
+	p.state = NewState()
+	return &p
+}
+
+// Run implements the main logic of the TestRunner, i.e. the instantiation and
+// connection of the TestSteps, routing blocks and pipeline runner.
+func (tr *TestRunner) Run(cancel, pause <-chan struct{}, t *test.Test, targets []*target.Target, jobID types.JobID, runID types.RunID) error {
+
+	if len(t.TestStepsBundles) == 0 {
+		return fmt.Errorf("no steps to run for test")
+	}
+
+	// rootLog is propagated to all the subsystems of the pipeline
+	rootLog := logging.GetLogger("pkg/runner")
+	fields := make(map[string]interface{})
+	fields["jobid"] = jobID
+	fields["runid"] = runID
+	rootLog = logging.AddFields(rootLog, fields)
+
+	log := logging.AddField(rootLog, "phase", "run")
+	pipeline := newPipeline(logging.AddField(rootLog, "entity", "pipeline"), t.TestStepsBundles, t, targets, jobID, runID, tr.timeouts)
+
+	log.Infof("setting up pipeline")
+	completedTargets := make(chan *target.Target)
+	inCh := pipeline.init(cancel, pause)
+
+	// inject targets in the step
+	terminateInjectionCh := make(chan struct{})
+	go func(terminate <-chan struct{}, inputChannel chan<- *target.Target) {
+		defer close(inputChannel)
+		log := logging.AddField(log, "step", "injection")
+		writer := newTargetWriter(log, tr.timeouts)
+		for _, target := range targets {
+			if err := writer.writeTimeout(terminate, inputChannel, target, tr.timeouts.MessageTimeout); err != nil {
+				log.Debugf("could not inject target %+v into first routing block: %+v", target, err)
+			}
+		}
+	}(terminateInjectionCh, inCh)
+
+	errCh := make(chan error)
+	go func() {
+		log.Infof("running pipeline")
+		errCh <- pipeline.run(cancel, pause, completedTargets)
+	}()
+
+	defer close(terminateInjectionCh)
+	// Receive targets from the completed channel controlled by the pipeline, while
+	// waiting for termination signals or fatal errors encountered while running
+	// the pipeline.
+	for {
+		select {
+		case <-cancel:
+			return <-errCh
+		case <-pause:
+			return <-errCh
+		case err := <-errCh:
+			return err
+		case target := <-completedTargets:
+			log.Infof("completed target: %v", target)
+		}
+	}
 }
 
 // NewTestRunner initializes and returns a new TestRunner object. This test
@@ -798,14 +956,13 @@ func NewTestRunner() TestRunner {
 			ShutdownTimeout:     config.TestRunnerShutdownTimeout,
 			StepShutdownTimeout: config.TestRunnerStepShutdownTimeout,
 		},
-		state: NewState(),
 	}
 }
 
 // NewTestRunnerWithTimeouts initializes and returns a new TestRunner object with
 // custom timeouts
 func NewTestRunnerWithTimeouts(timeouts TestRunnerTimeouts) TestRunner {
-	return TestRunner{timeouts: timeouts, state: NewState()}
+	return TestRunner{timeouts: timeouts}
 }
 
 // State is a structure that models the current state of the test runner


### PR DESCRIPTION
The logic of the test runner is not modular enough to accomodate the
need for implementing a cleanup pipeline. This revision refactors the
test runner so that the concept of pipeline can be re-used. The eventual
goal is to deploy two pipelines, one for testing and one for cleanup.