### PR TITLE
pkg/target: Rework target to have unique ID, remove name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ moment).
 
 ## Quick Start
 
-We offer a few Docker files to help setup ConTest. The fastest way to 
+We offer a few Docker files to help setup ConTest. The fastest way to
 have a ConTest instance up and running is to bring up the server and MySQL
 containers via the docker-compose configuration: just run
 `docker-compose up --build` from the root of the source tree.
@@ -348,7 +348,7 @@ commented for clarity:
             // on the actual plugin.
             "TargetManagerAcquireParameters": {
                 // the URI for the CSV file that contains a list of targets in
-                the format "ip,hostname". This is intentionally very simple.
+                the format "id,fqdn,ipv4,ipv6". This is intentionally very simple.
                 "FileURI": "hosts02.csv",
                 // The minimum number of targets needed for the test. If we
                 // don't get at least this number of devices, the job will fail.
@@ -519,20 +519,20 @@ Every job is associated to a list of targets, and what actions (and how) are
 executed on each target depends on the plugin.
 
 Targets are currently defined with three properties:
-* **Name**: a mnemonic name associated to the target. It could be its DNS short or
-  fully-qualified name, or any other name that can be associated to it.
-* **ID**: an identifier for the target. It should be unique, however this is not
-  enforced by the framework. For example, an identifier could be the target's
-  asset ID, a hardware fingerprint, but again, it can really be anything that
-  makes sense to the user.
-* **FQDN**: this field can be used to attribute a fully-qualified domain name to
-  the target. The presence and the well-formedness of this field are not
-  checked nor enforced.
+* **ID**: primary identifier for the target. Must be unique within the scope of this ConTest instance.
+  Common choices are IDs from inventory management systems, DNS short or full names,
+  or textual representations of ipv4/ipv6 addresses. Storage plugins might enforce uniqueness.
+* **FQDN**: DNS-resolvable name of the target, ideally a FQDN. Plugins can use
+  this field to contact the test target.
+* **PrimaryIPv6**/**PrimaryIPv4**: Raw IP address used by plugins to contact the test target.
+
+Only **ID** is required, but it is recommended to set as many fields as possible
+for maximum plugin compatibility. Note that no validation is done on FQDNs or IP addresses.
 
 The `Target` structure is defined in [pkg/target](pkg/target/target.go). Plugin
 configurations can access the specific fields via Go templates, as explained in
 more detail in the [Templates in test step arguments](#templates-in-plugin-configurations)
-section. For example, to print a target's name and ID with the `cmd` plugin:
+section. For example, to print a target's ID and FQDN with the `cmd` plugin:
 
 ```
 {
@@ -542,7 +542,7 @@ section. For example, to print a target's name and ID with the `cmd` plugin:
             "label": "some label",
             "parameters": {
                 "executable": ["echo"],
-                "args": ["Name is {{ .Name }} and ID is {{ .ID }}"]
+                "args": ["ID is {{ .ID }} and FQDN is {{ .FQDN }}"]
             }
         }
     ]
@@ -575,7 +575,7 @@ plugin executes a command on the ConTest server, not on the targets.
         "label": "some label",
         "parameters: {
             "executable": ["echo"],
-            "args": ["My name is {{ .Name }}"]
+            "args": ["My ID is {{ .ID }}"]
         }"
     }
 ...
@@ -592,9 +592,9 @@ Let's dissect the above.
 * the "args" parameter is the list of arguments to pass to the program execution
 
 Note that "args" contains only one argument, and this argument uses the Go
-templating syntax. `.Name` expands to the value contained in `Target.Name`,
+templating syntax. `.ID` expands to the value contained in `Target.ID`,
 since the target is the root object passed to the template. This means that you
-can also use `.ID` or `.FQDN` if you want to access other members of the target
+can also use `.FQDN` or `.PrimaryIPv6` if you want to access other members of the target
 structure.
 After the name expansion is done, the resulting string will be unique per
 target, and ConTest will execute the "echo" command with this customized output
@@ -612,15 +612,15 @@ write:
         "label": "some label",
         "parameters: {
             "executable": ["echo"],
-            "args": ["The first four letters of my name are {{ slice .Name 0 4 }}"]
+            "args": ["The first four letters of my FQDN are {{ slice .FQDN 0 4 }}"]
         }"
     }
 ...
 ```
 
 ConTest defines additional built-in functions in
-[pkg/test](pkg/test/functions.go). For example, to print the target name after
-capitalzing its letter, one can write:
+[pkg/test](pkg/test/functions.go). For example, to print the target FQDN after
+capitalzing its letters, one can write:
 
 ```
 ...
@@ -629,7 +629,7 @@ capitalzing its letter, one can write:
         "label": "some label",
         "parameters: {
             "executable": ["echo"],
-            "args": ["My capitalized name is {{ ToUpper .Name }}"]
+            "args": ["My capitalized name is {{ ToUpper .FQDN }}"]
         }"
     }
 ...
@@ -646,7 +646,7 @@ write a custom template function to get this information. There is no limitation
 on how to implement it: it can be simple string substitution, or it can be
 retrieved from a backend service requiring authentication.
 For example, imagine that we wrote a custom template function called `jumphost`,
-that receives the target name as input and returns the jump host (or an error),
+that receives the target fqdn as input and returns the jump host (or an error),
 we can use it as follows. Note that the "sshcmd" plugin runs a command on a
 remote host.
 
@@ -657,7 +657,7 @@ remote host.
         "label": "some label...",
         "parameters: {
             "user": "contest",
-            "host": "{{ jumphost .Name }}",
+            "host": "{{ jumphost .FQDN }}",
             "private_key_file": "/path/to/id_dsa",
             "executable": ["echo"],
             "args": ["ConTest was here"]

--- a/cmds/clients/contestcli-http/descriptors/fwtesting/lspci.json
+++ b/cmds/clients/contestcli-http/descriptors/fwtesting/lspci.json
@@ -9,7 +9,7 @@
             "TargetManagerAcquireParameters": {
                 "Targets": [
                     {
-                        "Name": "dut1",
+                        "FQDN": "dut1",
                         "ID": "12345"
                     }
                 ]
@@ -24,7 +24,7 @@
                         "name": "sshcmd",
                         "parameters": {
                                 "user": ["sesame"],
-                                "host": ["{{ .Name }}"],
+                                "host": ["{{ .FQDN }}"],
                                 "password": [""],
                                 "executable": ["lspci"],
                                 "expect": ["DDRIO Global Broadcast"]

--- a/cmds/clients/contestcli-http/start-literal.json
+++ b/cmds/clients/contestcli-http/start-literal.json
@@ -9,7 +9,7 @@
             "TargetManagerAcquireParameters": {
                 "Targets": [
                     {
-                        "Name": "example.org",
+                        "FQDN": "example.org",
                         "ID": "1234"
                     }
                 ]
@@ -25,7 +25,7 @@
                         "label": "some label",
                         "parameters": {
                             "executable": ["echo"],
-                            "args": ["Title={{ Title .Name }}, ToUpper={{ ToUpper .Name }}"]
+                            "args": ["Title={{ Title .FQDN }}, ToUpper={{ ToUpper .FQDN }}"]
                         }
                     }
                 ]

--- a/cmds/clients/contestcli-http/start-literal.yaml
+++ b/cmds/clients/contestcli-http/start-literal.yaml
@@ -18,7 +18,7 @@ TestDescriptors:
                 label: some label
                 parameters:
                     executable: [echo]
-                    args: ["Title={{ Title .Name }}, ToUpper={{ ToUpper .Name }}"]
+                    args: ["Title={{ Title .FQDN }}, ToUpper={{ ToUpper .FQDN }}"]
                     emit_stdout: [true]
                     emit_stderr: [true]
 Reporting:

--- a/cmds/contest/hosts.csv
+++ b/cmds/contest/hosts.csv
@@ -1,4 +1,4 @@
-compute1234,172.16.5.6
-storage2345,10.10.10.123
-machinelearning1234,192.168.123.231
-uselesshost10,10.0.0.10
+1234,compute1234,172.16.5.6,
+2345,storage2345,10.10.10.123,
+1234,machinelearning1234,192.168.123.231,
+10,uselesshost10,10.0.0.10,

--- a/cmds/contest/test_samples/sshhostname.json
+++ b/cmds/contest/test_samples/sshhostname.json
@@ -5,12 +5,11 @@
             "label": "some label",
             "parameters": {
                 "user": ["your_username"],
-                "host": ["{{ .Name }}"],
+                "host": ["{{ .FQDN }}"],
                 "private_key_file": ["/home/user/.ssh/id_rsa"],
                 "executable": ["ping"],
-                "args": ["-c1", "-W2", "www.{{ ToLower .Name }}"]
+                "args": ["-c1", "-W2", "www.{{ ToLower .FQDN }}"]
             }
         }
     ]
 }
-

--- a/pkg/runner/job_status.go
+++ b/pkg/runner/job_status.go
@@ -35,7 +35,7 @@ func (jr *JobRunner) buildTargetStatuses(coordinates job.TestStepCoordinates, ta
 		// Update the TargetStatus object associated to the Target. If there is no TargetStatus associated yet, append it
 		var targetStatus *job.TargetStatus
 		for index, candidateStatus := range targetStatuses {
-			if *candidateStatus.Target == *testEvent.Data.Target {
+			if candidateStatus.Target.ID == testEvent.Data.Target.ID {
 				targetStatus = &targetStatuses[index]
 				break
 			}
@@ -170,21 +170,21 @@ func (jr *JobRunner) buildTestStatus(coordinates job.TestCoordinates, currentJob
 	var targetStatuses []job.TargetStatus
 
 	// Keep track of the last TargetStatus seen for each Target
-	targetMap := make(map[target.Target]job.TargetStatus)
+	targetMap := make(map[string]job.TargetStatus)
 	for _, testStepStatus := range testStatus.TestStepStatuses {
 		for _, targetStatus := range testStepStatus.TargetStatuses {
-			targetMap[*targetStatus.Target] = targetStatus
+			targetMap[targetStatus.Target.ID] = targetStatus
 		}
 	}
 
 	for _, targetEvent := range targetAcquiredEvents {
 		t := *targetEvent.Data.Target
-		if _, ok := targetMap[t]; !ok {
+		if _, ok := targetMap[t.ID]; !ok {
 			// This Target is not associated to any TargetStatus, we assume it has not
 			// started the test
-			targetMap[t] = job.TargetStatus{}
+			targetMap[t.ID] = job.TargetStatus{}
 		}
-		targetStatuses = append(targetStatuses, targetMap[t])
+		targetStatuses = append(targetStatuses, targetMap[t.ID])
 	}
 
 	testStatus.TargetStatuses = targetStatuses

--- a/pkg/runner/test_runner_route_test.go
+++ b/pkg/runner/test_runner_route_test.go
@@ -122,9 +122,9 @@ func (suite *TestRunnerSuite) TestRouteInRoutesAllTargets() {
 
 	// test that all targets are routed to step input channel without delay, in order
 	targets := []*target.Target{
-		{Name: "host001", ID: "001", FQDN: "host001.facebook.com"},
-		{Name: "host002", ID: "002", FQDN: "host002.facebook.com"},
-		{Name: "host003", ID: "003", FQDN: "host003.facebook.com"},
+		{ID: "001", FQDN: "host001.facebook.com"},
+		{ID: "002", FQDN: "host002.facebook.com"},
+		{ID: "003", FQDN: "host003.facebook.com"},
 	}
 
 	routeInResult := make(chan error)
@@ -205,9 +205,9 @@ func (suite *TestRunnerSuite) TestRouteOutRoutesAllSuccessfulTargets() {
 	// test that all targets are routed in output from a test step are received by
 	// the routing logic and forwarded to the next routing block
 	targets := []*target.Target{
-		&target.Target{Name: "host001", ID: "001", FQDN: "host001.facebook.com"},
-		&target.Target{Name: "host002", ID: "002", FQDN: "host002.facebook.com"},
-		&target.Target{Name: "host003", ID: "003", FQDN: "host003.facebook.com"},
+		{ID: "001", FQDN: "host001.facebook.com"},
+		{ID: "002", FQDN: "host002.facebook.com"},
+		{ID: "003", FQDN: "host003.facebook.com"},
 	}
 
 	terminate := make(chan struct{})
@@ -263,7 +263,7 @@ func (suite *TestRunnerSuite) TestRouteOutRoutesAllSuccessfulTargets() {
 					routeResult <- fmt.Errorf("more targets returned than injected")
 					return
 				}
-				if t.Name != targets[numTargets].Name || t.ID != targets[numTargets].ID {
+				if t.ID != targets[numTargets].ID {
 					routeResult <- fmt.Errorf("targets returned in wrong order")
 					return
 				}
@@ -301,9 +301,9 @@ func (suite *TestRunnerSuite) TestRouteOutRoutesAllFailedTargets() {
 	// test that all targets are routed in output from a test step are received by
 	// the routing logic and forwarded to the next routing block
 	targets := []*target.Target{
-		&target.Target{Name: "host001", ID: "001", FQDN: "host001.facebook.com"},
-		&target.Target{Name: "host002", ID: "002", FQDN: "host002.facebook.com"},
-		&target.Target{Name: "host003", ID: "003", FQDN: "host003.facebook.com"},
+		{ID: "001", FQDN: "host001.facebook.com"},
+		{ID: "002", FQDN: "host002.facebook.com"},
+		{ID: "003", FQDN: "host003.facebook.com"},
 	}
 
 	terminate := make(chan struct{})
@@ -353,7 +353,7 @@ func (suite *TestRunnerSuite) TestRouteOutRoutesAllFailedTargets() {
 					routeResult <- fmt.Errorf("more targets returned than injected")
 					return
 				}
-				if targetErr.Target.Name != targets[numTargets].Name || targetErr.Target.ID != targets[numTargets].ID {
+				if targetErr.Target.ID != targets[numTargets].ID {
 					routeResult <- fmt.Errorf("targets returned in wrong order")
 					return
 				}

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -7,6 +7,8 @@ package target
 
 import (
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/facebookincubator/contest/pkg/event"
 )
@@ -31,18 +33,36 @@ type ErrPayload struct {
 	Error string
 }
 
-// Target represents a target to run tests on
+// Target represents a target to run tests on.
+// ID is required and must be unique. This is used to identify targets, some storage plugins use it as primary key.
+// Common choices include IDs from inventory management systems, (fully qualified) hostnames, or textual representations of IP addresses.
+// No assumptions about the format of IDs should be made (except being unique and not empty).
+// FQDN, PrimaryIPv4, and PrimaryIPv6 are used by plugins to contact the target, set as many as possible for maximum plugin compatibility.
+// Plugins are generally expected to attempt contacting devices via FQDN, IPv4, and IPv6. Note there is no way to enforce this and more specialized plugins might only support a subset.
 type Target struct {
-	Name string
-	ID   string
-	FQDN string
+	ID string
+    FQDN string
+    PrimaryIPv4, PrimaryIPv6 net.IP
 }
 
 func (t *Target) String() string {
 	if t == nil {
 		return "(*Target)(nil)"
 	}
-	return fmt.Sprintf("Target{Name: \"%s\", ID: \"%s\", FQDN: \"%s\"}", t.Name, t.ID, t.FQDN)
+	var res strings.Builder
+	res.WriteString(fmt.Sprintf("Target{ID: \"%s\"", t.ID))
+	// deref params if they are set, to be more useful than %v
+	if t.FQDN != "" {
+		res.WriteString(fmt.Sprintf(", FQDN: \"%s\"", t.FQDN))
+	}
+	if t.PrimaryIPv4 != nil {
+		res.WriteString(fmt.Sprintf(", PrimaryIPv4: \"%v\"", t.PrimaryIPv4))
+	}
+	if t.PrimaryIPv6 != nil {
+		res.WriteString(fmt.Sprintf(", PrimaryIPv6: \"%v\"", t.PrimaryIPv6))
+	}
+	res.WriteString("}")
+	return res.String()
 }
 
 // FilterTargets - Filter targets from targets based on targetIDs

--- a/pkg/test/parameter_test.go
+++ b/pkg/test/parameter_test.go
@@ -16,37 +16,37 @@ import (
 
 func TestParameterExpand(t *testing.T) {
 	validExprs := [][4]string{
-		// expression, target name, target ID, expected result
-		[4]string{"{{ ToLower .Name }}", "www.slackware.IT", "1234", "www.slackware.it"},
-		[4]string{"{{ .Name }}", "www.slackware.IT", "2345", "www.slackware.IT"},
-		[4]string{"{{ .Name }}", "www.slackware.it", "3456", "www.slackware.it"},
-		[4]string{"name={{ .Name }}, id={{ .ID }}", "blah", "12345", "name=blah, id=12345"},
+		// expression, target FQDN, target ID, expected result
+		[4]string{"{{ ToLower .FQDN }}", "www.slackware.IT", "1234", "www.slackware.it"},
+		[4]string{"{{ .FQDN }}", "www.slackware.IT", "2345", "www.slackware.IT"},
+		[4]string{"{{ .FQDN }}", "www.slackware.it", "3456", "www.slackware.it"},
+		[4]string{"fqdn={{ .FQDN }}, id={{ .ID }}", "blah", "12345", "fqdn=blah, id=12345"},
 	}
 	for _, x := range validExprs {
 		p := NewParam(x[0])
-		res, err := p.Expand(&target.Target{Name: x[1], ID: x[2]})
+		res, err := p.Expand(&target.Target{FQDN: x[1], ID: x[2]})
 		require.NoError(t, err, x[0])
 		require.Equal(t, x[3], res, x[0])
 	}
 }
 
 func TestParameterExpandUserFunctions(t *testing.T) {
-	title := func(a ...string) (string, error) {
+	customFunc := func(a ...string) (string, error) {
 		if len(a) == 0 {
 			return "", errors.New("no params")
 		}
 		return strings.Title(a[0]), nil
 	}
-	err := RegisterFunction("title", title)
+	err := RegisterFunction("CustomFunc", customFunc)
 	require.NoError(t, err)
 	validExprs := [][4]string{
-		// expression, target name, target ID, expected result
-		[4]string{"{{ Title .Name }}", "slackware.it", "1234", "Slackware.It"},
-		[4]string{"{{ Title .ID }}", "slackware.it", "a1234a", "A1234a"},
+		// expression, target FQDN, target ID, expected result
+		[4]string{"{{ CustomFunc .FQDN }}", "slackware.it", "1234", "Slackware.It"},
+		[4]string{"{{ CustomFunc .ID }}", "slackware.it", "a1234a", "A1234a"},
 	}
 	for _, x := range validExprs {
 		p := NewParam(x[0])
-		res, err := p.Expand(&target.Target{Name: x[1], ID: x[2]})
+		res, err := p.Expand(&target.Target{FQDN: x[1], ID: x[2]})
 		require.NoError(t, err, x[0])
 		require.Equal(t, x[3], res, x[0])
 	}

--- a/pkg/test/result.go
+++ b/pkg/test/result.go
@@ -20,7 +20,7 @@ func GetResult(targets map[*target.Target]error, ignore []*target.Target, expres
 		var skip bool
 		for _, ignoreTarget := range ignore {
 			skip = false
-			if *t == *ignoreTarget {
+			if t.ID == ignoreTarget.ID {
 				skip = true
 				break
 			}

--- a/plugins/targetlocker/inmemory/inmemory_test.go
+++ b/plugins/targetlocker/inmemory/inmemory_test.go
@@ -19,8 +19,8 @@ var (
 	jobID      = types.JobID(123)
 	otherJobID = types.JobID(456)
 
-	targetOne  = target.Target{Name: "target001", ID: "001"}
-	targetTwo  = target.Target{Name: "target002", ID: "002"}
+	targetOne  = target.Target{ID: "001"}
+	targetTwo  = target.Target{ID: "002"}
 	oneTarget  = []*target.Target{&targetOne}
 	twoTargets = []*target.Target{&targetOne, &targetTwo}
 )

--- a/plugins/targetlocker/noop/noop_test.go
+++ b/plugins/targetlocker/noop/noop_test.go
@@ -29,11 +29,11 @@ func TestNoopLock(t *testing.T) {
 	require.Nil(t, tl.Lock(jobID, nil))
 	require.Nil(t, tl.Lock(jobID, []*target.Target{}))
 	require.Nil(t, tl.Lock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
+		&target.Target{ID: "blah"},
 	}))
 	require.Nil(t, tl.Lock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
-		&target.Target{Name: "bleh"},
+		&target.Target{ID: "blah"},
+		&target.Target{ID: "bleh"},
 	}))
 }
 
@@ -48,12 +48,12 @@ func TestNoopTryLock(t *testing.T) {
 	_, err = tl.TryLock(jobID, []*target.Target{}, 0)
 	require.Nil(t, err)
 	_, err = tl.TryLock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
+		&target.Target{ID: "blah"},
 	}, 1)
 	require.Nil(t, err)
 	_, err = tl.TryLock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
-		&target.Target{Name: "bleh"},
+		&target.Target{ID: "blah"},
+		&target.Target{ID: "bleh"},
 	}, 2)
 	require.Nil(t, err)
 }
@@ -67,10 +67,10 @@ func TestNoopUnlock(t *testing.T) {
 	require.Nil(t, tl.Unlock(jobID, nil))
 	require.Nil(t, tl.Unlock(jobID, []*target.Target{}))
 	require.Nil(t, tl.Unlock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
+		&target.Target{ID: "blah"},
 	}))
 	require.Nil(t, tl.Unlock(jobID, []*target.Target{
-		&target.Target{Name: "blah"},
-		&target.Target{Name: "bleh"},
+		&target.Target{ID: "blah"},
+		&target.Target{ID: "bleh"},
 	}))
 }

--- a/plugins/targetmanagers/csvtargetmanager/csvfile.go
+++ b/plugins/targetmanagers/csvtargetmanager/csvfile.go
@@ -6,12 +6,14 @@
 // Package csvtargetmanager implements a simple target manager that parses a CSV
 // file. The format of the CSV file is the following:
 //
-// hostname1.example.com,1.2.3.4
-// hostname2,2001:db8::1
+// 123,hostname1.example.com,1.2.3.4,
+// 456,hostname2,,2001:db8::1
 //
-// In other words, two fields: the first containing a host name (fully qualified
-// or not), and the second containin the IP address of the target (this field is
-// optional).
+// In other words, four fields: the first containing a unique ID for the device
+// (might be identical to the IP or FQDN), next one is FQDN,
+// and then IPv4 and IPv6.
+// All fields except ID are optional, but many plugins require FQDN or IP fields to
+// reach the targets over the network.
 package csvtargetmanager
 
 import (
@@ -21,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"os"
 	"strings"
 
@@ -94,7 +97,7 @@ func (tf CSVFileTargetManager) ValidateReleaseParameters(params []byte) (interfa
 }
 
 // Acquire implements contest.TargetManager.Acquire, reading one entry per line
-// from a text file. Each input record has a hostname, a space, and a host ID.
+// from a text file. Each input record looks like this: ID,FQDN,IPv4,IPv6. Only ID is required
 func (tf *CSVFileTargetManager) Acquire(jobID types.JobID, cancel <-chan struct{}, parameters interface{}, tl target.Locker) ([]*target.Target, error) {
 	acquireParameters, ok := parameters.(AcquireParameters)
 	if !ok {
@@ -120,23 +123,40 @@ func (tf *CSVFileTargetManager) Acquire(jobID types.JobID, cancel <-chan struct{
 			// skip blank lines
 			continue
 		}
-		if len(record) != 2 {
-			return nil, errors.New("malformed input file, need exactly two fields per record")
+		if len(record) != 4 {
+			return nil, errors.New("malformed input file, need 4 entries per record (ID, FQDN, IPv4, IPv6)")
 		}
-		name, id := strings.TrimSpace(record[0]), strings.TrimSpace(record[1])
-		if name == "" || id == "" {
-			return nil, errors.New("invalid empty string for host name or host ID")
+		t := &target.Target{ID: strings.TrimSpace(record[0])}
+		if t.ID == "" {
+			return nil, errors.New("invalid empty string for host ID")
 		}
-		// no need to check if there is at least one item, the non-empty string
-		// has been checked already and this will always return at least one
-		// item.
-		firstComponent := strings.Split(name, ".")[0]
+		fqdn := strings.TrimSpace(record[1])
+		if fqdn != "" {
+			// no validation on fqdns
+			t.FQDN = fqdn
+		}
+		if ipv4 := strings.TrimSpace(record[2]); ipv4 != "" {
+			t.PrimaryIPv4 = net.ParseIP(ipv4)
+			if t.PrimaryIPv4 == nil || t.PrimaryIPv4.To4() == nil {
+				// didn't parse
+				return nil, fmt.Errorf("invalid non-empty IPv4 address \"%s\"", ipv4)
+			}
+		}
+		if ipv6 := strings.TrimSpace(record[3]); ipv6 != "" {
+			t.PrimaryIPv6 = net.ParseIP(ipv6)
+			if t.PrimaryIPv6 == nil || t.PrimaryIPv6.To16() == nil {
+				// didn't parse
+				return nil, fmt.Errorf("invalid non-empty IPv6 address \"%s\"", ipv6)
+			}
+		}
 		if len(acquireParameters.HostPrefixes) == 0 {
-			hosts = append(hosts, &target.Target{Name: name, ID: id})
-		} else {
+			hosts = append(hosts, t)
+		} else if t.FQDN != "" {
+			// host prefix filtering only works on devices with a FQDN
+			firstComponent := strings.Split(t.FQDN, ".")[0]
 			for _, hp := range acquireParameters.HostPrefixes {
 				if strings.HasPrefix(firstComponent, hp) {
-					hosts = append(hosts, &target.Target{Name: name, ID: id})
+					hosts = append(hosts, t)
 				}
 			}
 		}

--- a/plugins/targetmanagers/targetlist/targetlist.go
+++ b/plugins/targetmanagers/targetlist/targetlist.go
@@ -59,23 +59,21 @@ type TargetList struct {
 	targets []*target.Target
 }
 
-// ValidateAcquireParameters performs sanity checks on the fields of the
-// parameters that will be passed to Acquire.
+// ValidateAcquireParameters valides parameters that will be passed to Acquire.
 func (t TargetList) ValidateAcquireParameters(params []byte) (interface{}, error) {
 	var ap AcquireParameters
 	if err := json.Unmarshal(params, &ap); err != nil {
 		return nil, err
 	}
 	for _, target := range ap.Targets {
-		if strings.TrimSpace(target.Name) == "" {
-			return nil, errors.New("invalid target with empty name")
+		if strings.TrimSpace(target.ID) == "" {
+			return nil, errors.New("invalid target with empty ID")
 		}
 	}
 	return ap, nil
 }
 
-// ValidateReleaseParameters performs sanity checks on the fields of the
-// parameters that will be passed to Release.
+// ValidateReleaseParameters valides parameters that will be passed to Release.
 func (t TargetList) ValidateReleaseParameters(params []byte) (interface{}, error) {
 	var rp ReleaseParameters
 	if err := json.Unmarshal(params, &rp); err != nil {
@@ -84,8 +82,7 @@ func (t TargetList) ValidateReleaseParameters(params []byte) (interface{}, error
 	return rp, nil
 }
 
-// Acquire implements contest.TargetManager.Acquire, reading one entry per line
-// from a text file. Each input record has a hostname, a space, and a host ID.
+// Acquire implements contest.TargetManager.Acquire
 func (t *TargetList) Acquire(jobID types.JobID, cancel <-chan struct{}, parameters interface{}, tl target.Locker) ([]*target.Target, error) {
 	acquireParameters, ok := parameters.(AcquireParameters)
 	if !ok {

--- a/plugins/teststeps/slowecho/slowecho.go
+++ b/plugins/teststeps/slowecho/slowecho.go
@@ -97,7 +97,7 @@ processing:
 			wg.Add(1)
 			go func(t *target.Target) {
 				defer wg.Done()
-				log.Infof("Waiting %v for target %s", sleep, t.Name)
+				log.Infof("Waiting %v for target %s", sleep, t.ID)
 				select {
 				case <-cancel:
 					log.Infof("Returning because cancellation is requested")

--- a/plugins/teststeps/teststeps_test.go
+++ b/plugins/teststeps/teststeps_test.go
@@ -54,7 +54,7 @@ func TestForEachTargetOneTarget(t *testing.T) {
 		return nil
 	}
 	go func() {
-		d.inCh <- &target.Target{Name: "target001"}
+		d.inCh <- &target.Target{ID: "target001"}
 		// signal end of input
 		d.inCh <- nil
 	}()
@@ -82,7 +82,7 @@ func TestForEachTargetOneTargetAllFail(t *testing.T) {
 		return fmt.Errorf("error with target %+v", t)
 	}
 	go func() {
-		d.inCh <- &target.Target{Name: "target001"}
+		d.inCh <- &target.Target{ID: "target001"}
 		// signal end of input
 		d.inCh <- nil
 	}()
@@ -111,7 +111,7 @@ func TestForEachTargetTenTargets(t *testing.T) {
 	}
 	go func() {
 		for i := 0; i < 10; i++ {
-			d.inCh <- &target.Target{Name: fmt.Sprintf("target%00d", i)}
+			d.inCh <- &target.Target{ID: fmt.Sprintf("target%00d", i)}
 		}
 		// signal end of input
 		d.inCh <- nil
@@ -142,7 +142,7 @@ func TestForEachTargetTenTargetsAllFail(t *testing.T) {
 	}
 	go func() {
 		for i := 0; i < 10; i++ {
-			d.inCh <- &target.Target{Name: fmt.Sprintf("target%00d", i)}
+			d.inCh <- &target.Target{ID: fmt.Sprintf("target%00d", i)}
 		}
 		// signal end of input
 		d.inCh <- nil
@@ -171,14 +171,14 @@ func TestForEachTargetTenTargetsOneFails(t *testing.T) {
 	failingTarget := "target004"
 	fn := func(cancel, pause <-chan struct{}, tgt *target.Target) error {
 		log.Printf("Handling target %+v", tgt)
-		if tgt.Name == failingTarget {
+		if tgt.ID == failingTarget {
 			return fmt.Errorf("error with target %+v", tgt)
 		}
 		return nil
 	}
 	go func() {
 		for i := 0; i < 10; i++ {
-			d.inCh <- &target.Target{Name: fmt.Sprintf("target%03d", i)}
+			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
 		// signal end of input
 		d.inCh <- nil
@@ -189,13 +189,13 @@ func TestForEachTargetTenTargetsOneFails(t *testing.T) {
 			case <-d.done:
 				return
 			case tgt := <-d.outCh:
-				if tgt.Name == failingTarget {
+				if tgt.ID == failingTarget {
 					t.Errorf("Step for target %+v expected to fail but completed successfully instead", tgt)
 				} else {
 					log.Printf("Step for target %+v completed as expected", tgt)
 				}
 			case err := <-d.errCh:
-				if err.Target.Name == failingTarget {
+				if err.Target.ID == failingTarget {
 					log.Printf("Step for target failed as expected: %v", err)
 				} else {
 					t.Errorf("Expected no error but got one: %v", err)
@@ -233,7 +233,7 @@ func TestForEachTargetTenTargetsParallelism(t *testing.T) {
 	numTargets := 10
 	go func() {
 		for i := 0; i < numTargets; i++ {
-			d.inCh <- &target.Target{Name: fmt.Sprintf("target%03d", i)}
+			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
 		// signal end of input
 		d.inCh <- nil
@@ -310,7 +310,7 @@ func TestForEachTargetCancelSignalPropagation(t *testing.T) {
 
 	go func() {
 		for i := 0; i < numTargets; i++ {
-			d.inCh <- &target.Target{Name: fmt.Sprintf("target%03d", i)}
+			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
 		d.inCh <- nil
 	}()
@@ -351,7 +351,7 @@ func TestForEachTargetCancelBeforeInputChannelClosed(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		for i := 0; i < numTargets; i++ {
-			d.inCh <- &target.Target{Name: fmt.Sprintf("target%03d", i)}
+			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
 		wg.Wait() //Don't close the input channel until ForEachTarget returned
 	}()

--- a/tests/integ/events/testevents/common.go
+++ b/tests/integ/events/testevents/common.go
@@ -33,8 +33,8 @@ func populateTestEvents(backend storage.Storage, emitTime time.Time) error {
 	data := []byte("{ 'test_key': 'test_value' }")
 	payload := (*json.RawMessage)(&data)
 
-	testTargetFirst := target.Target{Name: "ATargetName", ID: "ATargetID", FQDN: "AFQDN"}
-	testTargetSecond := target.Target{Name: "BTargetName", ID: "BTargetID", FQDN: "BFQDN"}
+	testTargetFirst := target.Target{ID: "ATargetID", FQDN: "AFQDN"}
+	testTargetSecond := target.Target{ID: "BTargetID", FQDN: "BFQDN"}
 
 	hdrFirst := testevent.Header{JobID: 1, TestName: "ATestName", TestStepLabel: "TestStepLabel"}
 	dataFirst := testevent.Data{EventName: event.Name("AEventName"), Target: &testTargetFirst, Payload: payload}
@@ -61,7 +61,6 @@ func assertTestEvents(t *testing.T, ev []testevent.Event, emitTime time.Time) {
 	assert.Equal(t, "ATestName", ev[0].Header.TestName)
 	assert.Equal(t, "TestStepLabel", ev[0].Header.TestStepLabel)
 	assert.Equal(t, event.Name("AEventName"), ev[0].Data.EventName)
-	assert.Equal(t, "ATargetName", ev[0].Data.Target.Name)
 	assert.Equal(t, "ATargetID", ev[0].Data.Target.ID)
 	assert.Equal(t, payload, ev[0].Data.Payload)
 	assert.Equal(t, emitTime.UTC(), ev[0].EmitTime.UTC())
@@ -71,7 +70,6 @@ func assertTestEvents(t *testing.T, ev []testevent.Event, emitTime time.Time) {
 		assert.Equal(t, "BTestName", ev[1].Header.TestName)
 		assert.Equal(t, "TestStepLabel", ev[1].Header.TestStepLabel)
 		assert.Equal(t, event.Name("BEventName"), ev[1].Data.EventName)
-		assert.Equal(t, "BTargetName", ev[1].Data.Target.Name)
 		assert.Equal(t, "BTargetID", ev[1].Data.Target.ID)
 		assert.Equal(t, payload, ev[1].Data.Payload)
 		assert.Equal(t, emitTime.UTC(), ev[1].EmitTime.UTC())

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -84,11 +84,11 @@ func TestMain(m *testing.M) {
 	}
 	// Setup test Targets and empty parameters
 	targets = []*target.Target{
-		&target.Target{Name: "host001", ID: "001", FQDN: "host001.facebook.com"},
-		&target.Target{Name: "host002", ID: "002", FQDN: "host002.facebook.com"},
-		&target.Target{Name: "host003", ID: "003", FQDN: "host003.facebook.com"},
-		&target.Target{Name: "host004", ID: "004", FQDN: "host004.facebook.com"},
-		&target.Target{Name: "host005", ID: "005", FQDN: "host005.facebook.com"},
+		&target.Target{ID: "001", FQDN: "host001.facebook.com"},
+		&target.Target{ID: "002", FQDN: "host002.facebook.com"},
+		&target.Target{ID: "003", FQDN: "host003.facebook.com"},
+		&target.Target{ID: "004", FQDN: "host004.facebook.com"},
+		&target.Target{ID: "005", FQDN: "host005.facebook.com"},
 	}
 
 	// Configure the storage layer to be in-memory for TestRunner integration tests.

--- a/tests/plugins/targetlocker/dblocker/dblocker_test.go
+++ b/tests/plugins/targetlocker/dblocker/dblocker_test.go
@@ -22,8 +22,8 @@ import (
 var (
 	jobID = types.JobID(123)
 
-	targetOne  = target.Target{Name: "target001", ID: "001"}
-	targetTwo  = target.Target{Name: "target002", ID: "002"}
+	targetOne  = target.Target{ID: "001"}
+	targetTwo  = target.Target{ID: "002"}
 	oneTarget  = []*target.Target{&targetOne}
 	twoTargets = []*target.Target{&targetOne, &targetTwo}
 
@@ -73,7 +73,7 @@ func TestLockInvalidJobIDAndOneTarget(t *testing.T) {
 
 func TestLockValidJobIDAndEmptyIDTarget(t *testing.T) {
 	tl.ResetAllLocks()
-	assert.Error(t, tl.Lock(jobID, []*target.Target{&target.Target{Name: "test", ID: ""}}))
+	assert.Error(t, tl.Lock(jobID, []*target.Target{&target.Target{ID: ""}}))
 }
 
 func TestLockValidJobIDAndOneTarget(t *testing.T) {


### PR DESCRIPTION
### tldr
This changes the fields in the core `Target` struct from `Name, ID, FQDN` to `ID, FQDN, IPv4, IPv6`, with only `ID` required.
As this is a **major, breaking change**, feedback is appreciated.

### Rationale
This aims to solve the following problems with the way targets work at the moment:
- `Target` currently has 3 fields (`Name, ID, FQDN`) without clear rules what should be set and what is optional. This poses a problem for storage/database plugins as there is no obvious primary key. This is addressed by explicitly marking `ID` as the primary target identifier, which is now mandatory and must be unique.
- No well-defined way to store IP addresses. We anticipate most targets to be somehow addressed/controlled/tested via the network. At the moment, the IP might be in either `Name or ID`. This is addressed by explicitly adding `PrimaryIPv6` and `PrimaryIPv4`. We expect this field to be filled most of the time, but it is optional to support environments where DNS lookups are used or targets are not contacted via the IP network.
- Plugins (not targetmanagers) sometimes have to (re)construct `Target` objects for return values and similar. If they know one identifier (like the `ID`), it is unclear if they need to resolve and fill the other values before returning `Target`s. This is partially addressed by explicitly only making `ID`s mandatory. This is not a complete fix on its own, but it allows for one. The new `dblocker` (plugins/targetlocker) for example accepts `Target`s as input, but returns strictly only (`string`) `ID`s
- Comparing targets (and indexing maps with targets) is problematic. Targets might come from different sources (target managers, storages) with no strict guarantees if all the optional fields are filled, leading to surprising equality check results. This is addressed indirectly by adding `net.IP` to `Target`. This type is not comparable, making `Target` comparisons (and indexing) a compile-time error. In most cases this can be trivially replaced by comparing and indexing `Target.ID`

### Scenarios
Here are some environments we try to cover with this rework:
- Large places with inventory management systems. These systems often assign some unique ID to devices. Users can set `ID` to their internal inventory IDs if this is a useful way for lookups, and still have `FQDN` and the `IP` fields free for addressing.
- Hostnames as unique IDs. Either short names or fully qualified. Users should put their hostnames in both the `ID` and `FQDN` fields, and fill the `IP` fields if possible/useful.
- IP addresses as primary IDs. Users should put a normalised(!) textual representation into the `ID` field and also fill the matching `IP` field. `FQDN` can be filled as required.
- Not IP-addressable test devices. We expect this to be rare, but it is supported. If whatever serves as address is unique, it can be put it in `ID`. Since many built-in plugins like `SSH` can't be used anyway, the `FQDN` field can be used as a secondary string if absolutely necessary.

**If you have a usecase that is not covered, please reach out!**

### Not addressed here
- There was, and still is, ambiguity on how to contact a device on the network. Plugins must choose between `FQDN`, `PrimaryIPv6` and `PrimaryIPv4`. Note this problem existed before as well. Ideally, generic tests steps like SSH support all of them, while custom plugins are free to only support one/some, as they are only used in specific environments.

### Known breakage caused by this change
- `CSVFileTargetManager`: Format changed from `Name, ID` to `ID, FQDN, IPv6, IPv4`
- `TargetList`: This unmarshals `Target` structs from acquire parameters, they need to be updated (`Name, ID, FQDN` to `ID, Name, PrimaryIPv6, PrimaryIPv4`)
- Some custom `TestStep` implementations that use `Name`
- `Target` can no longer be compared, might break status struct comparisons with embedded `Targets` in some clients (TODO investigate)


### Open questions (*cough* feedback *cough*)
- `test_events` in the main storage (rdbms) plugin currently stores `target_id` and `target_name`. Should this be normalised to only store `target_id`. Does this need a new `targets` table for full event reconstruction for job resumption? (leaning towards only store id in this PR, introduce the targets table with another one related to resumption)
- `Target.ID` is of type `string`. Is this ok or should we declare a custom type?
- `Target.FQDN` is of type `*string`. The idea was to have it point to `ID` for environments where FQDNs are used as primary IDs. However, this is the only pointer in `Target`, assigning it inline can be a bit cumbersome. Should it just be `string` as well, as the memory impact will be minimal? (Leaning towards yes, make it `string`)
- (Semi-related, only mentioned because we are already refactoring this entire thing) Storage plugins will often enforce some length limit on the `ID`, `FQDN` fields. There is currently no way to express/validate targets before going to the storage layer.

