### PR TITLE
[RFC] Schema migration tool

### DIFF
--- a/db/rdbms/migration/0001_migrate_test_name_modified.go
+++ b/db/rdbms/migration/0001_migrate_test_name_modified.go
@@ -1,0 +1,130 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package migration
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/tools/migration"
+)
+
+// TestNameMigration implements a migration of test_name column
+type TestNameMigration struct {
+}
+
+// Desc returns the description of the migration task
+func (m TestNameMigration) Desc() string {
+	return "add test_name_modified to test_events"
+}
+
+// Version returns the version of the migration that TestNameMigration implements
+func (m TestNameMigration) Version() uint {
+	return 1
+}
+
+// Count returns the number of records that the task should migrate
+func (m TestNameMigration) Count(db *sql.DB) (uint, error) {
+	count := uint(0)
+
+	rows, err := db.Query("select count(*) from test_events")
+	if err != nil {
+		return 0, fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+	if rows.Next() == false {
+		return 0, fmt.Errorf("could not fetch number of records to migrate, at least one result from count(*) expected")
+	}
+
+	if err := rows.Scan(&count); err != nil {
+		return 0, fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+
+	return count, nil
+}
+
+// Up returns the upward schema migration instructions
+func (m TestNameMigration) Up() string {
+	return "ALTER TABLE test_events ADD COLUMN `test_name_modified` VARCHAR(64);"
+}
+
+// Down returns the upward schema migration instructions
+func (m TestNameMigration) Down() string {
+	return ""
+}
+
+// MigrateData runs the data migration task
+func (m TestNameMigration) MigrateData(db *sql.DB, terminate chan struct{}, progress chan *migration.Progress) error {
+
+	count := uint64(0)
+	rows, err := db.Query("select count(*) from test_events")
+	if err != nil {
+		return fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+	if rows.Next() == false {
+		return fmt.Errorf("could not fetch number of records to migrate, at least one result from count(*) expected")
+	}
+
+	if err := rows.Scan(&count); err != nil {
+		return fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+
+	p := migration.Progress{Total: count}
+
+	query := "select event_id, job_id, run_id, test_name, test_step_label, event_name, target_name, target_id, payload, emit_time from test_events"
+	rows, err = db.Query(query)
+	if err != nil {
+		return fmt.Errorf("could not fetch all test events to migrate: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	// TargetName and TargetID might be null, so a type which supports null should be used with Scan
+	var (
+		targetName sql.NullString
+		targetID   sql.NullString
+		payload    sql.NullString
+	)
+
+	for rows.Next() {
+		data := testevent.Data{}
+		header := testevent.Header{}
+		event := testevent.New(&header, &data)
+
+		var eventID int
+		err := rows.Scan(
+			&eventID,
+			&header.JobID,
+			&header.RunID,
+			&header.TestName,
+			&header.TestStepLabel,
+			&data.EventName,
+			&targetName,
+			&targetID,
+			&payload,
+			&event.EmitTime,
+		)
+		if err != nil {
+			return fmt.Errorf("could not scan row: %+v", err)
+		}
+
+		testNameModified := fmt.Sprintf("%s_%d", header.TestName, eventID)
+		query := "update test_events set test_name_modified = ? where event_id = ?"
+		_, err = db.Exec(query, testNameModified, eventID)
+		if err != nil {
+			return fmt.Errorf("could not modify record on event id %d: %+v", eventID, err)
+		}
+
+		p.Completed++
+		if p.Completed%100 == 0 {
+			progress <- &p
+		}
+
+	}
+
+	return nil
+}

--- a/db/rdbms/migration/0002_migrate_event_name_modified.go
+++ b/db/rdbms/migration/0002_migrate_event_name_modified.go
@@ -1,0 +1,130 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package migration
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/tools/migration"
+)
+
+// EventNameMigration implements a migration of test_name column
+type EventNameMigration struct {
+}
+
+// Desc returns the description of the migration task
+func (m EventNameMigration) Desc() string {
+	return "add event_name_modified to test_events"
+}
+
+// Version returns the version of the migration that EventNameMigration implements
+func (m EventNameMigration) Version() uint {
+	return 2
+}
+
+// Count returns the number of records that the task should migrate
+func (m EventNameMigration) Count(db *sql.DB) (uint, error) {
+	count := uint(0)
+
+	rows, err := db.Query("select count(*) from test_events")
+	if err != nil {
+		return 0, fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+	if rows.Next() == false {
+		return 0, fmt.Errorf("could not fetch number of records to migrate, at least one result from count(*) expected")
+	}
+
+	if err := rows.Scan(&count); err != nil {
+		return 0, fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+
+	return count, nil
+}
+
+// Up returns the upward schema migration instructions
+func (m EventNameMigration) Up() string {
+	return "ALTER TABLE test_events ADD COLUMN `event_name_modified` VARCHAR(64);"
+}
+
+// Down returns the upward schema migration instructions
+func (m EventNameMigration) Down() string {
+	return ""
+}
+
+// MigrateData runs the data migration task
+func (m EventNameMigration) MigrateData(db *sql.DB, terminate chan struct{}, progress chan *migration.Progress) error {
+
+	count := uint64(0)
+	rows, err := db.Query("select count(*) from test_events")
+	if err != nil {
+		return fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+	if rows.Next() == false {
+		return fmt.Errorf("could not fetch number of records to migrate, at least one result from count(*) expected")
+	}
+
+	if err := rows.Scan(&count); err != nil {
+		return fmt.Errorf("could not fetch number of records to migrate: %v", err)
+	}
+
+	p := migration.Progress{Total: count}
+
+	query := "select event_id, job_id, run_id, test_name, test_step_label, event_name, target_name, target_id, payload, emit_time from test_events"
+	rows, err = db.Query(query)
+	if err != nil {
+		return fmt.Errorf("could not fetch all test events to migrate: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	// TargetName and TargetID might be null, so a type which supports null should be used with Scan
+	var (
+		targetName sql.NullString
+		targetID   sql.NullString
+		payload    sql.NullString
+	)
+
+	for rows.Next() {
+		data := testevent.Data{}
+		header := testevent.Header{}
+		event := testevent.New(&header, &data)
+
+		var eventID int
+		err := rows.Scan(
+			&eventID,
+			&header.JobID,
+			&header.RunID,
+			&header.TestName,
+			&header.TestStepLabel,
+			&data.EventName,
+			&targetName,
+			&targetID,
+			&payload,
+			&event.EmitTime,
+		)
+		if err != nil {
+			return fmt.Errorf("could not scan row: %+v", err)
+		}
+
+		testNameModified := fmt.Sprintf("%s_MODIFIED", data.EventName)
+		query := "update test_events set event_name_modified = ? where event_id = ?"
+		_, err = db.Exec(query, testNameModified, eventID)
+		if err != nil {
+			return fmt.Errorf("could not modify record on event id %d: %+v", eventID, err)
+		}
+
+		p.Completed++
+		if p.Completed%100 == 0 {
+			progress <- &p
+		}
+
+	}
+
+	return nil
+}

--- a/db/rdbms/migration/v0/db.sql
+++ b/db/rdbms/migration/v0/db.sql
@@ -1,0 +1,67 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+
+CREATE TABLE test_events (
+	event_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+	job_id BIGINT(20) NOT NULL,
+	run_id BIGINT(20) NOT NULL,
+	test_name VARCHAR(32) NULL,
+	test_step_label VARCHAR(32) NULL,
+	event_name VARCHAR(32) NULL,
+	target_name VARCHAR(64) NULL,
+	target_id VARCHAR(64) NULL,
+	payload TEXT NULL,
+	emit_time TIMESTAMP NOT NULL,
+	PRIMARY KEY (event_id)
+);
+
+CREATE TABLE framework_events (
+	event_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+	job_id BIGINT(20) NOT NULL,
+	event_name VARCHAR(32) NULL,
+	payload TEXT NULL,
+	emit_time TIMESTAMP NOT NULL,
+	PRIMARY KEY (event_id)
+);
+
+CREATE TABLE run_reports (
+	report_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+	job_id BIGINT(20) NOT NULL,
+	run_id BIGINT(20) NOT NULL,
+	reporter_name VARCHAR(32) NOT NULL,
+	success TINYINT(1) NULL,
+	report_time TIMESTAMP NOT NULL,
+	data TEXT NOT NULL,
+	PRIMARY KEY (report_id)
+);
+
+CREATE TABLE final_reports (
+	report_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+	job_id BIGINT(20) NOT NULL,
+	success TINYINT(1) NULL,
+	reporter_name VARCHAR(32) NOT NULL,
+	report_time TIMESTAMP NOT NULL,
+	data TEXT NOT NULL,
+	PRIMARY KEY (report_id)
+);
+
+CREATE TABLE jobs (
+	job_id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+	name VARCHAR(32) NOT NULL,
+	requestor VARCHAR(32) NOT NULL,
+	server_id VARCHAR(64) NOT NULL,
+	request_time TIMESTAMP NOT NULL,
+	descriptor TEXT NOT NULL,
+	teststeps TEXT,
+	PRIMARY KEY (job_id)
+);
+
+CREATE TABLE locks (
+	target_id VARCHAR(64) NOT NULL,
+	job_id BIGINT(20) UNSIGNED NOT NULL,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	expires_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (target_id)
+);

--- a/pkg/config/db.go
+++ b/pkg/config/db.go
@@ -1,0 +1,9 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package config
+
+// DefaultDBURI represents the default URI used by the rdbms plugin
+const DefaultDBURI = "contest:contest@tcp(localhost:3306)/contest?parseTime=true"

--- a/pkg/runner/test_runner_route.go
+++ b/pkg/runner/test_runner_route.go
@@ -144,7 +144,7 @@ func (r *stepRouter) routeIn(terminate <-chan struct{}) (int, error) {
 	injectionWg.Wait()
 
 	if err != nil {
-		log.Debugf("routeIn failed: %v", err)
+		log.Debugf("routeIn failed: %w", err)
 		return 0, err
 	}
 	return len(ingressTarget), nil
@@ -246,13 +246,15 @@ func (r *stepRouter) routeOut(terminate <-chan struct{}) (int, error) {
 	}
 
 	if err != nil {
-		log.Debugf("routeOut failed: %v", err)
+		log.Debugf("routeOut failed: %w", err)
 		return 0, err
 	}
 	return len(egressTarget), nil
 
 }
 
+// route implements the routing logic from the previous routing block to the test step
+// and from the test step to the next routing block
 // route implements the routing logic from the previous routing block to the test step
 // and from the test step to the next routing block
 func (r *stepRouter) route(terminate <-chan struct{}, resultCh chan<- routeResult) {

--- a/tools/migration/migration.go
+++ b/tools/migration/migration.go
@@ -1,0 +1,145 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package migration
+
+import (
+	"bytes"
+	"database/sql"
+	"io"
+	"io/ioutil"
+	"sort"
+
+	"github.com/golang-migrate/migrate/v4/source"
+
+	"fmt"
+)
+
+// Progress represents the migration progress of the task
+type Progress struct {
+	Completed uint64
+	Total     uint64
+}
+
+// Task represents a single migration task
+type Task interface {
+	Desc() string
+	Version() uint
+
+	// Up and Down return the schema
+	Up() string
+	Down() string
+
+	MigrateData(db *sql.DB, terminate chan struct{}, progress chan *Progress) error
+}
+
+// Tasks implements source.Driver from "github.com/golang-migrate/migrate/v4/source",
+// holding internally a list of migrations
+type Tasks struct {
+	tasks         map[uint]Task
+	tasksVersions []uint
+}
+
+// NewTasks initializes a new Tasks object
+func NewTasks() *Tasks {
+	m := Tasks{}
+	m.tasks = make(map[uint]Task)
+	m.tasksVersions = make([]uint, 0)
+	return &m
+}
+
+// Register registers a migration task within Task
+func (m *Tasks) Register(task Task) error {
+	if _, present := m.tasks[task.Version()]; present {
+		return fmt.Errorf("migration task %d is already registered", task.Version())
+	}
+	m.tasks[task.Version()] = task
+
+	m.tasksVersions = append(m.tasksVersions, task.Version())
+	sort.Slice(m.tasksVersions, func(i, j int) bool { return m.tasksVersions[i] < m.tasksVersions[j] })
+
+	return nil
+}
+
+// GetTask returns the migration task corresponding to `version`
+func (m *Tasks) GetTask(version uint) Task {
+	if _, ok := m.tasks[version]; !ok {
+		return nil
+	}
+	return m.tasks[version]
+}
+
+// Open is a no-op for MigrationTasks driver, as all available migrations are
+// pre-registered in code
+func (m *Tasks) Open(_ string) (source.Driver, error) {
+	return m, nil
+}
+
+// Close closes the current MigrationTasks
+func (m *Tasks) Close() error {
+	return nil
+}
+
+// First returns the first available migration task
+func (m *Tasks) First() (uint, error) {
+	if len(m.tasksVersions) == 0 {
+		return 0, fmt.Errorf("no migrations registered")
+	}
+	v, ok := m.tasks[m.tasksVersions[0]]
+	if ok {
+		return m.tasksVersions[0], nil
+	}
+	return 0, fmt.Errorf("migration v%d not associated with any migration", v)
+}
+
+// Prev returns the previous migration task
+func (m *Tasks) Prev(version uint) (uint, error) {
+
+	for index, v := range m.tasksVersions {
+		if v == version {
+			if index == 0 {
+				return 0, fmt.Errorf("no previous version for v%d", v)
+			}
+			return m.tasksVersions[index-1], nil
+		}
+	}
+	return 0, fmt.Errorf("version v%d not found", version)
+}
+
+// Next returns the next migration task
+func (m *Tasks) Next(version uint) (uint, error) {
+
+	for index, v := range m.tasksVersions {
+		if v == version {
+			if index == len(m.tasksVersions)-1 {
+				return 0, fmt.Errorf("no next version for v%d", v)
+			}
+			return m.tasksVersions[index+1], nil
+		}
+	}
+	return 0, fmt.Errorf("version v%d not found", version)
+}
+
+// ReadUp returns the up migration for `version`
+func (m *Tasks) ReadUp(version uint) (io.ReadCloser, string, error) {
+	if _, ok := m.tasks[version]; !ok {
+		return nil, "", fmt.Errorf("no migration registered for version v%d", version)
+	}
+
+	t := m.tasks[version]
+	rc := ioutil.NopCloser(bytes.NewReader([]byte(t.Up())))
+	return rc, t.Desc(), nil
+}
+
+// ReadDown returns the down migration for `version`
+func (m *Tasks) ReadDown(version uint) (io.ReadCloser, string, error) {
+	if _, ok := m.tasks[version]; !ok {
+		return nil, "", fmt.Errorf("no migration registered for version v%d", version)
+	}
+
+	t := m.tasks[version]
+	rc := ioutil.NopCloser(bytes.NewReader([]byte(t.Down())))
+	return rc, t.Desc(), nil
+}

--- a/tools/migration/rdbms/main.go
+++ b/tools/migration/rdbms/main.go
@@ -1,0 +1,167 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database/mysql"
+	_ "github.com/golang-migrate/migrate/v4/database/mysql"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+
+	dbmigration "github.com/facebookincubator/contest/db/rdbms/migration"
+	"github.com/facebookincubator/contest/pkg/config"
+	"github.com/facebookincubator/contest/pkg/logging"
+	"github.com/facebookincubator/contest/tools/migration"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/gosuri/uiprogress"
+)
+
+const migrationPath = "db/rdbms/migration"
+
+var (
+	flagDBURI = flag.String("dbURI", config.DefaultDBURI, "Database URI")
+	flagSRC   = flag.Uint("from", 0, "Initial version of the schema")
+	flagDST   = flag.Uint("to", 0, "Destination version of the schema")
+)
+
+func main() {
+	flag.Parse()
+
+	log := logging.GetLogger("contest")
+	log.Level = logrus.DebugLevel
+
+	var (
+		vSrc uint
+		vDst uint
+	)
+	if *flagSRC == 0 {
+		log.Fatalf("initial version of the schema cannot be 0")
+	}
+
+	if *flagDST == 0 {
+		log.Fatalf("destination version of the schema cannot be 0")
+	}
+
+	if *flagSRC > *flagDST {
+		log.Fatalf("initial version of the schema m4ust be lower than final version")
+	}
+
+	dbURI := *flagDBURI
+
+	vSrc = *flagSRC
+	vDst = *flagDST
+
+	tasks := migration.NewTasks()
+
+	availableTasks := []migration.Task{dbmigration.TestNameMigration{}, dbmigration.EventNameMigration{}}
+	for _, task := range availableTasks {
+		err := tasks.Register(task)
+		if err != nil {
+			log.Fatalf("could not register `%s` migration task: %v", task.Desc(), err)
+		}
+	}
+
+	log.Infof("beginning schema migration from %d to %d", vSrc, vDst)
+
+	db, err := sql.Open("mysql", dbURI)
+	if err != nil {
+		log.Fatalf("could not open mysql URI: %s", dbURI)
+	}
+	driver, err := mysql.WithInstance(db, &mysql.Config{})
+	if err != nil {
+		log.Fatalf("could not open mysql instance: %+v", err)
+	}
+
+	log.Infof("beginning migration v%d -> v%d", vSrc, vDst)
+	m, err := migrate.NewWithInstance("tasks", tasks, "mysql", driver)
+	if err != nil {
+		log.Fatalf("could not create instace for migration v%d -> v%d: %+v", vSrc, vDst, err)
+	}
+
+	currentVersion, dirty, err := m.Version()
+	if err != nil {
+		// TODO consider the fact that there might be no migration in progress
+		log.Warningf("could not get the currrent active migration version: %+v", err)
+	}
+
+	if dirty {
+		log.Fatalf("current version (v%d) has not completed migration correctly, this needs to fixed manually", currentVersion)
+	}
+
+	if currentVersion >= vDst {
+		log.Fatalf("current version (v%d) does not allow to migrate to v%d", currentVersion, vDst)
+	}
+
+	uiprogress.Start()
+
+	for {
+		if currentVersion >= vDst {
+			break
+		}
+
+		err = m.Steps(1)
+		if err != nil {
+			log.Fatalf("could not run migration v%d: %+v", currentVersion, err)
+		}
+
+		currentVersion++
+		t := tasks.GetTask(currentVersion)
+		if t == nil {
+			log.Warningf("task to v%d migration is not available", currentVersion)
+			continue
+		}
+
+		terminateCh := make(chan struct{})
+		progressCh := make(chan *migration.Progress)
+		errCh := make(chan error)
+		go func() {
+			errCh <- t.MigrateData(db, terminateCh, progressCh)
+		}()
+
+		progress := uiprogress.New()
+		bar := progress.AddBar(100)
+		bar.AppendCompleted()
+		bar.PrependFunc(func(b *uiprogress.Bar) string {
+			return fmt.Sprintf("Task: %s", t.Desc())
+		})
+
+		progress.Start()
+
+		var errTask error
+		for {
+			select {
+
+			case p := <-progressCh:
+				if p.Total != 0 {
+					bar.Set(int((float64(p.Completed) / float64(p.Total)) * 100))
+				}
+			case errTask = <-errCh:
+				errCh = nil
+			}
+
+			if errTask != nil || errCh == nil {
+				bar.Set(100)
+				time.Sleep(500 * time.Millisecond)
+				break
+			}
+		}
+		if errTask != nil {
+			log.Fatalf("task %d failed to run: %+v", currentVersion, errTask)
+		}
+		progress.Stop()
+
+		log.Infof("migration v%d completed!", currentVersion)
+	}
+
+	log.Infof("all migrations have completed successfully!")
+}


### PR DESCRIPTION
Proposal for a schema migration tool, based on `golang-migrate/migrate`.

Each migration is representd with a Task structure, which dictates
which schema changes should be applied and defines in code how
data should be migrated from prevoius to new schema. So, the migration
process consists in two parts:

* Schema migration: this is done via golang-migrate/migrate library.
SQL for forward and backward migration is defined Task structures.
The schema is versioned based on the version number returned by
First/Next/Prev functions implemented by `Task` structures. Migrations
are applied in ascending order by `golang-migrate/migrate`, which keeps
track of the current version of the schema, and whether it was
applied cleanly in a dedicated table (`schema_migrations`).
* Data migration: after a schema has been migrated, data might need
to be migrated as well. This is done via also in code by `Task` structs
The same approach for tracking data migrations as schema migrations
will be implemented: there will be a `data_migrations` table which
keeps track of which schema version the data has been migrated to.
Schema migration and data migration versions need to be aligned,
even though it is not mandatory to define code to implement a data
migration.