### PR TITLE
[plugins/targetlocker/inmemory] several fixes

### DIFF
--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -38,6 +38,15 @@ type Locker interface {
 	// The request is rejected if the job ID does not match the one of the lock
 	// owner.
 	RefreshLocks(types.JobID, []*Target) error
+	// TODO this method is probably redundant and misleading. The job runner
+	//      should not check if the targets are locked by a given job ID, but
+	//      should lock them directly, so that the already locked ones are
+	//      refreshed, and the not locked ones are locked. This is a possible
+	//      scenario in target acquisition, e.g. when a target manager tries to
+	//      lock targets until enough are found, but is not responsible for
+	//      locking all of them since the job runner will do that anyway. This
+	//      reduces the responsibility on target managers, and hence the chances
+	//      of bugs.
 	// CheckLocks returns whether all the targets are locked by the given job ID,
 	// an array of locked targets, and an array of not-locked targets.
 	CheckLocks(types.JobID, []*Target) (bool, []*Target, []*Target)

--- a/plugins/targetlocker/inmemory/inmemory_test.go
+++ b/plugins/targetlocker/inmemory/inmemory_test.go
@@ -11,7 +11,18 @@ import (
 
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	jobID = types.JobID(123)
+
+	noTarget   = []*target.Target{}
+	targetOne  = target.Target{Name: "target001", ID: "001"}
+	targetTwo  = target.Target{Name: "target002", ID: "002"}
+	oneTarget  = []*target.Target{&targetOne}
+	twoTargets = []*target.Target{&targetOne, &targetTwo}
 )
 
 func TestInMemoryNew(t *testing.T) {
@@ -20,36 +31,155 @@ func TestInMemoryNew(t *testing.T) {
 	require.IsType(t, &InMemory{}, tl)
 }
 
-func TestInMemoryLock(t *testing.T) {
+func TestInMemoryLockInvalidJobIDAndNoTargets(t *testing.T) {
 	tl := New(time.Second)
-	// we don't enforce that at least one target is passed, as checking on
-	// non-zero targets is the framework's responsibility, not the plugin.
-	// So, zero targets is OK.
-	jobID := types.JobID(123)
-	require.Nil(t, tl.Lock(jobID, nil))
-	require.Nil(t, tl.Lock(jobID, []*target.Target{}))
-	require.Nil(t, tl.Lock(jobID, []*target.Target{
-		&target.Target{Name: "t1"},
-	}))
-	require.Nil(t, tl.Lock(jobID, []*target.Target{
-		&target.Target{Name: "t2"},
-		&target.Target{Name: "t3"},
-	}))
+	assert.Error(t, tl.Lock(0, nil))
 }
 
-func TestInMemoryUnlock(t *testing.T) {
+func TestInMemoryLockValidJobIDAndNoTargets(t *testing.T) {
 	tl := New(time.Second)
-	// we don't enforce that at least one target is passed, as checking on
-	// non-zero targets is the framework's responsibility, not the plugin.
-	// So, zero targets is OK.
-	jobID := types.JobID(123)
-	require.Nil(t, tl.Unlock(jobID, nil))
-	require.Nil(t, tl.Unlock(jobID, []*target.Target{}))
-	require.Nil(t, tl.Unlock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
-	}))
-	require.Nil(t, tl.Unlock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
-		&target.Target{Name: "bleh"},
-	}))
+	assert.Error(t, tl.Lock(jobID, nil))
+}
+
+func TestInMemoryLockInvalidJobIDAndOneTarget(t *testing.T) {
+	tl := New(time.Second)
+	assert.Error(t, tl.Lock(0, oneTarget))
+}
+
+func TestInMemoryLockValidJobIDAndOneTarget(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, oneTarget))
+}
+
+func TestInMemoryLockValidJobIDAndTwoTargets(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+}
+
+func TestInMemoryLockReentrantLock(t *testing.T) {
+	tl := New(10 * time.Second)
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+}
+
+func TestInMemoryLockReentrantLockDifferentJobID(t *testing.T) {
+	tl := New(10 * time.Second)
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+	require.Error(t, tl.Lock(jobID+1, twoTargets))
+}
+
+func TestInMemoryUnlockInvalidJobIDAndNoTargets(t *testing.T) {
+	tl := New(time.Second)
+	assert.Error(t, tl.Unlock(jobID, nil))
+}
+
+func TestInMemoryUnlockValidJobIDAndNoTargets(t *testing.T) {
+	tl := New(time.Second)
+	assert.Error(t, tl.Unlock(jobID, nil))
+}
+
+func TestInMemoryUnlockInvalidJobIDAndOneTarget(t *testing.T) {
+	tl := New(time.Second)
+	assert.Error(t, tl.Unlock(0, oneTarget))
+}
+
+func TestInMemoryUnlockValidJobIDAndOneTarget(t *testing.T) {
+	tl := New(time.Second)
+	require.Error(t, tl.Unlock(jobID, oneTarget))
+}
+
+func TestInMemoryUnlockValidJobIDAndTwoTargets(t *testing.T) {
+	tl := New(time.Second)
+	require.Error(t, tl.Unlock(jobID, twoTargets))
+}
+
+func TestInMemoryUnlockUnlockTwice(t *testing.T) {
+	tl := New(time.Second)
+	err := tl.Unlock(jobID, oneTarget)
+	log.Print(err)
+	assert.Error(t, err)
+	assert.Error(t, tl.Unlock(jobID, oneTarget))
+}
+
+func TestInMemoryUnlockReentrantLockDifferentJobID(t *testing.T) {
+	tl := New(time.Second)
+	require.Error(t, tl.Unlock(jobID, twoTargets))
+	assert.Error(t, tl.Unlock(jobID+1, twoTargets))
+}
+
+func TestInMemoryLockUnlockSameJobID(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+	assert.NoError(t, tl.Unlock(jobID, twoTargets))
+}
+
+func TestInMemoryLockUnlockDifferentJobID(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+	assert.Error(t, tl.Unlock(jobID+1, twoTargets))
+}
+
+func TestInMemoryCheckLocksNoneLocked(t *testing.T) {
+	tl := New(time.Second)
+	allLocked, locked, notLocked := tl.CheckLocks(jobID, twoTargets)
+	assert.False(t, allLocked)
+	assert.Equal(t, noTarget, locked)
+	assert.Equal(t, twoTargets, notLocked)
+}
+
+func TestInMemoryCheckLocksAllLocked(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, twoTargets))
+	allLocked, locked, notLocked := tl.CheckLocks(jobID, twoTargets)
+	assert.True(t, allLocked)
+	assert.Equal(t, twoTargets, locked)
+	assert.Equal(t, noTarget, notLocked)
+}
+
+func TestInMemoryCheckLocksSomeLocked(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, []*target.Target{&targetOne}))
+	allLocked, locked, notLocked := tl.CheckLocks(jobID, []*target.Target{&targetOne, &targetTwo})
+	assert.False(t, allLocked)
+	assert.Equal(t, []*target.Target{&targetOne}, locked)
+	assert.Equal(t, []*target.Target{&targetTwo}, notLocked)
+}
+
+func TestInMemoryCheckLocksMultipleOwners(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.Lock(jobID, []*target.Target{&targetOne}))
+	require.NoError(t, tl.Lock(jobID+1, []*target.Target{&targetTwo}))
+	// owner 1
+	allLocked, locked, notLocked := tl.CheckLocks(jobID, []*target.Target{&targetOne, &targetTwo})
+	assert.False(t, allLocked)
+	assert.Equal(t, []*target.Target{&targetOne}, locked)
+	assert.Equal(t, []*target.Target{&targetTwo}, notLocked)
+	// owner 2
+	allLocked, locked, notLocked = tl.CheckLocks(jobID+1, []*target.Target{&targetOne, &targetTwo})
+	assert.False(t, allLocked)
+	assert.Equal(t, []*target.Target{&targetTwo}, locked)
+	assert.Equal(t, []*target.Target{&targetOne}, notLocked)
+}
+
+func TestInMemoryRefreshLocks(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+}
+
+func TestInMemoryRefreshLocksTwice(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+}
+
+func TestInMemoryRefreshLocksOneThenTwo(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.RefreshLocks(jobID, oneTarget))
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+}
+
+func TestInMemoryRefreshLocksTwoThenOne(t *testing.T) {
+	tl := New(time.Second)
+	require.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+	assert.NoError(t, tl.RefreshLocks(jobID, oneTarget))
 }


### PR DESCRIPTION
There were several bugs in the in-memory target locker:
* requests were passed by value instead of reference, so the results
  were not visible to the caller
* owner was not set and not used for lock validation

Also:
* added validation of owner and number of targets in request objects
* added many tests to make sure this doesn't happen again
* better log messages

Signed-off-by: Andrea Barberio <insomniac@slackware.it>