### PR TITLE
separate timeouts for Lock() and RefreshLock() in target locker

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -129,7 +129,7 @@ func main() {
 	storage.SetStorage(s)
 
 	// set Locker engine
-	target.SetLocker(inmemory.New(config.LockTimeout))
+	target.SetLocker(inmemory.New(config.LockInitialTimeout, config.LockRefreshTimeout))
 
 	// user-defined function registration
 	for name, fn := range userFunctions {

--- a/pkg/config/timeouts.go
+++ b/pkg/config/timeouts.go
@@ -41,5 +41,11 @@ var TestRunnerShutdownTimeout = 30 * time.Second
 // doesn't reset when a TestStep returns.
 var TestRunnerStepShutdownTimeout = 5 * time.Second
 
-// LockTimeout represent the amount of time that a lock is held for a target
-var LockTimeout = 1 * time.Minute
+// LockRefreshTimeout is the amount of time by which a target lock is extended
+// periodically while a job is running.
+var LockRefreshTimeout = 1 * time.Minute
+
+// LockInitialTimeout is the initial lock duration when acquiring a new lock
+// during target acquisition. This should include TargetManagerTimeout to
+// allow for dynamic locking in the target manager.
+var LockInitialTimeout = TargetManagerTimeout + LockRefreshTimeout

--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -16,7 +16,7 @@ var locker Locker
 
 // LockerFactory is a type representing a function which builds
 // a Locker.
-type LockerFactory func(time.Duration) Locker
+type LockerFactory func(time.Duration, time.Duration) Locker
 
 // Locker defines an interface to lock and unlock targets. It is passed
 // to TargetManager's Acquire and Release methods, and the target manager

--- a/plugins/targetlocker/inmemory/inmemory_test.go
+++ b/plugins/targetlocker/inmemory/inmemory_test.go
@@ -25,75 +25,75 @@ var (
 )
 
 func TestInMemoryNew(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NotNil(t, tl)
 	require.IsType(t, &InMemory{}, tl)
 }
 
 func TestInMemoryLockInvalidJobIDAndNoTargets(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	assert.Error(t, tl.Lock(0, nil))
 }
 
 func TestInMemoryLockValidJobIDAndNoTargets(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	assert.Error(t, tl.Lock(jobID, nil))
 }
 
 func TestInMemoryLockInvalidJobIDAndOneTarget(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	assert.Error(t, tl.Lock(0, oneTarget))
 }
 
 func TestInMemoryLockValidJobIDAndOneTarget(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, oneTarget))
 }
 
 func TestInMemoryLockValidJobIDAndTwoTargets(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 }
 
 func TestInMemoryLockReentrantLock(t *testing.T) {
-	tl := New(10 * time.Second)
+	tl := New(10 * time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 }
 
 func TestInMemoryLockReentrantLockDifferentJobID(t *testing.T) {
-	tl := New(10 * time.Second)
+	tl := New(10 * time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	require.Error(t, tl.Lock(jobID+1, twoTargets))
 }
 
 func TestInMemoryUnlockInvalidJobIDAndNoTargets(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	assert.Error(t, tl.Unlock(jobID, nil))
 }
 
 func TestInMemoryUnlockValidJobIDAndNoTargets(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	assert.Error(t, tl.Unlock(jobID, nil))
 }
 
 func TestInMemoryUnlockInvalidJobIDAndOneTarget(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	assert.Error(t, tl.Unlock(0, oneTarget))
 }
 
 func TestInMemoryUnlockValidJobIDAndOneTarget(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.Error(t, tl.Unlock(jobID, oneTarget))
 }
 
 func TestInMemoryUnlockValidJobIDAndTwoTargets(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.Error(t, tl.Unlock(jobID, twoTargets))
 }
 
 func TestInMemoryUnlockUnlockTwice(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	err := tl.Unlock(jobID, oneTarget)
 	log.Print(err)
 	assert.Error(t, err)
@@ -101,42 +101,42 @@ func TestInMemoryUnlockUnlockTwice(t *testing.T) {
 }
 
 func TestInMemoryUnlockReentrantLockDifferentJobID(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.Error(t, tl.Unlock(jobID, twoTargets))
 	assert.Error(t, tl.Unlock(jobID+1, twoTargets))
 }
 
 func TestInMemoryLockUnlockSameJobID(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	assert.NoError(t, tl.Unlock(jobID, twoTargets))
 }
 
 func TestInMemoryLockUnlockDifferentJobID(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	assert.Error(t, tl.Unlock(jobID+1, twoTargets))
 }
 
 func TestInMemoryRefreshLocks(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.RefreshLocks(jobID, twoTargets))
 }
 
 func TestInMemoryRefreshLocksTwice(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.RefreshLocks(jobID, twoTargets))
 	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
 }
 
 func TestInMemoryRefreshLocksOneThenTwo(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.RefreshLocks(jobID, oneTarget))
 	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
 }
 
 func TestInMemoryRefreshLocksTwoThenOne(t *testing.T) {
-	tl := New(time.Second)
+	tl := New(time.Second, time.Second)
 	require.NoError(t, tl.RefreshLocks(jobID, twoTargets))
 	assert.NoError(t, tl.RefreshLocks(jobID, oneTarget))
 }

