### PR TITLE
targetlocker: Add limit parameter to TryLock

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -444,6 +444,7 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/pkg/target/locker.go
+++ b/pkg/target/locker.go
@@ -34,14 +34,14 @@ type Locker interface {
 	// Locks are reentrant, locking existing locks (with the same owner)
 	// extends the deadline.
 	Lock(types.JobID, []*Target) error
-	// TryLock attempts to lock all given targets.
+	// TryLock attempts to lock up to limit of the given targets.
 	// The job ID is the owner of the lock.
-	// This function attempts to lock as many of the given targets as possible,
+	// This function attempts to lock up to limit of the given targets,
 	// and returns a list of target IDs that it was able to lock.
 	// This function does not return an error if it was not able to lock any targets.
 	// Locks are reentrant, locking existing locks (with the same owner)
 	// extends the deadline.
-	TryLock(types.JobID, []*Target) ([]string, error)
+	TryLock(jobID types.JobID, targets []*Target, limit uint) ([]string, error)
 	// Unlock unlocks the specificied targets if they are held by the given owner.
 	// Unlock silently skips expired locks and targets that are not locked at all.
 	// Unlock does not fail if a valid lock is held on one of the targets.

--- a/plugins/targetlocker/noop/noop.go
+++ b/plugins/targetlocker/noop/noop.go
@@ -31,7 +31,7 @@ func (tl Noop) Lock(_ types.JobID, targets []*target.Target) error {
 }
 
 // TryLock locks the specified targets by doing nothing.
-func (tl Noop) TryLock(_ types.JobID, targets []*target.Target) ([]string, error) {
+func (tl Noop) TryLock(_ types.JobID, targets []*target.Target, limit uint) ([]string, error) {
 	log.Infof("Trylocked %d targets by doing nothing", len(targets))
 	res := make([]string, 0, len(targets))
 	for _, t := range targets {

--- a/plugins/targetlocker/noop/noop_test.go
+++ b/plugins/targetlocker/noop/noop_test.go
@@ -43,18 +43,18 @@ func TestNoopTryLock(t *testing.T) {
 	// non-zero targets is the framework's responsibility, not the plugin.
 	// So, zero targets is OK.
 	jobID := types.JobID(123)
-	_, err := tl.TryLock(jobID, nil)
+	_, err := tl.TryLock(jobID, nil, 0)
 	require.Nil(t, err)
-	_, err = tl.TryLock(jobID, []*target.Target{})
+	_, err = tl.TryLock(jobID, []*target.Target{}, 0)
 	require.Nil(t, err)
 	_, err = tl.TryLock(jobID, []*target.Target{
 		&target.Target{Name: "blah"},
-	})
+	}, 1)
 	require.Nil(t, err)
 	_, err = tl.TryLock(jobID, []*target.Target{
 		&target.Target{Name: "blah"},
 		&target.Target{Name: "bleh"},
-	})
+	}, 2)
 	require.Nil(t, err)
 }
 

--- a/tests/plugins/targetlocker/dblocker/dblocker_test.go
+++ b/tests/plugins/targetlocker/dblocker/dblocker_test.go
@@ -140,38 +140,71 @@ func TestLockUnlockDifferentJobID(t *testing.T) {
 	assert.Error(t, tl.Lock(jobID+1, twoTargets))
 }
 
+
 func TestTryLockOne(t *testing.T) {
 	tl.ResetAllLocks()
-	res, err := tl.TryLock(jobID, oneTarget)
+	res, err := tl.TryLock(jobID, oneTarget, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, oneTarget[0].ID, res[0])
 }
 
 func TestTryLockTwo(t *testing.T) {
 	tl.ResetAllLocks()
-	res, err := tl.TryLock(jobID, twoTargets)
+	res, err := tl.TryLock(jobID, twoTargets, 2)
 	assert.NoError(t, err)
 	// order is not guaranteed
 	assert.Contains(t, res, twoTargets[0].ID)
 	assert.Contains(t, res, twoTargets[1].ID)
 }
 
-func TestTryLockOneOfTwo(t *testing.T) {
+func TestInMemoryTryLockZeroLimited(t *testing.T) {
+	tl.ResetAllLocks()
+	// only request one
+	res, err := tl.TryLock(jobID, twoTargets, 0)
+	assert.NoError(t, err)
+	// it is allowed to set the limit to zero
+	assert.Equal(t, len(res), 0)
+}
+
+func TestTryLockTwoHigherLimit(t *testing.T) {
+	tl.ResetAllLocks()
+	// limit is just an upper bound, can be higher
+	res, err := tl.TryLock(jobID, twoTargets, 100)
+	assert.NoError(t, err)
+	// order is not guaranteed
+	assert.Contains(t, res, twoTargets[0].ID)
+	assert.Contains(t, res, twoTargets[1].ID)
+}
+
+func TestInMemoryTryLockOneLimited(t *testing.T) {
+	tl.ResetAllLocks()
+	// only request one
+	res, err := tl.TryLock(jobID, twoTargets, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, len(res), 1)
+	// API doesn't require it, but this locker guarantees order
+	// so the first one should have been locked,
+	// the second not because limit was 1
+	assert.Contains(t, res, twoTargets[0].ID)
+	assert.NotContains(t, res, twoTargets[1].ID)
+}
+
+func TestInMemoryTryLockOneOfTwo(t *testing.T) {
 	tl.ResetAllLocks()
 	assert.NoError(t, tl.Lock(jobID, oneTarget))
 	// now tryLock both with other ID
-	res, err := tl.TryLock(jobID+1, twoTargets)
+	res, err := tl.TryLock(jobID+1, twoTargets, 2)
 	assert.NoError(t, err)
 	// should have locked 1 but not 0
 	assert.NotContains(t, res, twoTargets[0].ID)
 	assert.Contains(t, res, twoTargets[1].ID)
 }
 
-func TestTryLockNoneOfTwo(t *testing.T) {
+func TestInMemoryTryLockNoneOfTwo(t *testing.T) {
 	tl.ResetAllLocks()
 	assert.NoError(t, tl.Lock(jobID, twoTargets))
 	// now tryLock both with other ID
-	res, err := tl.TryLock(jobID+1, twoTargets)
+	res, err := tl.TryLock(jobID+1, twoTargets, 2)
 	// should have locked zero targets, but no error
 	assert.NoError(t, err)
 	assert.Empty(t, res)


### PR DESCRIPTION
`TryLock` currently attempts to lock as many targets as possible. This works, but in many cases targetmanagers want to hit a specific number of targets in the end, and since they can't predict which targets will fail locking, they provide more candidates to `TryLock`.

This can overshoot the target, locking more than the user really needs. Targetmanagers can work around this by calling UnLock at the cost of another roundtrip to the lock service/database.

This PR adds a `limit` parameter to `TryLock` and implements it in all three lockers (noop, inmemory, dblocker). The lockers will then internally try to acquire locks until they reach the limit and stop.
Note this is strictly just an upper limit, it is not an error to lock less targets than the limit says (or even zero targets).


Test Plan:
This should be fully covered by new and old unit tests.