### PR TITLE
[db][migration] Improve extended descriptor migration

### DIFF
--- a/tests/plugins/targetlocker/dblocker/dblocker_test.go
+++ b/tests/plugins/targetlocker/dblocker/dblocker_test.go
@@ -140,7 +140,6 @@ func TestLockUnlockDifferentJobID(t *testing.T) {
 	assert.Error(t, tl.Lock(jobID+1, twoTargets))
 }
 
-
 func TestTryLockOne(t *testing.T) {
 	tl.ResetAllLocks()
 	res, err := tl.TryLock(jobID, oneTarget, 1)

--- a/tools/migration/rdbms/migrate/migrate.go
+++ b/tools/migration/rdbms/migrate/migrate.go
@@ -15,6 +15,8 @@ import (
 type Migrate interface {
 	Up(tx *sql.Tx) error
 	Down(tx *sql.Tx) error
+	UpNoTx(db *sql.DB) error
+	DownNoTx(db *sql.DB) error
 }
 
 // Factory defines a factory type of an object implementing Migration interface


### PR DESCRIPTION
A significant limitation of the library we use for db migrations is
that a migration can run only within a transaction. This doesn't scale
for large migrations. This patch introduces an interface to run a
migration outside of a `*sql.Tx`. The actual tool which invokes the
migration does not support running the transaction within `*sql.DB` yet:
we either need to add support to the upstream library, or move to a
custom implementation.

In addition, this patch modifies extended descriptor migration to run
batch update queries. The batch and single row implementations were
tested against ~95k records and resulted in roughly the following
numbers:
* Batch update (shard size 50): 4m26s
* Single row update (shard size 50): 5m51s