### PR TITLE
Add missing comment from previous PR

### DIFF
--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -64,9 +64,13 @@ type eventCmdStderrPayload struct {
 
 // Cmd is used to run arbitrary commands as test steps.
 type Cmd struct {
-	executable             string
-	args                   []test.Param
-	dir                    *test.Param
+	executable string
+	args       []test.Param
+	dir        *test.Param
+	// warning: if you enable emit_stdout and emit_stderr in your plugin
+	// configuration, be aware that the emitted payload is saved to the
+	// ConTest database, and that it might be a very long string. Depending on
+	// the output length, it could be truncated in order to store it.
 	emitStdout, emitStderr bool
 }
 


### PR DESCRIPTION
In https://github.com/facebookincubator/contest/pull/189 I said I'd
update the comment about lengthy output and DB truncation, but I failed
to update the PR. Doing it now.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>