### PR TITLE
Feature/add support of wait and exit

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -72,7 +72,7 @@ func main() {
 	log.Printf("JobManager %+v", jm)
 
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 
 	if err := jm.Start(sigs); err != nil {
 		log.Fatal(err)

--- a/tests/integ/jobmanager/common_longtest.go
+++ b/tests/integ/jobmanager/common_longtest.go
@@ -1,0 +1,20 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// +build integration integration_storage
+// +build longtest
+
+package test
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/jobmanager"
+)
+
+func (suite *TestJobManagerSuite) TestWaitAndExit() {
+	suite.testExit(syscall.SIGUSR1, jobmanager.EventJobCompleted, 10*time.Second)
+}


### PR DESCRIPTION
Previously we had only "pause all the jobs and exit" signal for a JobManager. But since "pause" is still not implemenented neither in the core code nor in plugins, it is required to introduce another way to graceful shutdown a ConTest instance.
And meanwhile it is proposed to use "wait for all the job to complete and the exit".