### PR TITLE
[storage] Enforce the desired db version

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -48,7 +48,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("could not initialize database: %v", err)
 	}
-	storage.SetStorage(s)
+	if err := storage.SetStorage(s); err != nil {
+		log.Fatalf("could not set storage: %v", err)
+	}
 
 	dbVer, err := s.Version()
 	if err != nil {

--- a/pkg/config/storage.go
+++ b/pkg/config/storage.go
@@ -1,0 +1,9 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package config
+
+// MinStorageVersion defines the minimum requires version that contest can run on
+const MinStorageVersion = 0

--- a/pkg/runner/test_runner_route_test.go
+++ b/pkg/runner/test_runner_route_test.go
@@ -97,7 +97,8 @@ func (suite *TestRunnerSuite) SetupTest() {
 
 	s, err := memory.New()
 	require.NoError(suite.T(), err)
-	storage.SetStorage(s)
+	err = storage.SetStorage(s)
+	require.NoError(suite.T(), err)
 
 	header := testevent.Header{
 		JobID:         1,

--- a/pkg/storage/events.go
+++ b/pkg/storage/events.go
@@ -77,7 +77,7 @@ func NewTestEventEmitterFetcher(header testevent.Header) testevent.EmitterFetche
 	}
 }
 
-// NewTestEventEmitterFetcher creates a new EmitterFetcher object associated with a Header
+// NewTestEventEmitterFetcherWithAllowedEvents creates a new EmitterFetcher object associated with a Header
 func NewTestEventEmitterFetcherWithAllowedEvents(header testevent.Header, allowedEvents *map[event.Name]bool) testevent.EmitterFetcher {
 	return TestEventEmitterFetcher{
 		TestEventEmitter{header: header},

--- a/pkg/storage/events_test.go
+++ b/pkg/storage/events_test.go
@@ -6,6 +6,7 @@
 package storage
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -54,12 +55,14 @@ func (n *nullStorage) GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]fra
 	return nil, nil
 }
 
-func (m *nullStorage) Version() (int64, error) {
+func (n *nullStorage) Version() (uint64, error) {
 	return 0, nil
 }
 
 func TestMain(m *testing.M) {
-	SetStorage(&nullStorage{})
+	if err := SetStorage(&nullStorage{}); err != nil {
+		panic(fmt.Sprintf("could not configure storage: %v", err))
+	}
 	os.Exit(m.Run())
 }
 

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -220,7 +220,7 @@ func (m *Memory) GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]framewor
 }
 
 // Version returns the version of the memory storage layer.
