### PR TITLE
TargetLocker: remove CheckLocks, enforce locking during target acquisition

### DIFF
--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -38,18 +38,6 @@ type Locker interface {
 	// The request is rejected if the job ID does not match the one of the lock
 	// owner.
 	RefreshLocks(types.JobID, []*Target) error
-	// TODO this method is probably redundant and misleading. The job runner
-	//      should not check if the targets are locked by a given job ID, but
-	//      should lock them directly, so that the already locked ones are
-	//      refreshed, and the not locked ones are locked. This is a possible
-	//      scenario in target acquisition, e.g. when a target manager tries to
-	//      lock targets until enough are found, but is not responsible for
-	//      locking all of them since the job runner will do that anyway. This
-	//      reduces the responsibility on target managers, and hence the chances
-	//      of bugs.
-	// CheckLocks returns whether all the targets are locked by the given job ID,
-	// an array of locked targets, and an array of not-locked targets.
-	CheckLocks(types.JobID, []*Target) (bool, []*Target, []*Target)
 }
 
 // SetLocker sets the desired lock engine for targets.

--- a/plugins/targetlocker/inmemory/inmemory.go
+++ b/plugins/targetlocker/inmemory/inmemory.go
@@ -211,22 +211,6 @@ func (tl *InMemory) RefreshLocks(jobID types.JobID, targets []*target.Target) er
 	return <-req.err
 }
 
-// CheckLocks tells whether all the targets are locked, and returns a slice of
-// locked and a slice of unlocked targets.
-func (tl *InMemory) CheckLocks(jobID types.JobID, targets []*target.Target) (bool, []*target.Target, []*target.Target) {
-	log.Infof("Checking if %d target(s) are locked by job ID %d", len(targets), jobID)
-	req := newReq(jobID, targets)
-	tl.checkLocksRequests <- &req
-	if err := <-req.err; err != nil {
-		// TODO the target.Locker.CheckLocks interface has to change to return an
-		// error as well, because lock checking can fail, e.g. when using
-		// external services.
-		// Just log an error for now.
-		log.Warningf("Error when trying to unlock targets: %v", err)
-	}
-	return len(req.locked) == len(targets), req.locked, req.notLocked
-}
-
 // New initializes and returns a new InMemory target locker.
 func New(timeout time.Duration) target.Locker {
 	lockRequests := make(chan *request)

--- a/plugins/targetlocker/inmemory/inmemory_test.go
+++ b/plugins/targetlocker/inmemory/inmemory_test.go
@@ -18,7 +18,6 @@ import (
 var (
 	jobID = types.JobID(123)
 
-	noTarget   = []*target.Target{}
 	targetOne  = target.Target{Name: "target001", ID: "001"}
 	targetTwo  = target.Target{Name: "target002", ID: "002"}
 	oneTarget  = []*target.Target{&targetOne}
@@ -117,48 +116,6 @@ func TestInMemoryLockUnlockDifferentJobID(t *testing.T) {
 	tl := New(time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	assert.Error(t, tl.Unlock(jobID+1, twoTargets))
-}
-
-func TestInMemoryCheckLocksNoneLocked(t *testing.T) {
-	tl := New(time.Second)
-	allLocked, locked, notLocked := tl.CheckLocks(jobID, twoTargets)
-	assert.False(t, allLocked)
-	assert.Equal(t, noTarget, locked)
-	assert.Equal(t, twoTargets, notLocked)
-}
-
-func TestInMemoryCheckLocksAllLocked(t *testing.T) {
-	tl := New(time.Second)
-	require.NoError(t, tl.Lock(jobID, twoTargets))
-	allLocked, locked, notLocked := tl.CheckLocks(jobID, twoTargets)
-	assert.True(t, allLocked)
-	assert.Equal(t, twoTargets, locked)
-	assert.Equal(t, noTarget, notLocked)
-}
-
-func TestInMemoryCheckLocksSomeLocked(t *testing.T) {
-	tl := New(time.Second)
-	require.NoError(t, tl.Lock(jobID, []*target.Target{&targetOne}))
-	allLocked, locked, notLocked := tl.CheckLocks(jobID, []*target.Target{&targetOne, &targetTwo})
-	assert.False(t, allLocked)
-	assert.Equal(t, []*target.Target{&targetOne}, locked)
-	assert.Equal(t, []*target.Target{&targetTwo}, notLocked)
-}
-
-func TestInMemoryCheckLocksMultipleOwners(t *testing.T) {
-	tl := New(time.Second)
-	require.NoError(t, tl.Lock(jobID, []*target.Target{&targetOne}))
-	require.NoError(t, tl.Lock(jobID+1, []*target.Target{&targetTwo}))
-	// owner 1
-	allLocked, locked, notLocked := tl.CheckLocks(jobID, []*target.Target{&targetOne, &targetTwo})
-	assert.False(t, allLocked)
-	assert.Equal(t, []*target.Target{&targetOne}, locked)
-	assert.Equal(t, []*target.Target{&targetTwo}, notLocked)
-	// owner 2
-	allLocked, locked, notLocked = tl.CheckLocks(jobID+1, []*target.Target{&targetOne, &targetTwo})
-	assert.False(t, allLocked)
-	assert.Equal(t, []*target.Target{&targetTwo}, locked)
-	assert.Equal(t, []*target.Target{&targetOne}, notLocked)
 }
 
 func TestInMemoryRefreshLocks(t *testing.T) {

--- a/plugins/targetlocker/noop/noop.go
+++ b/plugins/targetlocker/noop/noop.go
@@ -36,13 +36,6 @@ func (tl Noop) Unlock(_ types.JobID, targets []*target.Target) error {
 	return nil
 }
 
-// CheckLocks tells whether all the targets are locked. They all are, always. It
-// also returns an array of the ones that are locked, and the ones that are not locked.
-func (tl Noop) CheckLocks(jobID types.JobID, targets []*target.Target) (bool, []*target.Target, []*target.Target) {
-	log.Infof("All %d targets are obviously locked, since I did nothing", len(targets))
-	return true, targets, nil
-}
-
 // RefreshLocks refreshes all the locks by the internal (non-existing) timeout,
 // by flawlessly doing nothing.
 func (tl Noop) RefreshLocks(jobID types.JobID, targets []*target.Target) error {

--- a/plugins/targetlocker/noop/noop_test.go
+++ b/plugins/targetlocker/noop/noop_test.go
@@ -53,24 +53,3 @@ func TestNoopUnlock(t *testing.T) {
 		&target.Target{Name: "bleh"},
 	}))
 }
-
-func TestNoopCheckLocks(t *testing.T) {
-	tl := New(time.Second)
-	// we don't enforce that at least one target is passed, as checking on
-	// non-zero targets is the framework's responsibility, not the plugin.
-	// So, zero targets is OK.
-	jobID := types.JobID(123)
-	allAreLocked, locked, notLocked := tl.CheckLocks(jobID, nil)
-	require.True(t, allAreLocked)
-	require.Nil(t, locked)
-	require.Nil(t, notLocked)
-
-	targets := []*target.Target{
-		&target.Target{Name: "t1"},
-		&target.Target{Name: "t2"},
-	}
-	allAreLocked, locked, notLocked = tl.CheckLocks(jobID, targets)
-	require.True(t, allAreLocked)
-	require.Equal(t, locked, targets)
-	require.Nil(t, notLocked, nil)
-}


### PR DESCRIPTION
CheckLocks is no longer needed, and can be misleading. I have removed
this method entirely, and enforced that all targets are locked during
the target acquisition phase.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>