### PR TITLE
Fix race condition in job status emission

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ global:
 env:
   global:
     - COMPOSE_VERSION=1.25.4
+    - GO111MODULE=on
   jobs:
     - TEST_SUITE=tests
     - TEST_SUITE=linters


### PR DESCRIPTION
Before this patch there is a race condition where the job status event
is emitted before a report is saved. A client waiting on the status
might get zero job reports if the job status is fetched before the
report is saved to the database. This is a behaviour we have seen
internally.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>