### PR TITLE
[db][migration] Fix bad connection in transaction when testing migrations

### DIFF
--- a/tests/integ/migration/0002_migrate_descriptor_to_extended_descriptor_test.go
+++ b/tests/integ/migration/0002_migrate_descriptor_to_extended_descriptor_test.go
@@ -90,6 +90,7 @@ func (suite *TestDescriptorMigrationSuite) TestUpMigratesToExtendedDescriptor() 
 	// fetching extended descriptor and unmarshalling it into ExtendedDescriptor structure
 	selectStatement := "select extended_descriptor from jobs"
 	rows, err := suite.tx.Query(selectStatement)
+	defer rows.Close()
 
 	require.NoError(suite.T(), err)
 


### PR DESCRIPTION
Missing Close() on rows results in failure to issue multiple queries
within the same transaction.