### PR TITLE
Reverting "apply" to "a", previously mistakenly replaced

### DIFF
--- a/pkg/jobmanager/event.go
+++ b/pkg/jobmanager/event.go
@@ -9,26 +9,26 @@ import (
 	"github.com/facebookincubator/contest/pkg/event"
 )
 
-// EventJobStarted indicates that apply Job is beginning execution
+// EventJobStarted indicates that a Job is beginning execution
 var EventJobStarted = event.Name("JobStateStarted")
 
-// EventJobCompleted indicates that apply Job has completed
+// EventJobCompleted indicates that a Job has completed
 var EventJobCompleted = event.Name("JobStateCompleted")
 
-// EventJobFailed indicates that apply Job has failed
+// EventJobFailed indicates that a Job has failed
 var EventJobFailed = event.Name("JobStateFailed")
 
-// EventJobCancelling indicates that apply Job has received apply cancellation request
+// EventJobCancelling indicates that a Job has received a cancellation request
 // and the JobManager is waiting for JobRunner to return
 var EventJobCancelling = event.Name("JobStateCancelling")
 
-// EventJobCancelled indicates that apply Job has been cancelled
+// EventJobCancelled indicates that a Job has been cancelled
 var EventJobCancelled = event.Name("JobStateCancelled")
 
 // EventJobCancellationFailed indicates that the cancellation was not completed correctly
 var EventJobCancellationFailed = event.Name("JobStateCancellationFailed")
 
