### PR TITLE
Bugfix for amount of runs

### DIFF
--- a/pkg/event/frameworkevent/framework.go
+++ b/pkg/event/frameworkevent/framework.go
@@ -74,7 +74,7 @@ func (value queryFieldEventNames) queryFieldPointer(query *Query) interface{} {
 	return &query.EventNames
 }
 
-// QueryEventName sets a single EventName field in the Query objec
+// QueryEventName sets a single EventName field in the Query object
 func QueryEventName(eventName event.Name) QueryField { return queryFieldEventNames{eventName} }
 
 // QueryEmittedStartTime sets the EmittedStartTime field of the Query object

--- a/pkg/runner/job_status_test.go
+++ b/pkg/runner/job_status_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/stretchr/testify/require"
+)
+
+type dummyFrameworkEventManager struct {
+	t *testing.T
+}
+
+func (fem dummyFrameworkEventManager) Emit(event frameworkevent.Event) error {
+	return nil
+}
+func (fem dummyFrameworkEventManager) Fetch(fields ...frameworkevent.QueryField) ([]frameworkevent.Event, error) {
+	require.Len(fem.t, fields, 1)
+	require.Equal(fem.t, frameworkevent.QueryEventName(EventRunStarted), fields[0])
+	return []frameworkevent.Event{
+		{
+			JobID:     1,
+			EventName: EventRunStarted,
+			Payload:   &[]json.RawMessage{json.RawMessage(`{"RunID":2}`)}[0],
+			EmitTime:  time.Unix(2, 0),
+		},
+		{
+			JobID:     1,
+			EventName: EventRunStarted,
+			Payload:   &[]json.RawMessage{json.RawMessage(`{"RunID":1}`)}[0],
+			EmitTime:  time.Unix(1, 0),
+		},
+	}, nil
+}
+
+func TestBuildRunStatuses(t *testing.T) {
+	jr := &JobRunner{
+		targetMap:             nil,
+		targetLock:            nil,
+		frameworkEventManager: dummyFrameworkEventManager{t: t},
+		testEvManager:         nil,
+	}
+	runStatuses, err := jr.BuildRunStatuses(&job.Job{
+		ID:   1,
+		Runs: 3,
+	})
+	require.NoError(t, err)
+	require.Len(t, runStatuses, 2)
+}

--- a/plugins/targetlocker/inmemory/inmemory_test.go
+++ b/plugins/targetlocker/inmemory/inmemory_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	jobID = types.JobID(123)
+	jobID      = types.JobID(123)
 	otherJobID = types.JobID(456)
 
 	targetOne  = target.Target{Name: "target001", ID: "001"}
@@ -57,13 +57,13 @@ func TestInMemoryLockValidJobIDAndTwoTargets(t *testing.T) {
 }
 
 func TestInMemoryLockReentrantLock(t *testing.T) {
-	tl := New(10 * time.Second, time.Second)
+	tl := New(10*time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 }
 
 func TestInMemoryLockReentrantLockDifferentJobID(t *testing.T) {
-	tl := New(10 * time.Second, time.Second)
+	tl := New(10*time.Second, time.Second)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	require.Error(t, tl.Lock(jobID+1, twoTargets))
 }
@@ -143,7 +143,7 @@ func TestInMemoryRefreshLocksTwoThenOne(t *testing.T) {
 }
 
 func TestRefreshMultiple(t *testing.T) {
-	tl := New(200 * time.Millisecond, 200 * time.Millisecond)
+	tl := New(200*time.Millisecond, 200*time.Millisecond)
 	require.NoError(t, tl.Lock(jobID, twoTargets))
 	time.Sleep(100 * time.Millisecond)
 	// they are not expired yet, extend both

--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -46,7 +46,7 @@ var Events = []event.Name{
 type eventCmdStartPayload struct {
 	Path string
 	Args []string
-	Dir string
+	Dir  string
 }
 
 // Cmd is used to run arbitrary commands as test steps.
@@ -82,7 +82,7 @@ func (ts *Cmd) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, para
 		cmd.Dir = ts.dir
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout, cmd.Stderr = &stdout, &stderr
-		if ts.dir!="" {
+		if ts.dir != "" {
 			log.Printf("Running command '%+v' in directory '%+v'", cmd, cmd.Dir)
 		} else {
 			log.Printf("Running command '%+v'", cmd)
@@ -91,7 +91,7 @@ func (ts *Cmd) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, para
 		errCh := make(chan error)
 		go func() {
 			// Emit EventCmdStart
-			payload, err := json.Marshal(eventCmdStartPayload{Path: cmd.Path, Args: cmd.Args,  Dir: cmd.Dir})
+			payload, err := json.Marshal(eventCmdStartPayload{Path: cmd.Path, Args: cmd.Args, Dir: cmd.Dir})
 			if err != nil {
 				log.Warningf("Cannot encode payload for EventCmdStart: %v", err)
 			} else {


### PR DESCRIPTION
If the run start events are returns in a non-straight order then the algorithm was returning wrong amount of returns which was affecting the final reports.