### PR TITLE
bugfix(api): properly print the timeout

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -100,7 +100,7 @@ func (a *API) SendEvent(ev *Event, timeout *time.Duration) error {
 	case a.Events <- ev:
 		return nil
 	case <-time.After(to):
-		return fmt.Errorf("sending event timed out after %v", timeout)
+		return fmt.Errorf("sending event timed out after %v", to)
 	}
 }
 


### PR DESCRIPTION
We were getting errors:
```
time out waiting for response after <nil>
```

But it should be a timeout instead of `nil`.