### PR TITLE
plugins/teststeps/sshcmd: Add Timeout and busy waiting

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -315,6 +315,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d h1:9FCpayM9Egr1baVnV1SX0H87m+XB0B8S0hAMi99X/3U=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -237,7 +237,10 @@ func (ts *SSHCmd) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, p
 				if time.Now().After(timeTimeout) {
 					return fmt.Errorf("timed out after %s", timeout)
 				}
-				session.Signal(ssh.Signal("CONT"))
+				err = session.Signal(ssh.Signal("CONT"))
+				if err != nil {
+					log.Warnf("Unable to send CONT to ssh server: %v", err)
+				}
 				// Sanity Break to not spam the Server
 				time.Sleep(250 * time.Millisecond)
 			}

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -232,10 +232,12 @@ func (ts *SSHCmd) Run(cancel, pause <-chan struct{}, ch test.TestStepChannels, p
 			case <-pause:
 				return session.Signal(ssh.SIGKILL)
 			case <-time.After(250 * time.Millisecond):
-				matches := re.FindAll(stdout.Bytes(), -1)
-				if len(matches) > 0 {
-					log.Infof("match for regex '%s' found", expect)
-					return nil
+				if expect != "" {
+					matches := re.FindAll(stdout.Bytes(), -1)
+					if len(matches) > 0 {
+						log.Infof("match for regex '%s' found", expect)
+						return nil
+					}
 				}
 				if time.Now().After(timeTimeout) {
 					return fmt.Errorf("timed out after %s", timeout)


### PR DESCRIPTION
1. Add Timeout to the command
2. Add busy waiting. Busy waiting is needed to catch the expect
   parameter. Otherwise, if we have a continuous command e.g. reading
   from the command line it will never complete successfully, thus it
   will also not be parsed for the expect parameter - and thus never
   success.

I added a "dummy" CONT to keep the ssh connection busy - such that it
does not close down because of a time out.

Signed-off-by: Christian Walter <christian.walter@9elements.com>