### PR TITLE
plugins/targetmanager: Add Retries to Locking within CSVTargetManager

### DIFF
--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -56,6 +56,7 @@ func FilterTargets(targetIDs []string, targets []*Target) ([]*Target, error) {
 			if target.ID == targetID {
 				targetList = append(targetList, target)
 				found = true
+				break
 			}
 		}
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -44,3 +44,25 @@ func (t *Target) String() string {
 	}
 	return fmt.Sprintf("Target{Name: \"%s\", ID: \"%s\", FQDN: \"%s\"}", t.Name, t.ID, t.FQDN)
 }
+
+// FilterTargets - Filter targets from targets based on targetIDs
+func FilterTargets(targetIDs []string, targets []*Target) ([]*Target, error) {
+
+	var targetList []*Target
+
+	for _, targetID := range targetIDs {
+		found := false
+		for _, target := range targets {
+			if target.ID == targetID {
+				targetList = append(targetList, target)
+				found = true
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("unable to match target id %s to target", targetID)
+		}
+	}
+
+	return targetList, nil
+}

--- a/plugins/targetlocker/inmemory/inmemory.go
+++ b/plugins/targetlocker/inmemory/inmemory.go
@@ -189,7 +189,7 @@ func (tl *InMemory) Lock(jobID types.JobID, targets []*target.Target) error {
 
 // Lock locks the specified targets.
 func (tl *InMemory) TryLock(jobID types.JobID, targets []*target.Target, limit uint) ([]string, error) {
-	log.Infof("Trying to trylock %d targets", len(targets))
+	log.Infof("Trying to trylock on %d targets", len(targets))
 	req := newReq(jobID, targets)
 	req.timeout = tl.lockTimeout
 	req.allowConflicts = true

--- a/plugins/targetlocker/inmemory/inmemory.go
+++ b/plugins/targetlocker/inmemory/inmemory.go
@@ -189,7 +189,7 @@ func (tl *InMemory) Lock(jobID types.JobID, targets []*target.Target) error {
 
 // Lock locks the specified targets.
 func (tl *InMemory) TryLock(jobID types.JobID, targets []*target.Target, limit uint) ([]string, error) {
-	log.Infof("Trying to trylock on %d targets", len(targets))
+	log.Infof("Trying trylock on %d targets", len(targets))
 	req := newReq(jobID, targets)
 	req.timeout = tl.lockTimeout
 	req.allowConflicts = true

--- a/plugins/targetmanagers/csvtargetmanager/csvfile.go
+++ b/plugins/targetmanagers/csvtargetmanager/csvfile.go
@@ -160,7 +160,7 @@ func (tf *CSVFileTargetManager) Acquire(jobID types.JobID, cancel <-chan struct{
 	// feed all devices into new API call `TryLock`, with desired limit
 	lockedString, err := tl.TryLock(jobID, hosts, uint(acquireParameters.MaxNumberDevices))
 	if err != nil {
-		return nil, fmt.Errorf("can't lock enough targets")
+		return nil, fmt.Errorf("failed to lock targets: %w", err)
 	}
 	locked, err := target.FilterTargets(lockedString, hosts)
 	if err != nil {


### PR DESCRIPTION
This adds retry-mechanism to the CSVTargetManager. We do shuffle and
retry locking the targets three times.

Signed-off-by: Christian Walter <christian.walter@9elements.com>