### PR TITLE
targetlocker: Add TryLock API call, implement in plugins

### DIFF
--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -34,6 +34,14 @@ type Locker interface {
 	// Locks are reentrant, locking existing locks (with the same owner)
 	// extends the deadline.
 	Lock(types.JobID, []*Target) error
+	// TryLock attempts to lock all given targets.
+	// The job ID is the owner of the lock.
+	// This function attempts to lock as many of the given targets as possible,
+	// and returns a list of target IDs that it was able to lock.
+	// This function does not return an error if it was not able to lock any targets.
+	// Locks are reentrant, locking existing locks (with the same owner)
+	// extends the deadline.
+	TryLock(types.JobID, []*Target) ([]string, error)
 	// Unlock unlocks the specificied targets if they are held by the given owner.
 	// Unlock silently skips expired locks and targets that are not locked at all.
 	// Unlock does not fail if a valid lock is held on one of the targets.

--- a/plugins/targetlocker/noop/noop.go
+++ b/plugins/targetlocker/noop/noop.go
@@ -30,6 +30,16 @@ func (tl Noop) Lock(_ types.JobID, targets []*target.Target) error {
 	return nil
 }
 
+// TryLock locks the specified targets by doing nothing.
+func (tl Noop) TryLock(_ types.JobID, targets []*target.Target) ([]string, error) {
+	log.Infof("Trylocked %d targets by doing nothing", len(targets))
+	res := make([]string, 0, len(targets))
+	for _, t := range targets {
+		res = append(res, t.ID)
+	}
+	return res, nil
+}
+
 // Unlock unlocks the specified targets by doing nothing.
 func (tl Noop) Unlock(_ types.JobID, targets []*target.Target) error {
 	log.Infof("Unlocked %d targets by doing nothing", len(targets))

--- a/plugins/targetlocker/noop/noop_test.go
+++ b/plugins/targetlocker/noop/noop_test.go
@@ -37,6 +37,27 @@ func TestNoopLock(t *testing.T) {
 	}))
 }
 
+func TestNoopTryLock(t *testing.T) {
+	tl := New(time.Second)
+	// we don't enforce that at least one target is passed, as checking on
+	// non-zero targets is the framework's responsibility, not the plugin.
+	// So, zero targets is OK.
+	jobID := types.JobID(123)
+	_, err := tl.TryLock(jobID, nil)
+	require.Nil(t, err)
+	_, err = tl.TryLock(jobID, []*target.Target{})
+	require.Nil(t, err)
+	_, err = tl.TryLock(jobID, []*target.Target{
+		&target.Target{Name: "blah"},
+	})
+	require.Nil(t, err)
+	_, err = tl.TryLock(jobID, []*target.Target{
+		&target.Target{Name: "blah"},
+		&target.Target{Name: "bleh"},
+	})
+	require.Nil(t, err)
+}
+
 func TestNoopUnlock(t *testing.T) {
 	tl := New(time.Second)
 	// we don't enforce that at least one target is passed, as checking on


### PR DESCRIPTION
This adds `TryLock`, which can be used to batch locking calls properly. It does not error when some locks can't be acquired, and returns a list of target IDs that worked.

Test Plan:
Each of the implementations in noop, inmemory, dblocker is separate and covered by their own (new) unit tests.
Also running the integration suite. The new API called is not used yet of course, future commits will do that.