### PR TITLE
config: increase lock timeout to be > target manager timeout

### DIFF
--- a/pkg/config/timeouts.go
+++ b/pkg/config/timeouts.go
@@ -42,4 +42,5 @@ var TestRunnerShutdownTimeout = 30 * time.Second
 var TestRunnerStepShutdownTimeout = 5 * time.Second
 
 // LockTimeout represent the amount of time that a lock is held for a target
-var LockTimeout = 1 * time.Minute
+// This should be greater than TargetManagerTimeout to allow for dynamic locking.
+var LockTimeout = TargetManagerTimeout + 1*time.Minute


### PR DESCRIPTION
Defaults should be safe. If a target manager dynamically locks a target,
and then does some more things, it can become unlocked because the timeout
expires.

It is possible to write fancy target managers that know this and
refresh locks, but we should not require it by default.


Signed-off-by: Tobias Fleig <tfleig@fb.com>