### PR TITLE
Use marshal-able embedded error in ErrorEventPayload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/insomniacslk/termhook v0.0.0-20190716141402-454368e885ec
-	github.com/insomniacslk/xjson v0.0.0-20190510162823-f016a4991179
+	github.com/insomniacslk/xjson v0.0.0-20210105111737-0de92d6adda5
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/insomniacslk/termhook v0.0.0-20190716141402-454368e885ec h1:5+0mqILIF
 github.com/insomniacslk/termhook v0.0.0-20190716141402-454368e885ec/go.mod h1:8eGC3NZFqSFxpbWduqdoolXfuhN3K8KH9wMmldc3sYs=
 github.com/insomniacslk/xjson v0.0.0-20190510162823-f016a4991179 h1:/chUAu1Yt4ipW2AHtRdVwc3ua1REYuq9+Dnzl0zvK1Y=
 github.com/insomniacslk/xjson v0.0.0-20190510162823-f016a4991179/go.mod h1:G8c61yEjNgzQNF0lOvul8ls5IHE/MxbGx7M98ADBVEA=
+github.com/insomniacslk/xjson v0.0.0-20210105111737-0de92d6adda5 h1:SwY4nNgXJQAj1AyWTHVp1DYt+qe0rZs33gNlCDLiLz0=
+github.com/insomniacslk/xjson v0.0.0-20210105111737-0de92d6adda5/go.mod h1:G8c61yEjNgzQNF0lOvul8ls5IHE/MxbGx7M98ADBVEA=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -15,6 +15,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/insomniacslk/xjson"
+
 	"github.com/facebookincubator/contest/pkg/api"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
@@ -36,7 +38,7 @@ var cancellationTimeout = 60 * time.Second
 
 // ErrorEventPayload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
 type ErrorEventPayload struct {
-	Err string
+	Err xjson.Error
 }
 
 // JobManager is the core component for the long-running job management service.
@@ -417,7 +419,7 @@ func (jm *JobManager) emitErrEvent(jobID types.JobID, eventName event.Name, err 
 	)
 	if err != nil {
 		log.Errorf(err.Error())
-		payload := ErrorEventPayload{Err: err.Error()}
+		payload := ErrorEventPayload{Err: xjson.NewError(err)}
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
 			log.Warningf("Could not serialize payload for event %s: %v", eventName, err)

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -83,7 +83,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 				if err := json.Unmarshal(*je.Payload, &ep); err != nil {
 					stateErrMsg = fmt.Sprintf("internal error: EventJobFailed's payload cannot be unmarshalled. Raw payload: %s, Error: %v", *je.Payload, err)
 				} else {
-					stateErrMsg = ep.Err
+					stateErrMsg = ep.Err.Error()
 				}
 			}
 		}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the


### PR DESCRIPTION
Closes https://github.com/facebookincubator/contest/issues/111 

It can likely be accomplished with implementing MarshalJson() directly on error interface, yet I'm hesitant to augment a base type.

Kudos for making tests easy to run! :pray: 