### PR TITLE
fix(runner): Fetch only the run-start events related to the job

### DIFF
--- a/pkg/runner/job_status.go
+++ b/pkg/runner/job_status.go
@@ -211,7 +211,7 @@ func (jr *JobRunner) BuildRunStatus(coordinates job.RunCoordinates, currentJob *
 func (jr *JobRunner) BuildRunStatuses(currentJob *job.Job) ([]job.RunStatus, error) {
 
 	// Calculate the status only for the runs which effectively were executed
-	runStartEvents, err := jr.frameworkEventManager.Fetch(frameworkevent.QueryEventName(EventRunStarted))
+	runStartEvents, err := jr.frameworkEventManager.Fetch(frameworkevent.QueryEventName(EventRunStarted), frameworkevent.QueryJobID(currentJob.ID))
 	if err != nil {
 		return nil, fmt.Errorf("could not determine how many runs were executed: %v", err)
 	}

--- a/pkg/runner/job_status_test.go
+++ b/pkg/runner/job_status_test.go
@@ -23,8 +23,9 @@ func (fem dummyFrameworkEventManager) Emit(event frameworkevent.Event) error {
 	return nil
 }
 func (fem dummyFrameworkEventManager) Fetch(fields ...frameworkevent.QueryField) ([]frameworkevent.Event, error) {
-	require.Len(fem.t, fields, 1)
+	require.Len(fem.t, fields, 2)
 	require.Equal(fem.t, frameworkevent.QueryEventName(EventRunStarted), fields[0])
+	require.Equal(fem.t, frameworkevent.QueryJobID(1), fields[1])
 	return []frameworkevent.Event{
 		{
 			JobID:     1,


### PR DESCRIPTION
Currently the algorithm downloads all the run-start events instead of related to the job. Fixing it.