### PR TITLE
For each target tests

### DIFF
--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -18,7 +18,7 @@ var log = logging.GetLogger("plugins/teststeps")
 // ForEachTarget function below.
 type PerTargetFunc func(cancel, pause <-chan struct{}, target *target.Target) error
 
-// ForEachTarget is a facility provided to simplify plugin implemtations. This
+// ForEachTarget is a facility provided to simplify plugin implementations. This
 // function wraps the logic that handles target routing through the in/out/err
 // test step channels, and also handles cancellation and pausing.
 // The user of this function has to pass the cancel, pause, and test step
@@ -27,49 +27,46 @@ type PerTargetFunc func(cancel, pause <-chan struct{}, target *target.Target) er
 // each target. The implementation of the per-target function is responsible for
 // handling internal cancellation and pausing.
 func ForEachTarget(pluginName string, cancel, pause <-chan struct{}, ch test.TestStepChannels, f PerTargetFunc) error {
+	type tgtErr struct {
+		target *target.Target
+		err error
+	}
+	tgtErrCh := make(chan tgtErr)
 	for {
 		select {
-		case target := <-ch.In:
-			if target == nil {
+		case tgt := <-ch.In:
+			if tgt == nil {
 				// no more targets incoming
 				return nil
 			}
-			log.Debugf("%s: ForEachTarget: received target %s", pluginName, target)
-			errCh := make(chan error)
+			log.Debugf("%s: ForEachTarget: received target %s", pluginName, tgt)
 			go func() {
-				log.Debugf("%s: ForEachTarget: calling function on target %s", pluginName, target)
-				errCh <- f(cancel, pause, target)
+				log.Debugf("%s: ForEachTarget: calling function on target %s", pluginName, tgt)
+				tgtErrCh <- tgtErr{target: tgt, err: f(cancel, pause, tgt)}
 			}()
-
-			select {
-			case err := <-errCh:
-				if err != nil {
-					select {
-					case ch.Err <- cerrors.TargetError{Target: target, Err: err}:
-						log.Errorf("%s: ForEachTarget: failed to apply test step function on target %s: %v", pluginName, target, err)
-					case <-cancel:
-						log.Debugf("%s: ForEachTarget: received cancellation signal", pluginName)
-						return nil
-					case <-pause:
-						log.Debugf("%s: ForEachTarget: received pausing signal", pluginName)
-						return nil
-					}
-				} else {
-					select {
-					case ch.Out <- target:
-						log.Debugf("%s: ForEachTarget: target %s completed successfully", pluginName, target)
-					case <-cancel:
-						log.Debugf("%s: ForEachTarget: received cancellation signal", pluginName)
-						return nil
-					case <-pause:
-						log.Debugf("%s: ForEachTarget: received pausing signal", pluginName)
-						return nil
-					}
+		case te := <-tgtErrCh:
+			if te.err != nil {
+				select {
+				case ch.Err <- cerrors.TargetError{Target: te.target, Err: te.err}:
+					log.Errorf("%s: ForEachTarget: failed to apply test step function on target %s: %v", pluginName, te.target, te.err)
+				case <-cancel:
+					log.Debugf("%s: ForEachTarget: received cancellation signal", pluginName)
+					return nil
+				case <-pause:
+					log.Debugf("%s: ForEachTarget: received pausing signal", pluginName)
+					return nil
 				}
-			case <-cancel:
-				return nil
-			case <-pause:
-				return nil
+			} else {
+				select {
+				case ch.Out <- te.target:
+					log.Debugf("%s: ForEachTarget: target %s completed successfully", pluginName, te.target)
+				case <-cancel:
+					log.Debugf("%s: ForEachTarget: received cancellation signal", pluginName)
+					return nil
+				case <-pause:
+					log.Debugf("%s: ForEachTarget: received pausing signal", pluginName)
+					return nil
+				}
 			}
 		case <-cancel:
 			return nil

--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -37,7 +37,7 @@ func ForEachTarget(pluginName string, cancel, pause <-chan struct{}, ch test.Tes
 	tgtInFlight := int32(0)
 	noMoreTargetsCh := make(chan struct{})
 
-	go func() {
+	go func(tgtInFlight *int32) {
 		defer func() {
 			log.Debugf("%s: ForEachTarget: exiting incoming loop, targets inflight %d", pluginName, tgtInFlight)
 		}()
@@ -54,9 +54,9 @@ func ForEachTarget(pluginName string, cancel, pause <-chan struct{}, ch test.Tes
 			go func() {
 				tgtErrCh <- tgtErr{target: tgt, err: f(cancel, pause, tgt)}
 			}()
-			atomic.AddInt32(&tgtInFlight, 1)
+			atomic.AddInt32(tgtInFlight, 1)
 		}
-	}()
+	}(&tgtInFlight)
 
 	noMoreTargets := false
 	defer func() {

--- a/plugins/teststeps/teststeps_test.go
+++ b/plugins/teststeps/teststeps_test.go
@@ -1,0 +1,254 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package teststeps
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/cerrors"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+type data struct {
+	done          chan struct{}
+	cancel, pause chan struct{}
+	inCh, outCh   chan *target.Target
+	errCh         chan cerrors.TargetError
+	stepChans     test.TestStepChannels
+}
+
+func newData() data {
+	inCh := make(chan *target.Target)
+	outCh := make(chan *target.Target)
+	errCh := make(chan cerrors.TargetError)
+	return data{
+		done:  make(chan struct{}, 1),
+		cancel: make(chan struct{}),
+		pause: make(chan struct{}),
+		inCh:  inCh,
+		outCh: outCh,
+		errCh: errCh,
+		stepChans: test.TestStepChannels{
+			In:  inCh,
+			Out: outCh,
+			Err: errCh,
+		},
+	}
+}
+
+func TestForEachTargetOneTarget(t *testing.T) {
+	d := newData()
+	fn := func(cancel, pause <-chan struct{}, tgt *target.Target) error {
+		log.Printf("Handling target %+v", tgt)
+		return nil
+	}
+	go func() {
+		d.inCh <- &target.Target{Name: "target001"}
+		// signal end of input
+		d.inCh <- nil
+	}()
+	go func() {
+		for {
+			select {
+			case <-d.done:
+				break
+			case tgt := <-d.outCh:
+				log.Printf("Step for target %+v completed as expected", tgt)
+			case err := <-d.errCh:
+				t.Errorf("Expected no error but got one: %v", err)
+			}
+		}
+	}()
+	err := ForEachTarget("test_one_target ", d.cancel, d.pause, d.stepChans, fn)
+	d.done <- struct{}{}
+	require.NoError(t, err)
+}
+
+func TestForEachTargetOneTargetAllFail(t *testing.T) {
+	d := newData()
+	fn := func(cancel, pause <-chan struct{}, t *target.Target) error {
+		log.Printf("Handling target %+v", t)
+		return fmt.Errorf("error with target %+v", t)
+	}
+	go func() {
+		d.inCh <- &target.Target{Name: "target001"}
+		// signal end of input
+		d.inCh <- nil
+	}()
+	go func() {
+		for {
+			select {
+			case <-d.done:
+				break
+			case tgt := <-d.outCh:
+				t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
+			case err := <-d.errCh:
+				log.Printf("Step for target failed as expected: %v", err)
+			}
+		}
+	}()
+	err := ForEachTarget("test_one_target ", d.cancel, d.pause, d.stepChans, fn)
+	d.done <- struct{}{}
+	require.NoError(t, err)
+}
+
+func TestForEachTargetTenTargets(t *testing.T) {
+	d := newData()
+	fn := func(cancel, pause <-chan struct{}, tgt *target.Target) error {
+		log.Printf("Handling target %+v", tgt)
+		return nil
+	}
+	go func() {
+		for i := 0; i < 10; i++ {
+			d.inCh <- &target.Target{Name: fmt.Sprintf("target%00d", i)}
+		}
+		// signal end of input
+		d.inCh <- nil
+	}()
+	go func() {
+		for {
+			select {
+			case <-d.done:
+				break
+			case tgt := <-d.outCh:
+				log.Printf("Step for target %+v completed as expected", tgt)
+			case err := <-d.errCh:
+				t.Errorf("Expected no error but got one: %v", err)
+			}
+		}
+	}()
+	err := ForEachTarget("test_one_target ", d.cancel, d.pause, d.stepChans, fn)
+	d.done <- struct{}{}
+	require.NoError(t, err)
+}
+
+func TestForEachTargetTenTargetsAllFail(t *testing.T) {
+	d := newData()
+	fn := func(cancel, pause <-chan struct{}, tgt *target.Target) error {
+		log.Printf("Handling target %+v", tgt)
+		return fmt.Errorf("error with target %+v", tgt)
+	}
+	go func() {
+		for i := 0; i < 10; i++ {
+			d.inCh <- &target.Target{Name: fmt.Sprintf("target%00d", i)}
+		}
+		// signal end of input
+		d.inCh <- nil
+	}()
+	go func() {
+		for {
+			select {
+			case <-d.done:
+				break
+			case tgt := <-d.outCh:
+				t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
+			case err := <-d.errCh:
+				log.Printf("Step for target failed as expected: %v", err)
+			}
+		}
+	}()
+	err := ForEachTarget("test_one_target ", d.cancel, d.pause, d.stepChans, fn)
+	d.done <- struct{}{}
+	require.NoError(t, err)
+}
+
+func TestForEachTargetTenTargetsOneFails(t *testing.T) {
+	d := newData()
+	// chosen by fair dice roll.
+	// guaranteed to be random.
+	failingTarget := "target004"
+	fn := func(cancel, pause <-chan struct{}, tgt *target.Target) error {
+		log.Printf("Handling target %+v", tgt)
+		if tgt.Name == failingTarget {
+			return fmt.Errorf("error with target %+v", tgt)
+		}
+		return nil
+	}
+	go func() {
+		for i := 0; i < 10; i++ {
+			d.inCh <- &target.Target{Name: fmt.Sprintf("target%03d", i)}
+		}
+		// signal end of input
+		d.inCh <- nil
+	}()
+	go func() {
+		for {
+			select {
+			case <-d.done:
+				break
+			case tgt := <-d.outCh:
+				if tgt.Name == failingTarget {
+					t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
+				} else {
+					log.Printf("Step for target %+v completed as expected", tgt)
+				}
+			case err := <-d.errCh:
+				if err.Target.Name == failingTarget {
+					log.Printf("Step for target failed as expected: %v", err)
+				} else {
+					t.Errorf("Expected no error but got one: %v", err)
+				}
+			}
+		}
+	}()
+	err := ForEachTarget("test_one_target ", d.cancel, d.pause, d.stepChans, fn)
+	d.done <- struct{}{}
+	require.NoError(t, err)
+}
+
+// TestForEachTargetTenTargetsParallelism checks if we didn't break the parallelism of
+// ForEachTarget. It passes 10 targets and a function that takes 1 second for each
+// target, so the whole process should not take more than ~1s if properly parallelized.
+// I am using a deadline of 3s to give it some margin, knowing that if it is sequential
+// it will take ~10s.
+func TestForEachTargetTenTargetsParallelism(t *testing.T) {
+	sleepTime := time.Second
+	d := newData()
+	fn := func(cancel, pause <-chan struct{}, tgt *target.Target) error {
+		time.Sleep(sleepTime)
+		log.Printf("Handling target %+v", tgt)
+		return nil
+	}
+	numTargets := 10
+	go func() {
+		for i := 0; i < numTargets; i++ {
+			d.inCh <- &target.Target{Name: fmt.Sprintf("target%03d", i)}
+		}
+		// signal end of input
+		d.inCh <- nil
+	}()
+	deadlineExceeded := false
+	go func() {
+		maxWaitTime := sleepTime * 3
+		deadline := time.Now().Add(maxWaitTime)
+		log.Printf("Setting deadline to now+%s", maxWaitTime)
+		for {
+			select {
+			case <-d.done:
+				break
+			case tgt := <-d.outCh:
+				t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
+			case err := <-d.errCh:
+				log.Printf("Step for target failed as expected: %v", err)
+			case <-time.After(time.Until(deadline)):
+				deadlineExceeded = true
+				log.Printf("Deadline exceeded")
+				d.cancel <- struct{}{}
+				return
+			}
+		}
+	}()
+	err := ForEachTarget("test_one_target ", d.cancel, d.pause, d.stepChans, fn)
+	d.done <- struct{}{}
+	if deadlineExceeded {
+		t.Fatal("wait deadline exceeded, it's possible that parallelization is not working anymore")
+	}
+	require.NoError(t, err)
+}

--- a/plugins/teststeps/teststeps_test.go
+++ b/plugins/teststeps/teststeps_test.go
@@ -62,7 +62,7 @@ func TestForEachTargetOneTarget(t *testing.T) {
 		for {
 			select {
 			case <-d.done:
-				break
+				return
 			case tgt := <-d.outCh:
 				log.Printf("Step for target %+v completed as expected", tgt)
 			case err := <-d.errCh:
@@ -90,7 +90,7 @@ func TestForEachTargetOneTargetAllFail(t *testing.T) {
 		for {
 			select {
 			case <-d.done:
-				break
+				return
 			case tgt := <-d.outCh:
 				t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
 			case err := <-d.errCh:
@@ -120,7 +120,7 @@ func TestForEachTargetTenTargets(t *testing.T) {
 		for {
 			select {
 			case <-d.done:
-				break
+				return
 			case tgt := <-d.outCh:
 				log.Printf("Step for target %+v completed as expected", tgt)
 			case err := <-d.errCh:
@@ -151,7 +151,7 @@ func TestForEachTargetTenTargetsAllFail(t *testing.T) {
 		for {
 			select {
 			case <-d.done:
-				break
+				return
 			case tgt := <-d.outCh:
 				t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
 			case err := <-d.errCh:
@@ -187,7 +187,7 @@ func TestForEachTargetTenTargetsOneFails(t *testing.T) {
 		for {
 			select {
 			case <-d.done:
-				break
+				return
 			case tgt := <-d.outCh:
 				if tgt.Name == failingTarget {
 					t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
@@ -337,7 +337,7 @@ func TestForEachTargetCancelBeforeInputChannelClosed(t *testing.T) {
 		log.Printf("Handling target %+v", tgt)
 		select {
 		case <-cancel:
-			log.Printf("target %+v caneled", tgt)
+			log.Printf("target %+v cancelled", tgt)
 			atomic.AddInt32(&canceledTargets, 1)
 		case <-pause:
 			log.Printf("target %+v paused", tgt)


### PR DESCRIPTION
This is a rework of https://github.com/facebookincubator/contest/pull/139 by @insomniacslk. Current implementation of ForEachTarget helper handles incoming targets sequentially, but the task runner expects them to be handled in parallel and has a timeout for each target to be consumed (30 sec). This PR makes  ForEachTarget handle targets in parallel, as it should be by design.