### PR TITLE
bugfix(jobmanager): Do not panic on null-values in Job Description

### DIFF
--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -104,6 +104,9 @@ func newPartialJobFromDescriptor(pr *pluginregistry.PluginRegistry, jd *job.JobD
 	tests := make([]*test.Test, 0, len(jd.TestDescriptors))
 	testDescriptors := make([][]*test.TestStepDescriptor, 0, len(jd.TestDescriptors))
 	for _, td := range jd.TestDescriptors {
+		if td == nil {
+			return nil, errors.New("test description is null")
+		}
 		if td.TargetManagerName == "" {
 			return nil, errors.New("target manager name cannot be empty")
 		}
@@ -130,6 +133,9 @@ func newPartialJobFromDescriptor(pr *pluginregistry.PluginRegistry, jd *job.JobD
 		var stepBundles []test.TestStepBundle
 		labels := make(map[string]bool)
 		for idx, testStepDesc := range testStepDescs {
+			if testStepDesc == nil {
+				return nil, errors.New("test step description is null")
+			}
 			tse, err := pr.NewTestStepEvents(testStepDesc.Name)
 			if err != nil {
 				return nil, err

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -461,3 +461,23 @@ func (suite *TestJobManagerSuite) TestTestStepLabelDuplication() {
 	_, err := suite.startJob(jobDescriptorLabelDuplication)
 	require.Error(suite.T(), err)
 }
+
+func (suite *TestJobManagerSuite) TestTestStepNull() {
+	go func() {
+		suite.jm.Start(suite.sigs)
+		close(suite.jobManagerCh)
+	}()
+
+	_, err := suite.startJob(jobDescriptorNullStep)
+	require.Error(suite.T(), err)
+}
+
+func (suite *TestJobManagerSuite) TestTestNull() {
+	go func() {
+		suite.jm.Start(suite.sigs)
+		close(suite.jobManagerCh)
+	}()
+
+	_, err := suite.startJob(jobDescriptorNullTest)
+	require.Error(suite.T(), err)
+}

--- a/tests/integ/jobmanager/jobdescriptors.go
+++ b/tests/integ/jobmanager/jobdescriptors.go
@@ -156,3 +156,38 @@ var jobDescriptorLabelDuplication = descriptorMust(`
        ],
        "TestName": "IntegrationTest: label_duplication"
    }`)
+
+var jobDescriptorNullStep = descriptorMust(`
+   "TestFetcherFetchParameters": {
+       "Steps": [
+           {
+               "name": "noop",
+               "label": "some_label_here",
+               "parameters": {}
+           },
+           null
+       ],
+       "TestName": "IntegrationTest: null TestStep"
+   }`)
+
+var jobDescriptorNullTest = `
+{
+    "JobName": "test job",
+    "Tags": [
+        "integration_testing"
+    ],
+    "TestDescriptors": [
+        null
+    ],
+    "Reporting": {
+        "RunReporters": [
+            {
+                "Name": "TargetSuccess",
+                "Parameters": {
+                    "SuccessExpression": ">0%"
+                }
+            }
+        ]
+    }
+}
+`


### PR DESCRIPTION
A job description like this:
```
{
    "JobName": "test job",
    "Tags": [
        "integration_testing"
    ],
    "TestDescriptors": [
        null
    ],
    "Reporting": {
        "RunReporters": [
            {
                "Name": "TargetSuccess",
                "Parameters": {
                    "SuccessExpression": ">0%"
                }
            }
        ]
    }
}
```
is causing panic because of `null` in `TestDescriptors`. Fixing it and the same problem for a TestStep.