### PR TITLE
[plugins/cmd] Emit correct completion event

### DIFF
--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -109,7 +109,7 @@ func (ts *Cmd) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, para
 			errCh <- cmd.Run()
 			// Emit EventCmdEnd
 			evData := testevent.Data{
-				EventName: EventCmdStart,
+				EventName: EventCmdEnd,
 				Target:    target,
 				Payload:   nil,
 			}


### PR DESCRIPTION
Fixed wrong event emission at the end. It was EventCmdStart, it should
have been EventCmdEnd, not anymore.

Executed job spec at `cmds/clients/contestcli-http/start-literal.yaml`
and verified that the emitted events are correct:
```
$ go run . status 73 | jq '.Data.Status.RunStatus.TestStatuses[0].TestStepStatuses[0].TargetStatuses[0].Events'
Requesting URL http://localhost:8080/status with requestor ID 'contestcli-http'
  with params:
    requestor: [contestcli-http]
    jobID: [73]

The server responded with status 200 OK[
  {
    "Data": {
      "EventName": "CmdStart",
      "Payload": {
        "Args": [
          "/bin/echo",
          "Title=Example.Org, ToUpper=EXAMPLE.ORG"
        ],
        "Dir": "",
        "Path": "/bin/echo"
      },
      "Target": {
        "FQDN": "",
        "ID": "1234",
        "Name": "example.org"
      }
    },
    "EmitTime": "2020-10-12T17:19:34Z",
    "Header": {
      "JobID": 73,
      "RunID": 3,
      "TestName": "literal test",
      "TestStepLabel": "some label"
    }
  },
  {
    "Data": {
      "EventName": "CmdEnd",
      "Payload": null,
      "Target": {
        "FQDN": "",
        "ID": "1234",
        "Name": "example.org"
      }
    },
    "EmitTime": "2020-10-12T17:19:34Z",
    "Header": {
      "JobID": 73,
      "RunID": 3,
      "TestName": "literal test",
      "TestStepLabel": "some label"
    }
  }
]
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>