### PR TITLE
[plugins/targetlockers/inmemory] log lock details when already locked

### DIFF
--- a/plugins/targetlocker/inmemory/inmemory.go
+++ b/plugins/targetlocker/inmemory/inmemory.go
@@ -96,7 +96,7 @@ func broker(lockRequests, unlockRequests, checkLocksRequests <-chan *request, do
 							l.expiresAt = time.Now().Add(req.timeout)
 							locks[*t] = l
 						} else {
-							lockErr = fmt.Errorf("lock request: target already locked: %+v", t)
+							lockErr = fmt.Errorf("lock request: target already locked: %+v (lock: %+v)", t, l)
 						}
 						break
 					}


### PR DESCRIPTION
When a target is already locked, the logs and status did not expose
enough information about what is holding the lock. This commit adds such
information.

Tested by running two concurrent jobs.
Server logs:
```
[2020-08-13T11:01:39+02:00] ERROR pkg/jobmanager: run #1: cannot fetch targets for test 'literal test': lock request: target already locked: Target{Name: "example.org", ID: "1234", FQDN: ""} (lock: {owner:68 lockedAt:{wall:13818554647487406031 ext:67386579246 loc:0xc8c420} expiresAt:{wall:13818554711911929595 ext:127386593370 loc:0xc8c420}})
```

Status:
```
$ ./contestcli-http status 69 | jq '.Data.Status.StateErrMsg'
Requesting URL http://localhost:8080/status with requestor ID 'contestcli-http'
  with params:
    requestor: [contestcli-http]
    jobID: [69]

The server responded with status 200 OK"run #1: cannot fetch targets for test 'literal test': lock request: target already locked: Target{Name: \"example.org\", ID: \"1234\", FQDN: \"\"} (lock: {owner:68 lockedAt:{wall:13818554647487406031 ext:67386579246 loc:0xc8c420} expiresAt:{wall:13818554711911929595 ext:127386593370 loc:0xc8c420}})"
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>