### PR TITLE
[pkg/storage] Add support to storage backend to retrive schema version

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -50,6 +50,13 @@ func main() {
 	}
 	storage.SetStorage(s)
 
+	dbVer, err := s.Version()
+	if err != nil {
+		log.Warningf("could not determine storage version: %v", err)
+	} else {
+		log.Infof("storage version: %d", dbVer)
+	}
+
 	// set Locker engine
 	target.SetLocker(inmemory.New(config.LockInitialTimeout, config.LockRefreshTimeout))
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	github.com/pressly/goose v2.7.0-rc5+incompatible
 	github.com/prometheus/common v0.15.0
@@ -23,8 +22,5 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 )

--- a/go.sum
+++ b/go.sum
@@ -315,6 +315,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d h1:9FCpayM9Egr1baVnV1SX0H87m+XB0B8S0hAMi99X/3U=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/storage/events_test.go
+++ b/pkg/storage/events_test.go
@@ -54,6 +54,10 @@ func (n *nullStorage) GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]fra
 	return nil, nil
 }
 
+func (m *nullStorage) Version() (int64, error) {
+	return 0, nil
+}
+
 func TestMain(m *testing.M) {
 	SetStorage(&nullStorage{})
 	os.Exit(m.Run())

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -39,6 +39,9 @@ type Storage interface {
 	// Framework events storage interface
 	StoreFrameworkEvent(event frameworkevent.Event) error
 	GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]frameworkevent.Event, error)
+
+	// Version returns the version of the storage being used
+	Version() (int64, error)
 }
 
 // TransactionalStorage is implemented by storage backends that support transactions.

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -219,6 +219,11 @@ func (m *Memory) GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]framewor
 	return matchingFrameworkEvents, nil
 }
 
+// Version returns the version of the memory storage layer.
+func (m *Memory) Version() (int64, error) {
+	return 0, nil
+}
+
 // New create a new Memory events storage backend
 func New() (storage.Storage, error) {
 	m := Memory{lock: &sync.Mutex{}}

--- a/plugins/storage/rdbms/init.go
+++ b/plugins/storage/rdbms/init.go
@@ -16,6 +16,8 @@ import (
 	"github.com/facebookincubator/contest/pkg/logging"
 	"github.com/facebookincubator/contest/pkg/storage"
 
+	"github.com/facebookincubator/contest/tools/migration/rdbms/migrationlib"
+
 	// this blank import registers the mysql driver
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -117,6 +119,14 @@ func (r *RDBMS) Rollback() error {
 		return fmt.Errorf("no active transaction")
 	}
 	return tx.Rollback()
+}
+
+// Version returns the current version of the RDBMS schema
+func (r *RDBMS) Version() (int64, error) {
+	if sqlDB, ok := r.db.(*sql.DB); ok {
+		return migrationlib.DBVersion(sqlDB)
+	}
+	return 0, fmt.Errorf("db object (%T) is not a sql.DB", r.db)
 }
 
 func (r *RDBMS) init() error {

--- a/tools/migration/rdbms/migrationlib/version.go
+++ b/tools/migration/rdbms/migrationlib/version.go
@@ -1,0 +1,16 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package migrationlib
+
+import (
+	"database/sql"
+	"github.com/pressly/goose"
+)
+
+// DBVersion returns the current version of the database schema
+func DBVersion(db *sql.DB) (int64, error) {
+	return goose.GetDBVersion(db)
+}


### PR DESCRIPTION
We are introducing versioning of the database schema and the storage
backend(s) should support returning the current version of the schema,
regardless of whether the concept of "schema" applies to the backend at
all.