### PR TITLE
Expose error in status for failed job states

### DIFF
--- a/pkg/job/status.go
+++ b/pkg/job/status.go
@@ -83,6 +83,9 @@ type Status struct {
 	// State represents the last recorded state of a job
 	State string
 
+	// StateErrMsg is an optional error message associated to the job state
+	StateErrMsg string
+
 	// StartTime indicates when the job started. A value of 0 indicates "not
 	// started yet"
 	StartTime time.Time

--- a/pkg/jobmanager/event.go
+++ b/pkg/jobmanager/event.go
@@ -28,7 +28,7 @@ var EventJobCancelled = event.Name("JobStateCancelled")
 // EventJobCancellationFailed indicates that the cancellation was not completed correctly
 var EventJobCancellationFailed = event.Name("JobStateCancellationFailed")
 
-// JobCompletionEvents gather all event that mark the end of a job
+// JobCompletionEvents gathers all event names that mark the end of a job
 var JobCompletionEvents = []event.Name{
 	EventJobCompleted,
 	EventJobFailed,
@@ -36,7 +36,7 @@ var JobCompletionEvents = []event.Name{
 	EventJobCancellationFailed,
 }
 
-// JobStateEvents gather all event names which track the state of a job
+// JobStateEvents gathers all event names which track the state of a job
 var JobStateEvents = []event.Name{
 	EventJobStarted,
 	EventJobCompleted,

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -31,8 +31,8 @@ var log = logging.GetLogger("pkg/jobmanager")
 
 var cancellationTimeout = 60 * time.Second
 
-// errorPayload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
-type errorPayload struct {
+// ErrorEventPayload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
+type ErrorEventPayload struct {
 	Err string
 }
 
@@ -386,7 +386,7 @@ func (jm *JobManager) emitErrEvent(jobID types.JobID, eventName event.Name, err 
 	)
 	if err != nil {
 		log.Errorf(err.Error())
-		payload := errorPayload{Err: err.Error()}
+		payload := ErrorEventPayload{Err: err.Error()}
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
 			log.Warningf("Could not serialize payload for event %s: %v", eventName, err)


### PR DESCRIPTION
This change exposes the error message in status requests when a job ends
with JobStateFailed. This makes troubleshooting easier, without having
to access the database.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>