### PR TITLE
pkg/logging/logger.go: Add more Log Levels

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -44,8 +44,39 @@ func Disable() {
 	log.SetOutput(ioutil.Discard)
 }
 
+// Trace - Set Log Level to Trace
+func Trace() {
+	log.SetLevel(logrus.TraceLevel)
+}
+
+// Debug - Set Log Level to Debug
 func Debug() {
 	log.SetLevel(logrus.DebugLevel)
+}
+
+// Info - Set Log Level to Info
+func Info() {
+	log.SetLevel(logrus.InfoLevel)
+}
+
+// Warn - Set Log Level to Warn
+func Warn() {
+	log.SetLevel(logrus.WarnLevel)
+}
+
+// Error - Set Log Level to Error
+func Error() {
+	log.SetLevel(logrus.ErrorLevel)
+}
+
+// Fatal - Set Log Level to Fatal
+func Fatal() {
+	log.SetLevel(logrus.FatalLevel)
+}
+
+// Panic - Set Log Level to Panic
+func Panic() {
+	log.SetLevel(logrus.PanicLevel)
 }
 
 func init() {


### PR DESCRIPTION
For a follow up commit we need more log levels. Currently the default is
Debug - Add Warn, Info, Trace, Panic and Fatal for completeness here.

Signed-off-by: Christian Walter <christian.walter@9elements.com>