### PR TITLE
Replace flag with pflag

### DIFF
--- a/cmds/clients/contestcli-http/main.go
+++ b/cmds/clients/contestcli-http/main.go
@@ -9,19 +9,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/facebookincubator/contest/pkg/api"
 	"github.com/facebookincubator/contest/pkg/config"
 	"github.com/facebookincubator/contest/pkg/jobmanager"
 	"github.com/facebookincubator/contest/plugins/listeners/httplistener"
+
+	flag "github.com/spf13/pflag"
 )
 
 // Unauthenticated, unencrypted sample HTTP client for ConTest.
@@ -40,10 +42,10 @@ const (
 )
 
 var (
-	flagAddr      = flag.String("addr", "http://localhost:8080", "ConTest server [scheme://]host:port[/basepath] to connect to")
-	flagRequestor = flag.String("r", defaultRequestor, "Identifier of the requestor of the API call")
-	flagWait      = flag.Bool("wait", false, "After starting a job, wait for it to finish, and exit 0 only if it is successful")
-	flagYAML      = flag.Bool("yaml", false, "Parse job descriptor as YAML instead of JSON")
+	flagAddr      = flag.StringP("addr", "a", "http://localhost:8080", "ConTest server [scheme://]host:port[/basepath] to connect to")
+	flagRequestor = flag.StringP("requestor", "r", defaultRequestor, "Identifier of the requestor of the API call")
+	flagWait      = flag.BoolP("wait", "w", false, "After starting a job, wait for it to finish, and exit 0 only if it is successful")
+	flagYAML      = flag.BoolP("yaml", "Y", false, "Parse job descriptor as YAML instead of JSON")
 )
 
 func main() {
@@ -67,7 +69,11 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
-	verb := flag.Arg(0)
+	verb := strings.TrimSpace(flag.Arg(0))
+	if verb == "" {
+		fmt.Fprintf(flag.CommandLine.Output(), "Missing verb, see --help\n")
+		os.Exit(1)
+	}
 	if err := run(verb); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v0.0.6 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1
 	github.com/spf13/viper v1.6.2 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/u-root/u-root v6.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1 h1:zrNp7OPtn2fjeNHI9CghvwxqQvvkK0RxUo86hE86vhU=
+github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.1 h1:VPZzIkznI1YhVMRi6vNFLHSwhnhReBfgTxIPccpfdZk=


### PR DESCRIPTION
We are not size-constrained for the client, so I am replacing the
standard `flag` with the more flexible `pflag`. Benefits:
* support GNU style short and long, (e.g. `-Y` and `--yaml` are now
  the same), which are more widely adopted
* positional arguments can occur before switches (e.g. now can run
  `contestcli-http start -Y` without generating an error)

This changes the default behaviour though, since long options require
a double-dash instead of a single one. Single-letter options (like `-r`)
are unchanged since they are treated as short options.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>