### PR TITLE
Fixed incorrect logger in CSVFileTargetManager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 // indirect
 	github.com/pressly/goose v2.7.0-rc5+incompatible
-	github.com/prometheus/common v0.15.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d h1:62ap6LNOjDU6uGmKXHJbSfciMoV+FeI1sRXx/pLDL44=
 golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/plugins/targetmanagers/csvtargetmanager/csvfile.go
+++ b/plugins/targetmanagers/csvtargetmanager/csvfile.go
@@ -24,16 +24,18 @@ import (
 	"os"
 	"strings"
 
+	"github.com/facebookincubator/contest/pkg/logging"
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/insomniacslk/xjson"
-	"github.com/prometheus/common/log"
 )
 
 // Name defined the name of the plugin
 var (
 	Name = "CSVFileTargetManager"
 )
+
+var log = logging.GetLogger("targetmanagers/" + strings.ToLower(Name))
 
 // AcquireParameters contains the parameters necessary to acquire targets.
 type AcquireParameters struct {


### PR DESCRIPTION
In https://github.com/facebookincubator/contest/pull/172 I have
erroneously imported the wrong logging library, because I didn't declare
the logger, goimports imported whatever looked to have a compatible
API, and I didn't notice the mistake.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>