### PR TITLE
simple db based target locker

### DIFF
--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -19,24 +19,32 @@ var locker Locker
 type LockerFactory func(time.Duration, time.Duration) Locker
 
 // Locker defines an interface to lock and unlock targets. It is passed
-// to TargetManager's Acquire and Release methods, and the target manager
-// implementation is required to lock all the returned targets.
+// to TargetManager's Acquire and Release methods.
+// TargetManagers are not required to lock targets, but they are allowed to.
+// The framework will lock targets after Acquire returns, but if this fails
+// due to a race, the job fails.
+// Calling any of the functions with an empty list of targets is allowed and
+// will return without error.
 type Locker interface {
-	// Lock locks the specified targets. The timeout must be handled by the
-	// plugin, and configured at construction time by the plugin's
-	// New(time.Duration) function.
+	// Lock locks the specified targets.
+	// The timeout is controlled by the locker plugin and set at construction time.
 	// The job ID is the owner of the lock.
-	// The underlying implementation is responsible for using the job ID as lock
-	// owner, and for unlocking the already-locked ones in case of errors.
+	// This function either succeeds and locks all the requested targets, or
+	// leaves the existing locks untouched in case of conflicts.
+	// Locks are reentrant, locking existing locks (with the same owner)
+	// extends the deadline.
 	Lock(types.JobID, []*Target) error
-	// Unlock unlocks the specified targets, with the specified job ID as owner.
-	// The underlying implementation is responsible of rejecting the operation if
-	// the lock owner is not matching the job ID.
+	// Unlock unlocks the specificied targets if they are held by the given owner.
+	// Unlock silently skips expired locks and targets that are not locked at all.
+	// Unlock does not fail if a valid lock is held on one of the targets.
+	// In these cases, a warning is printed, the foreign lock is left intact and
+	// no error is returned.
 	Unlock(types.JobID, []*Target) error
-	// RefreshLocks extends the lock. The amount of time the lock is extended
-	// should be handled by the plugin, and configured at initialization time.
-	// The request is rejected if the job ID does not match the one of the lock
-	// owner.
+	// RefreshLocks locks or extends existing locks on the given targets.
+	// This function offers the same behavior and guarantees as Lock,
+	// except it uses a different timeout.
+	// Note this means calling RefreshLocks on unlocked targets is allowed and
+	// will (re-)acquire the lock.
 	RefreshLocks(types.JobID, []*Target) error
 }
 

