### PR TITLE
jobmanager/status: Fetch reports after status events to prevent race

### DIFF
--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -25,12 +25,6 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 		Err:       nil,
 	}
 
-	report, err := jm.jobStorageManager.GetJobReport(jobID)
-	if err != nil {
-		evResp.Err = fmt.Errorf("could not fetch job report: %v", err)
-		return &evResp
-	}
-
 	// Fetch all the events associated to changes of state of the Job
 	jobEvents, err := jm.frameworkEvManager.Fetch(
 		frameworkevent.QueryJobID(jobID),
@@ -93,6 +87,12 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 				}
 			}
 		}
+	}
+
+	report, err := jm.jobStorageManager.GetJobReport(jobID)
+	if err != nil {
+		evResp.Err = fmt.Errorf("could not fetch job report: %v", err)
+		return &evResp
 	}
 
 	jobStatus := job.Status{


### PR DESCRIPTION
There is (still) a race when a job finishes exactly when a client calls status.

This was already partially fixed by @insomniacslk in #144, but can still happen.
We now correctly write the report before setting the status event, but the `status` code reads the report first, then the status event. This means the following can happen:

1. Job is running, almost done
2. Client requests job status
3. Status code starts running, reads empty reports, because job not done
4. Job finishes, writes reports, sets status to completed
5. Status code reads completed status and sends it to client
6. Client is confused because it got a completed job without any reports, defaults to job failed

This change reverts the order in the status call to read the job status first, and then the reports.
This is not a full fix, but it will prevent incomplete status responses with Completed = true, but no report being sent out.
(It will instead trade it for incomplete reports with the reports already set, but the job not marked as completed yet. This should make well behaved clients continue polling, and they will get a full report on the next attempt)