--- a/tests/integ/jobmanager/jobmanager_memory_test.go
+++ b/tests/integ/jobmanager/jobmanager_memory_test.go
@@ -32,7 +32,7 @@ func TestJobManagerSuiteMemoryStorage(t *testing.T) {
 	testSuite.storage = storagelayer
 	storage.SetStorage(storagelayer)
 
-	targetLocker := inmemory.New(10 * time.Second)
+	targetLocker := inmemory.New(10 * time.Second, 10 * time.Second)
 	target.SetLocker(targetLocker)
 
 	suite.Run(t, &testSuite)

--- a/tests/integ/jobmanager/jobmanager_rdbms_test.go
+++ b/tests/integ/jobmanager/jobmanager_rdbms_test.go
@@ -35,7 +35,7 @@ func TestJobManagerSuiteRdbmsStorage(t *testing.T) {
 	storage.SetStorage(storageLayer)
 	testSuite.storage = storageLayer
 
-	targetLocker := inmemory.New(10 * time.Second)
+	targetLocker := inmemory.New(10 * time.Second, 10 * time.Second)
 	target.SetLocker(targetLocker)
 
 	suite.Run(t, &testSuite)


### PR DESCRIPTION
This is the newer version of https://github.com/facebookincubator/contest/pull/130

This splits the timeouts for locking an asset initially and
refreshing locks later. The initial increase allows for dynamic target
locking in the target manager.

Later refreshs when the job is running use the shorter timeout.


Signed-off-by: Tobias Fleig <tfleig@fb.com>

Test Plan:
Ran it with the simple json test:
```
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering target manager csvfiletargetmanager
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering target manager targetlist
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test fetcher uri
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test fetcher literal
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step echo
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step slowecho
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step example
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step cmd
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step sshcmd
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step randecho
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering test step terminalexpect
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering reporter targetsuccess
[2020-08-17T13:24:22+01:00]  INFO pkg/pluginregistry: Registering reporter noop
[2020-08-17T13:24:22+01:00]  INFO contest: JobManager &{jobs:map[] jobRunner:0xc00019e7e0 jobsMu:{state:0 sema:0} jobsWg:{noCopy:{} state1:[0 0 0]} jobStorageManager:{} frameworkEvManager:{FrameworkEventEmitter:{} FrameworkEventFetcher:{}} testEvManager:{} apiListener:0x19051a8 apiCancel:0xc00010e6c0 pluginRegistry:0xc000162580 serverIDFunc:<nil>}
[2020-08-17T13:24:22+01:00]  INFO listeners/httplistener: Started HTTP API listener on :8080
[2020-08-17T13:24:27+01:00]  INFO pkg/jobmanager: Handling event &{Type:event_type_start ServerID:laptop Err:<nil> Msg:{requestor:contestcli-http TestID: NumRuns:0 JobDescriptor:{
    "JobName": "test job",
    "Reporting": {
        "FinalReporters": [
            {
                "Name": "noop"
            }
        ],
        "RunReporters": [
            {
                "Name": "TargetSuccess",
                "Parameters": {
                    "SuccessExpression": "\u003e80%"
                }
            },
            {
                "Name": "Noop"
            }
        ]
    },
    "RunInterval": "3s",
    "Runs": 3,
    "Tags": [
        "test",
        "csv"
    ],
    "TestDescriptors": [
        {
            "TargetManagerAcquireParameters": {
                "Targets": [
                    {
                        "ID": "1234",
                        "Name": "example.org"
                    }
                ]
            },
            "TargetManagerName": "TargetList",
            "TargetManagerReleaseParameters": {},
            "TestFetcherFetchParameters": {
                "Steps": [
                    {
                        "label": "some label",
                        "name": "cmd",
                        "parameters": {
                            "args": [
                                "Title={{ Title .Name }}, ToUpper={{ ToUpper .Name }}"
                            ],
                            "executable": [
                                "echo"
                            ]
                        }
                    }
                ],
                "TestName": "Literal test"
            },
            "TestFetcherName": "literal"
        }
    ]
}} RespCh:0xc000132720}
[2020-08-17T13:24:27+01:00]  INFO testfetchers/literal: Returning literal test steps
[2020-08-17T13:24:27+01:00]  INFO pkg/jobmanager: Sending response &{Requestor:contestcli-http JobID:1 Err:<nil> Status:0xc0001592c0}
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Running job 'test job' 3 times
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Run #1: fetching targets for test 'Literal test'
[2020-08-17T13:24:27+01:00]  INFO targetlocker/inmemory: Trying to lock 1 targets
[2020-08-17T13:24:27+01:00]  INFO targetmanagers/targetlist: Acquired 1 targets
[2020-08-17T13:24:27+01:00]  INFO targetlocker/inmemory: Trying to lock 1 targets
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Run #1: running test #0 for job 'test job' (job ID: 1) on 1 targets
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: setting up pipeline jobid=1 phase=run runid=1
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: running pipeline jobid=1 phase=run runid=1
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: waiting for pipeline to complete entity=test_pipeline jobid=1 runid=1
[2020-08-17T13:24:27+01:00]  INFO teststeps/cmd: Running command '/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG'
[2020-08-17T13:24:27+01:00]  INFO teststeps/cmd: Stdout of command '/bin/echo' with args '[/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG]' is 'Title=Example.Org, ToUpper=EXAMPLE.ORG
'
[2020-08-17T13:24:27+01:00]  WARN teststeps/cmd: Stderr of command '/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG' is: ''
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: waiting for all steps to complete entity=test_pipeline jobid=1 phase=waitTargets runid=1
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: completed entity=test_pipeline jobid=1 runid=1
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: test runner completed target: Target{Name: "example.org", ID: "1234", FQDN: ""} jobid=1 phase=run runid=1
[2020-08-17T13:24:27+01:00]  INFO targetmanagers/targetlist: Released 1 targets
[2020-08-17T13:24:27+01:00]  INFO targetlocker/inmemory: Trying to unlock 1 targets
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Unlocked 1 target(s) for job ID 1
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Run #1 of job 1 considered successful according to TargetSuccess
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Run #1 of job 1 considered successful according to noop
[2020-08-17T13:24:27+01:00]  INFO pkg/runner: Sleeping 3s before the next run...
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: Run #2: fetching targets for test 'Literal test'
[2020-08-17T13:24:30+01:00]  INFO targetlocker/inmemory: Trying to lock 1 targets
[2020-08-17T13:24:30+01:00]  INFO targetmanagers/targetlist: Acquired 1 targets
[2020-08-17T13:24:30+01:00]  INFO targetlocker/inmemory: Trying to lock 1 targets
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: Run #2: running test #0 for job 'test job' (job ID: 1) on 1 targets
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: setting up pipeline jobid=1 phase=run runid=2
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: running pipeline jobid=1 phase=run runid=2
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: waiting for pipeline to complete entity=test_pipeline jobid=1 runid=2
[2020-08-17T13:24:30+01:00]  INFO teststeps/cmd: Running command '/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG'
[2020-08-17T13:24:30+01:00]  INFO teststeps/cmd: Stdout of command '/bin/echo' with args '[/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG]' is 'Title=Example.Org, ToUpper=EXAMPLE.ORG
'
[2020-08-17T13:24:30+01:00]  WARN teststeps/cmd: Stderr of command '/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG' is: ''
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: waiting for all steps to complete entity=test_pipeline jobid=1 phase=waitTargets runid=2
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: test runner completed target: Target{Name: "example.org", ID: "1234", FQDN: ""} jobid=1 phase=run runid=2
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: completed entity=test_pipeline jobid=1 runid=2
[2020-08-17T13:24:30+01:00]  INFO targetmanagers/targetlist: Released 1 targets
[2020-08-17T13:24:30+01:00]  INFO targetlocker/inmemory: Trying to unlock 1 targets
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: Unlocked 1 target(s) for job ID 1
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: Run #2 of job 1 considered successful according to TargetSuccess
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: Run #2 of job 1 considered successful according to noop
[2020-08-17T13:24:30+01:00]  INFO pkg/runner: Sleeping 3s before the next run...
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: Run #3: fetching targets for test 'Literal test'
[2020-08-17T13:24:33+01:00]  INFO targetlocker/inmemory: Trying to lock 1 targets
[2020-08-17T13:24:33+01:00]  INFO targetmanagers/targetlist: Acquired 1 targets
[2020-08-17T13:24:33+01:00]  INFO targetlocker/inmemory: Trying to lock 1 targets
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: Run #3: running test #0 for job 'test job' (job ID: 1) on 1 targets
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: setting up pipeline jobid=1 phase=run runid=3
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: running pipeline jobid=1 phase=run runid=3
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: waiting for pipeline to complete entity=test_pipeline jobid=1 runid=3
[2020-08-17T13:24:33+01:00]  INFO teststeps/cmd: Running command '/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG'
[2020-08-17T13:24:33+01:00]  INFO teststeps/cmd: Stdout of command '/bin/echo' with args '[/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG]' is 'Title=Example.Org, ToUpper=EXAMPLE.ORG
'
[2020-08-17T13:24:33+01:00]  WARN teststeps/cmd: Stderr of command '/bin/echo Title=Example.Org, ToUpper=EXAMPLE.ORG' is: ''
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: waiting for all steps to complete entity=test_pipeline jobid=1 phase=waitTargets runid=3
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: completed entity=test_pipeline jobid=1 runid=3
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: test runner completed target: Target{Name: "example.org", ID: "1234", FQDN: ""} jobid=1 phase=run runid=3
[2020-08-17T13:24:33+01:00]  INFO targetmanagers/targetlist: Released 1 targets
[2020-08-17T13:24:33+01:00]  INFO targetlocker/inmemory: Trying to unlock 1 targets
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: Unlocked 1 target(s) for job ID 1
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: Run #3 of job 1 considered successful according to TargetSuccess
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: Run #3 of job 1 considered successful according to noop
[2020-08-17T13:24:33+01:00]  INFO pkg/runner: Job 1 (3 runs out of 3 desired) considered successful
[2020-08-17T13:24:33+01:00]  INFO pkg/jobmanager: Job &{ID:1 Name:test job Tags:[test csv] Done:0xc00010e8a0 CancelCh:0xc00010e900 PauseCh:0xc00010e960 Runs:3 RunInterval:3s TestDescriptors:[[{"Name":"cmd","Label":"some label","Parameters":{"args":["Title={{ Title .Name }}, ToUpper={{ ToUpper .Name }}"],"executable":["echo"]}}]] Tests:[0xc000162a40] RunReporterBundles:[0xc000129dc0 0xc000129de0] FinalReporterBundles:[0xc000129e00]} completed after 6.017380769s
```