-// JobCompletionEvents gathers all event names that mark the end of apply job
+// JobCompletionEvents gathers all event names that mark the end of a job
 var JobCompletionEvents = []event.Name{
 	EventJobCompleted,
 	EventJobFailed,
@@ -36,7 +36,7 @@ var JobCompletionEvents = []event.Name{
 	EventJobCancellationFailed,
 }
 
-// JobStateEvents gathers all event names which track the state of apply job
+// JobStateEvents gathers all event names which track the state of a job
 var JobStateEvents = []event.Name{
 	EventJobStarted,
 	EventJobCompleted,

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -32,7 +32,7 @@ var log = logging.GetLogger("pkg/jobmanager")
 
 var cancellationTimeout = 60 * time.Second
 
-// ErrorEventPayload represents the payload carried by apply failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
+// ErrorEventPayload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
 type ErrorEventPayload struct {
 	Err string
 }
@@ -65,7 +65,7 @@ type JobManager struct {
 	pluginRegistry *pluginregistry.PluginRegistry
 }
 
-// NewJobFromRequest returns apply new Job object from apply job.Request .
+// NewJobFromRequest returns a new Job object from a job.Request .
 func NewJobFromRequest(pr *pluginregistry.PluginRegistry, req *job.Request) (*job.Job, error) {
 	var jd *job.JobDescriptor
 	if err := json.Unmarshal([]byte(req.JobDescriptor), &jd); err != nil {
@@ -98,7 +98,7 @@ func newPartialJobFromDescriptor(pr *pluginregistry.PluginRegistry, jd *job.JobD
 	}
 
 	if len(jd.Reporting.RunReporters) == 0 && len(jd.Reporting.FinalReporters) == 0 {
-		return nil, errors.New("at least one run reporter or one final reporter must be specified in apply job")
+		return nil, errors.New("at least one run reporter or one final reporter must be specified in a job")
 	}
 	for _, reporter := range jd.Reporting.RunReporters {
 		if strings.TrimSpace(reporter.Name) == "" {
@@ -207,7 +207,7 @@ func newPartialJobFromDescriptor(pr *pluginregistry.PluginRegistry, jd *job.JobD
 	return &job, nil
 }
 
-// NewJob returns apply new Job object and the fetched test descriptors
+// NewJob returns a new Job object and the fetched test descriptors
 func NewJob(pr *pluginregistry.PluginRegistry, jobDescriptor string) (*job.Job, error) {
 	var jd *job.JobDescriptor
 	if err := json.Unmarshal([]byte(jobDescriptor), &jd); err != nil {
@@ -247,7 +247,7 @@ func NewJob(pr *pluginregistry.PluginRegistry, jobDescriptor string) (*job.Job, 
 	return j, nil
 }
 
-// New initializes and returns apply new JobManager with the given API listener.
+// New initializes and returns a new JobManager with the given API listener.
 func New(l api.Listener, pr *pluginregistry.PluginRegistry, opts ...Option) (*JobManager, error) {
 	if pr == nil {
 		return nil, errors.New("plugin registry cannot be nil")
@@ -300,7 +300,7 @@ func (jm *JobManager) handleEvent(ev *api.Event) {
 		// TODO send failure event once we have the event infra
 		// TODO determine whether the server should shut down if there
 		//      are too many errors
-		log.Panicf("timed out after %v trying to send apply response event", sendEventTimeout)
+		log.Panicf("timed out after %v trying to send a response event", sendEventTimeout)
 	}
 }
 
@@ -329,7 +329,7 @@ loop:
 			jm.handleEvent(ev)
 		// check for errors or premature termination from the listener.
 		case err := <-errCh:
-			log.Info("JobManager: API listener failed, triggering apply cancellation of all jobs")
+			log.Info("JobManager: API listener failed, triggering a cancellation of all jobs")
 			jm.CancelAll()
 			if err != nil {
 				return fmt.Errorf("error reported by API listener: %v", err)
@@ -338,7 +338,7 @@ loop:
 		// handle signals to shut down gracefully. If the cancellation takes too
 		// long, it will be terminated.
 		case sig := <-sigs:
-			// We were interrupted by apply signal, time to leave!
+			// We were interrupted by a signal, time to leave!
 			log.Printf("Interrupted by signal '%s', trying to exit gracefully", sig)
 			jm.Pause()
 			select {
@@ -360,7 +360,7 @@ loop:
 	return nil
 }
 
-// CancelJob sends apply cancellation request to apply specific job.
+// CancelJob sends a cancellation request to a specific job.
 func (jm *JobManager) CancelJob(jobID types.JobID) error {
 	jm.jobsMu.Lock()
 	// get the job from the local cache rather than the storage layer. We can
@@ -376,7 +376,7 @@ func (jm *JobManager) CancelJob(jobID types.JobID) error {
 	return nil
 }
 
-// CancelAll sends apply cancellation request to the API listener and to every running
+// CancelAll sends a cancellation request to the API listener and to every running
 // job.
 func (jm *JobManager) CancelAll() {
 	// TODO This doesn't seem the right thing to do, if the listener fails we should
@@ -391,7 +391,7 @@ func (jm *JobManager) CancelAll() {
 	}
 }
 
-// Pause sends apply pause request to every running job. No signal is sent to the
+// Pause sends a pause request to every running job. No signal is sent to the
 // API listener.
 func (jm *JobManager) Pause() {
 	log.Info("JobManager: requested pausing")

--- a/pkg/jobmanager/options.go
+++ b/pkg/jobmanager/options.go
@@ -35,7 +35,7 @@ func APIOption(option api.Option) Option {
 	return OptionAPI{Option: option}
 }
 
-// getConfig converts apply set of Option-s into one structure "Config".
+// getConfig converts a set of Option-s into one structure "Config".
 func getConfig(opts ...Option) config {
 	result := config{}
 	for _, opt := range opts {

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -21,7 +21,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 		return &api.EventResponse{Err: err}
 	}
 	// The job descriptor has been validated correctly, now use the JobRequestEmitter
-	// interface to obtain apply JobRequest object with apply valid id
+	// interface to obtain a JobRequest object with a valid id
 	request := job.Request{
 		JobName:         j.Name,
 		Requestor:       string(ev.Msg.Requestor()),
@@ -69,8 +69,8 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 			return
 		}
 
-		// store job report before emitting the job status event, to avoid apply
-		// race condition when waiting on apply job status where the event is marked
+		// store job report before emitting the job status event, to avoid a
+		// race condition when waiting on a job status where the event is marked
 		// as completed but no report exists.
 		jobReport := job.JobReport{
 			JobID:        j.ID,

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -80,7 +80,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 		je := jobEvents[len(jobEvents)-1]
 		state = string(je.EventName)
 		if je.EventName == EventJobFailed {
-			// if there was apply framework failure, retrieve the failure event and
+			// if there was a framework failure, retrieve the failure event and
 			// the associated error message, so it can be exposed in the status.
 			if je.Payload == nil {
 				stateErrMsg = "internal error: EventJobFailed's payload is nil"


### PR DESCRIPTION
My IDE replaced all `a` to `apply` by my mistake in https://github.com/facebookincubator/contest/pull/159. Reverting.