-func (m *Memory) Version() (int64, error) {
+func (m *Memory) Version() (uint64, error) {
 	return 0, nil
 }
 

--- a/plugins/storage/rdbms/init.go
+++ b/plugins/storage/rdbms/init.go
@@ -122,11 +122,8 @@ func (r *RDBMS) Rollback() error {
 }
 
 // Version returns the current version of the RDBMS schema
-func (r *RDBMS) Version() (int64, error) {
-	if sqlDB, ok := r.db.(*sql.DB); ok {
-		return migrationlib.DBVersion(sqlDB)
-	}
-	return 0, fmt.Errorf("db object (%T) is not a sql.DB", r.db)
+func (r *RDBMS) Version() (uint64, error) {
+	return migrationlib.DBVersion(r.db)
 }
 
 func (r *RDBMS) init() error {

--- a/tests/integ/events/testevents/testevents_memory_test.go
+++ b/tests/integ/events/testevents/testevents_memory_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/facebookincubator/contest/pkg/storage"
 	"github.com/facebookincubator/contest/plugins/storage/memory"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,7 +26,8 @@ func TestTestEventsSuiteMemoryStorage(t *testing.T) {
 		panic(fmt.Sprintf("could not initialize in-memory storage layer: %v", err))
 	}
 	testSuite.storage = storagelayer
-	storage.SetStorage(storagelayer)
+	err = storage.SetStorage(storagelayer)
+	require.NoError(t, err)
 
 	suite.Run(t, &testSuite)
 }

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -222,7 +222,8 @@ func (suite *TestJobManagerSuite) SetupTest() {
 	suite.sigs = sigs
 
 	suite.txStorage = common.InitStorage(suite.storage)
-	storage.SetStorage(suite.txStorage)
+	err = storage.SetStorage(suite.txStorage)
+	require.NoError(suite.T(), err)
 }
 
 func (suite *TestJobManagerSuite) TearDownTest() {

--- a/tests/integ/jobmanager/jobmanager_memory_test.go
+++ b/tests/integ/jobmanager/jobmanager_memory_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/facebookincubator/contest/plugins/storage/memory"
 	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -30,7 +31,8 @@ func TestJobManagerSuiteMemoryStorage(t *testing.T) {
 
 	}
 	testSuite.storage = storagelayer
-	storage.SetStorage(storagelayer)
+	err = storage.SetStorage(storagelayer)
+	require.NoError(t, err)
 
 	targetLocker := inmemory.New(10*time.Second, 10*time.Second)
 	target.SetLocker(targetLocker)

--- a/tests/integ/jobmanager/jobmanager_rdbms_test.go
+++ b/tests/integ/jobmanager/jobmanager_rdbms_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 	"github.com/facebookincubator/contest/tests/integ/common"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -32,7 +33,8 @@ func TestJobManagerSuiteRdbmsStorage(t *testing.T) {
 	if err != nil {
 		panic(fmt.Sprintf("could not initialize rdbms storage layer: %v", err))
 	}
-	storage.SetStorage(storageLayer)
+	err = storage.SetStorage(storageLayer)
+	require.NoError(t, err)
 	testSuite.storage = storageLayer
 
 	targetLocker := inmemory.New(10*time.Second, 10*time.Second)

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -97,7 +97,10 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("could not initialize in-memory storage layer: %v", err))
 	}
-	storage.SetStorage(s)
+	err = storage.SetStorage(s)
+	if err != nil {
+		panic(fmt.Sprintf("could not set storage memory layer: %v", err))
+	}
 
 	os.Exit(m.Run())
 }

--- a/tests/plugins/targetlocker/dblocker/dblocker_test.go
+++ b/tests/plugins/targetlocker/dblocker/dblocker_test.go
@@ -140,7 +140,6 @@ func TestLockUnlockDifferentJobID(t *testing.T) {
 	assert.Error(t, tl.Lock(jobID+1, twoTargets))
 }
 
-
 func TestTryLockOne(t *testing.T) {
 	tl.ResetAllLocks()
 	res, err := tl.TryLock(jobID, oneTarget, 1)

--- a/tools/migration/rdbms/migrationlib/version.go
+++ b/tools/migration/rdbms/migrationlib/version.go
@@ -6,11 +6,78 @@
 package migrationlib
 
 import (
+	"fmt"
+
 	"database/sql"
+	"github.com/go-sql-driver/mysql"
 	"github.com/pressly/goose"
 )
 
-// DBVersion returns the current version of the database schema
-func DBVersion(db *sql.DB) (int64, error) {
-	return goose.GetDBVersion(db)
+// queryExecutor represents the MCD interface between sql.Db and sql.Tx
+// objects that is sufficient to retrieve the db version number.
+type queryExecutor interface {
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}
+
+// DBVersion returns the current version of the database schema.
+// The library exposes a GetDBVersion function which however requires
+// a *sql.Db object. Several contest flows work instead within a
+// transactional context, so we need to be able to extract the version
+// in a way that is agnostic to the `sql` object used (either `sql.Tx` or
+// `sql.Db`).
+func DBVersion(db queryExecutor) (uint64, error) {
+
+	rows, err := db.Query(fmt.Sprintf("select version_id, is_applied from %s order by id desc", goose.TableName()))
+	if err != nil {
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
+			if mysqlErr.Number == 1146 {
+				// db versioning table does not exist, assume version 0
+				return 0, nil
+			}
+		}
+		return 0, fmt.Errorf("could not retrieve db version, error %+v, %T: %w", err, err, err)
+	}
+	defer rows.Close()
+
+	toSkip := make([]uint64, 0)
+
+	for rows.Next() {
+		var (
+			versionID uint64
+			isApplied bool
+		)
+		if err = rows.Scan(&versionID, &isApplied); err != nil {
+			return 0, fmt.Errorf("could not scan row: %w", err)
+		}
+
+		// the is_applied field tracks whether the migration was an
+		// up or down migration. If we see a down migration, while
+		// going through the records in descending order, then we
+		// should skip that version altogether.
+		skip := false
+		for _, v := range toSkip {
+			if v == versionID {
+				skip = true
+				break
+			}
+		}
+
+		if skip {
+			continue
+		}
+
+		if isApplied {
+			return versionID, nil
+		}
+
+		// latest version of migration has not been applied.
+		toSkip = append(toSkip, versionID)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("could not retrieve db version: %w", err)
+	}
+
+	// if we couldn't figure out the db version, assume we are working on version 0
+	// i.e. the db is not versioned yet.
+	return 0, nil
 }


### PR DESCRIPTION
We started tracking the db schema version. The code will have a
hard dependency on a specific schema version being available, so
we should fail any attempt to set a storage backend if its advertised
schema version does not match the requirements of core ConTest storage
pkg..

For all those instances for which schema versioning is not in place yet
(e.g. schema is v0, so the reference baseline), reported version will
be 0. This patch sets the minimum schema version to 0, so it will allow
any backend version.