### PR TITLE
[pkg/teststeps] Avoid busy loop in ForEachTarget

### DIFF
--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -7,6 +7,7 @@ package teststeps
 
 import (
 	"sync/atomic"
+	"time"
 
 	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/logging"
@@ -113,9 +114,17 @@ func ForEachTarget(pluginName string, cancel, pause <-chan struct{}, ch test.Tes
 			noMoreTargets = true
 		case <-cancel:
 			log.Debugf("%s: ForEachTarget: received cancellation signal while waiting for results", pluginName)
+			if !reportResults {
+				time.Sleep(time.Second)
+			}
+			log.Infof("Waiting for all targets to be released (%d in flight)", atomic.LoadInt32(&tgtInFlight))
 			reportResults = false
 		case <-pause:
 			log.Debugf("%s: ForEachTarget: received pausing signal while waiting for results", pluginName)
+			if !reportResults {
+				time.Sleep(time.Second)
+			}
+			log.Infof("Waiting for all targets to be released (%d in flight)", atomic.LoadInt32(&tgtInFlight))
 			reportResults = false
 		}
 	}


### PR DESCRIPTION
I've hit a bug where cancellation leads to a busy loop until all the
plugins have returned. This happens because once the cancellation is
requested, the for-select will continuously enter the cancellation case.
With this sleep the cancellation path is not busy anymore and the CPU
doesn't suffer.
This was particuarly bad with buggy plugins that do not return quickly
enough (or at all - which is a plugin bug).

Signed-off-by: Andrea Barberio <insomniac@slackware.it>