--- a/plugins/targetlocker/dblocker/dblocker.go
+++ b/plugins/targetlocker/dblocker/dblocker.go
@@ -1,0 +1,343 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package dblocker
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/logging"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/types"
+
+	// this blank import registers the mysql driver
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// Name is the plugin name.
+var Name = "DBLocker"
+
+var log = logging.GetLogger("targetlocker/" + strings.ToLower(Name))
+
+// dblock represents parts of lock in the database, basically
+// a row from SELECT target_id, job_ID, expires_at
+type dblock struct {
+	targetID  string
+	jobID     int64
+	expiresAt time.Time
+}
+
+// String pretty-prints dblocks for logging and errors
+func (d dblock) String() string {
+	return fmt.Sprintf("target: %s job: %d expires: %s", d.targetID, d.jobID, d.expiresAt)
+}
+
+// targetIDList is a helper to convert contest targets to
+// a list of primary IDs used in the database
+func targetIDList(targets []*target.Target) []string {
+	res := make([]string, 0, len(targets))
+	for _, target := range targets {
+		res = append(res, target.ID)
+	}
+	return res
+}
+
+// listQueryString is a helper to create a (?, ?, ?) string
+// with as many ? as requested.
+// This can safely be concatenated into SQL queries as it
+// can never contain input data, it only repeates a static
+// string a given number of times.
+func listQueryString(length uint) string {
+	switch length {
+	case 0:
+		return "()"
+	case 1:
+		return "(?)"
+	default:
+		return "(" + strings.Repeat("?, ", int(length)-1) + "?)"
+	}
+}
+
+// DBLocker implements a simple target locker based on a relational database.
+// The current implementation only supports MySQL officially.
+// All functions in DBLocker are safe for concurrent use by multiple goroutines.
+type DBLocker struct {
+	driverName string
+	db         *sql.DB
+	// lockTimeout set on each initial lock request
+	lockTimeout time.Duration
+	// refreshTimeout is used during refresh
+	refreshTimeout time.Duration
+}
+
+// cleanExpired deletes all expired locks on the given targets
+// (lock owner is ignored)
+func (d *DBLocker) cleanExpired(tx *sql.Tx, targets []string, now time.Time) error {
+	q := "DELETE FROM locks WHERE expires_at < ? AND target_id IN " + listQueryString(uint(len(targets))) + ";"
+	// convert targets to a list of interface{}
+	queryList := make([]interface{}, 0, len(targets)+1)
+	queryList = append(queryList, now)
+	for _, targetID := range targets {
+		queryList = append(queryList, targetID)
+	}
+	_, err := tx.Exec(q, queryList...)
+	if err != nil {
+		return fmt.Errorf("unable to clean existing locks: %w", err)
+	}
+	return nil
+}
+
+// queryLocks returns a map of ID -> dblock for a given list of targets
+func (d *DBLocker) queryLocks(tx *sql.Tx, targets []string) (map[string]dblock, error) {
+	q := "SELECT target_id, job_id, expires_at FROM locks WHERE target_id IN " + listQueryString(uint(len(targets))) + ";"
+	// convert targets to a list of interface{}
+	queryList := make([]interface{}, 0, len(targets))
+	for _, targetID := range targets {
+		queryList = append(queryList, targetID)
+	}
+
+	rows, err := tx.Query(q, queryList...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read existing locks: %w", err)
+	}
+	defer rows.Close()
+
+	row := dblock{}
+	locks := make(map[string]dblock)
+	for rows.Next() {
+		if err := rows.Scan(&row.targetID, &row.jobID, &row.expiresAt); err != nil {
+			return nil, fmt.Errorf("unexpected read from database: %w", err)
+		}
+		locks[row.targetID] = row
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("unexpected error iterating db read results: %w", err)
+	}
+	return locks, nil
+}
+
+// handleLock does the real locking, it assumes the jobID is valid
+func (d *DBLocker) handleLock(jobID int64, targets []string, timeout time.Duration) error {
+	// everything operates on this frozen time
+	now := time.Now()
+	expires := now.Add(timeout)
+	// locking is all or nothing in one transaction
+	// phantom reads might mess with the expired lock cleaning assumptions below,
+	// so request serializable isolation
+	tx, err := d.db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("unable to start database transaction: %w", err)
+	}
+	defer func() {
+		// this always fails if tx.Commit() was called before, ignore error
+		_ = tx.Rollback()
+	}()
+
+	// clean expired locks first, this simplifies the logic later
+	if err := d.cleanExpired(tx, targets, now); err != nil {
+		return err
+	}
+
+	locks, err := d.queryLocks(tx, targets)
+	if err != nil {
+		return err
+	}
+	// go through existing locks, they are either held by something else (abort)
+	// held by us (update time), or not held (insert)
+	inserts := make([]string, 0)
+	updates := make([]string, 0)
+	conflicts := make([]dblock, 0)
+	for _, t := range targets {
+		lock, ok := locks[t]
+		switch {
+		case !ok:
+			inserts = append(inserts, t)
+		case lock.jobID == jobID:
+			updates = append(updates, t)
+		default:
+			conflicts = append(conflicts, lock)
+		}
+	}
+	if len(conflicts) > 0 {
+		return fmt.Errorf("unable to lock targets %v for owner %d, have conflicting locks: %v", targets, jobID, conflicts)
+	}
+
+	ins := "INSERT INTO locks (target_id, job_id, created_at, expires_at) VALUES (?, ?, ?, ?);"
+	for _, id := range inserts {
+		if _, err := tx.Exec(ins, id, jobID, now, expires); err != nil {
+			return fmt.Errorf("unable to lock target %s: %w", id, err)
+		}
+	}
+
+	upd := "UPDATE locks SET expires_at = ? WHERE target_id = ? AND job_id = ?;"
+	for _, id := range updates {
+		if _, err := tx.Exec(upd, expires, id, jobID); err != nil {
+			return fmt.Errorf("unable to refresh lock on target %s: %w", id, err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// handleUnlock does the real unlocking, it assumes the jobID is valid
+func (d *DBLocker) handleUnlock(jobID int64, targets []string) error {
+	// unlocking is all or nothing in one transaction
+	// phantom reads might mess with the expired lock cleaning assumptions below,
+	// so request serializable isolation
+	tx, err := d.db.BeginTx(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return fmt.Errorf("unable to start database transaction: %w", err)
+	}
+	defer func() {
+		// this always fails if tx.Commit() was called before, ignore error
+		_ = tx.Rollback()
+	}()
+
+	// clean expired locks first, this simplifies the logic later
+	if err := d.cleanExpired(tx, targets, time.Now()); err != nil {
+		return err
+	}
+
+	locks, err := d.queryLocks(tx, targets)
+	if err != nil {
+		return err
+	}
+
+	// detect conflicts (unlock on foreign locks) and warn about them,
+	// but don't abort.
+	conflicts := make([]dblock, 0)
+	for _, lock := range locks {
+		if lock.jobID != jobID {
+			conflicts = append(conflicts, lock)
+		}
+	}
+	if len(conflicts) > 0 {
+		log.Warningf("unable to unlock targets %v for owner %d due to different lock owners: %+v", targets, jobID, conflicts)
+	}
+
+	// only remove locks held by the owner
+	del := "DELETE FROM locks WHERE job_id = ? AND target_id IN " + listQueryString(uint(len(targets))) + ";"
+	queryList := make([]interface{}, 0, len(targets)+1)
+	queryList = append(queryList, jobID)
+	for _, targetID := range targets {
+		queryList = append(queryList, targetID)
+	}
+	_, err = tx.Exec(del, queryList...)
+	if err != nil {
+		return fmt.Errorf("unable to unlock targets %v, owner %d: %w", targets, jobID, err)
+	}
+
+	return tx.Commit()
+}
+
+func validateTargets(targets []*target.Target) error {
+	for _, target := range targets {
+		if target.ID == "" {
+			return fmt.Errorf("target list cannot contain empty target ID. Full list: %v", targets)
+		}
+	}
+	return nil
+}
+
+// Lock locks the given targets.
+// See target.Locker for API details
+func (d *DBLocker) Lock(jobID types.JobID, targets []*target.Target) error {
+	if jobID == 0 {
+		return fmt.Errorf("invalid lock request, jobID cannot be zero (targets: %v)", targets)
+	}
+	if err := validateTargets(targets); err != nil {
+		return fmt.Errorf("invalid lock request: %w", err)
+	}
+	log.Debugf("Requested to lock %d targets for job ID %d: %v", len(targets), jobID, targets)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	return d.handleLock(int64(jobID), targetIDList(targets), d.lockTimeout)
+}
+
+// Unlock unlocks the given targets.
+// See target.Locker for API details
+func (d *DBLocker) Unlock(jobID types.JobID, targets []*target.Target) error {
+	if jobID == 0 {
+		return fmt.Errorf("invalid unlock request, jobID cannot be zero (targets: %v)", targets)
+	}
+	if err := validateTargets(targets); err != nil {
+		return fmt.Errorf("invalid unlock request: %w", err)
+	}
+	log.Debugf("Requested to unlock %d targets for job ID %d: %v", len(targets), jobID, targets)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	return d.handleUnlock(int64(jobID), targetIDList(targets))
+}
+
+// RefreshLocks refreshes (or locks!) the given targets.
+// See target.Locker for API details
+func (d *DBLocker) RefreshLocks(jobID types.JobID, targets []*target.Target) error {
+	if jobID == 0 {
+		return fmt.Errorf("invalid refresh request, jobID cannot be zero (targets: %v)", targets)
+	}
+	if err := validateTargets(targets); err != nil {
+		return fmt.Errorf("invalid refresh request: %w", err)
+	}
+	log.Debugf("Requested to refresh %d targets for job ID %d: %v", len(targets), jobID, targets)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	return d.handleLock(int64(jobID), targetIDList(targets), d.refreshTimeout)
+}
+
+// ResetAllLocks resets the database and clears all locks, regardless of who owns them.
+// This is primarily for testing, and should not be used by used in prod, this
+// is why it is not exposed by target.Locker
+func (d *DBLocker) ResetAllLocks() error {
+	log.Warning("DELETING ALL LOCKS")
+	_, err := d.db.Exec("TRUNCATE TABLE locks;")
+	return err
+}
+
+// Opt is a function type that sets parameters on the DBLocker object
+type Opt func(dblocker *DBLocker)
+
+// DriverName allows using a mysql-compatible driver (e.g. a wrapper around mysql
+// or a syntax-compatible variant).
+func DriverName(name string) Opt {
+	return func(rdbms *DBLocker) {
+		rdbms.driverName = name
+	}
+}
+
+// New initializes and returns a new DBLocker target locker.
+func New(dbURI string, lockTimeout, refreshTimeout time.Duration, opts ...Opt) (target.Locker, error) {
+	res := &DBLocker{
+		lockTimeout:    lockTimeout,
+		refreshTimeout: refreshTimeout,
+	}
+
+	for _, Opt := range opts {
+		Opt(res)
+	}
+
+	driverName := "mysql"
+	if res.driverName != "" {
+		driverName = res.driverName
+	}
+	db, err := sql.Open(driverName, dbURI)
+	if err != nil {
+		return nil, fmt.Errorf("could not initialize database: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("unable to contact database: %w", err)
+	}
+	res.db = db
+	return res, nil
+}

--- a/tests/plugins/targetlocker/dblocker/dblocker_test.go
+++ b/tests/plugins/targetlocker/dblocker/dblocker_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// +build integration_storage
+
+package dblocker
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/logging"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/plugins/targetlocker/dblocker"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	jobID = types.JobID(123)
+
+	targetOne  = target.Target{Name: "target001", ID: "001"}
+	targetTwo  = target.Target{Name: "target002", ID: "002"}
+	oneTarget  = []*target.Target{&targetOne}
+	twoTargets = []*target.Target{&targetOne, &targetTwo}
+
+	tl *dblocker.DBLocker
+)
+
+func TestMain(m *testing.M) {
+	// tests reset the database, which makes the locker yell all the time,
+	// disable for the integration tests
+	logging.GetLogger("tests/integ")
+	logging.Disable()
+
+	dbURI := "contest:contest@tcp(mysql:3306)/contest_integ?parseTime=true"
+	locker, err := dblocker.New(dbURI, 2*time.Second, 2*time.Second)
+	if err != nil {
+		panic(err)
+	}
+	tl = locker.(*dblocker.DBLocker)
+	os.Exit(m.Run())
+}
+
+func TestNew(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NotNil(t, tl)
+	assert.IsType(t, &dblocker.DBLocker{}, tl)
+}
+
+func TestLockInvalidJobIDAndNoTargets(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.Error(t, tl.Lock(0, nil))
+}
+
+func TestLockValidJobIDAndNoTargets(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, nil))
+}
+
+func TestLockValidJobIDAndNoTargets2(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, []*target.Target{}))
+}
+
+func TestLockInvalidJobIDAndOneTarget(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.Error(t, tl.Lock(0, oneTarget))
+}
+
+func TestLockValidJobIDAndEmptyIDTarget(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.Error(t, tl.Lock(jobID, []*target.Target{&target.Target{Name: "test", ID: ""}}))
+}
+
+func TestLockValidJobIDAndOneTarget(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, oneTarget))
+}
+
+func TestLockValidJobIDAndTwoTargets(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+}
+
+func TestLockReentrantLock(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+	assert.NoError(t, tl.Lock(jobID, oneTarget))
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+}
+
+func TestLockReentrantLockDifferentJobID(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+	assert.Error(t, tl.Lock(jobID+1, twoTargets))
+	assert.Error(t, tl.Lock(jobID+1, oneTarget))
+}
+
+func TestUnlockInvalidJobIDAndNoTargets(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Unlock(jobID, nil))
+}
+
+func TestUnlockValidJobIDAndNoTargets(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Unlock(jobID, nil))
+}
+
+func TestUnlockInvalidJobIDAndOneTarget(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.Error(t, tl.Unlock(0, oneTarget))
+}
+
+func TestUnlockValidJobIDAndOneTarget(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Unlock(jobID, oneTarget))
+}
+
+func TestUnlockValidJobIDAndTwoTargets(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Unlock(jobID, twoTargets))
+}
+
+func TestLockUnlockSameJobID(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+	assert.NoError(t, tl.Unlock(jobID, twoTargets))
+}
+
+func TestLockUnlockDifferentJobID(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+	// this does not error, but will also not release the lock...
+	assert.NoError(t, tl.Unlock(jobID+1, twoTargets))
+	// ... so it cannot be acquired by job+1
+	assert.Error(t, tl.Lock(jobID+1, twoTargets))
+}
+
+func TestRefreshLocks(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+}
+
+func TestRefreshLocksTwice(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+}
+
+func TestRefreshLocksOneThenTwo(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.RefreshLocks(jobID, oneTarget))
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+}
+
+func TestRefreshLocksTwoThenOne(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+	assert.NoError(t, tl.RefreshLocks(jobID, oneTarget))
+}
+
+func TestLockExpiry(t *testing.T) {
+	tl.ResetAllLocks()
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+	// getting them immediately fails for other owner
+	assert.Error(t, tl.Lock(jobID+1, twoTargets))
+	time.Sleep(3 * time.Second)
+	// expired, now it should work
+	assert.NoError(t, tl.Lock(jobID+1, twoTargets))
+}
+
+func TestRefreshMultiple(t *testing.T) {
+	// not super happy with this test, it is timing sensitive
+	tl.ResetAllLocks()
+	// now for the actual test
+	assert.NoError(t, tl.Lock(jobID, twoTargets))
+	time.Sleep(1500 * time.Millisecond)
+	// they are not expired yet, extend both
+	assert.NoError(t, tl.RefreshLocks(jobID, twoTargets))
+	time.Sleep(1 * time.Second)
+	// if they were refreshed properly, they are still valid and attempts to get them must fail
+	assert.Error(t, tl.Lock(jobID+1, []*target.Target{&targetOne}))
+	assert.Error(t, tl.Lock(jobID+1, []*target.Target{&targetTwo}))
+}
+
+func TestLockingTransactional(t *testing.T) {
+	tl.ResetAllLocks()
+	// lock the second target
+	assert.NoError(t, tl.Lock(jobID, []*target.Target{&targetTwo}))
+	// try to lock both with another owner (this fails as expected)
+	assert.Error(t, tl.Lock(jobID+1, twoTargets))
+	// API says target one should remain unlocked because Lock() is transactional
+	// this means it can be locked by the first owner
+	assert.NoError(t, tl.Lock(jobID, []*target.Target{&targetOne}))
+}


### PR DESCRIPTION
Summary of changes:
 - Add a minimal rdbms-based target locker implementation
 - Clarify target.Locker API docs


This adds a minimal target locker that uses a relational database as backend.

Using this locker allows sharing locks between multiple instances of Contest Server and makes locks survive server restarts.

The unit/integration test suite for this new locker is an extended version of the inmemory test suite, some tests changed to confirm with the clarified locker API and some tests added to prevent bugs like #134.

This implementation only uses target.ID as primary and only identifier for targets, we have a refactor pending to make it more clear how targets are specified and what is required to identify them.