### PR TITLE
Implement context inheritance and cancel/pause signals propagation for statectx.Context

### DIFF
--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -201,7 +201,7 @@ func newPartialJobFromDescriptor(pr *pluginregistry.PluginRegistry, jd *job.JobD
 		FinalReporterBundles: nil,
 	}
 
-	j.StateCtx, j.StateCtxPause, j.StateCtxCancel = statectx.NewContext()
+	j.StateCtx, j.StateCtxPause, j.StateCtxCancel = statectx.New()
 	return &j, nil
 }
 

--- a/pkg/statectx/cancel_context.go
+++ b/pkg/statectx/cancel_context.go
@@ -8,10 +8,11 @@ import (
 	"time"
 )
 
-func newCancelContext() (context.Context, func(err error)) {
+func newCancelContext(ctx context.Context) (context.Context, func(err error)) {
 	result := &cancelContext{
 		done: make(chan struct{}),
 	}
+	result.propagateCancel(ctx)
 	return result, func(err error) {
 		result.cancel(err)
 	}
@@ -21,6 +22,9 @@ type cancelContext struct {
 	mu   sync.Mutex
 	err  error
 	done chan struct{}
+
+	parent   *cancelContext
+	children map[*cancelContext]struct{} // set to nil by the first cancel call
 }
 
 func (*cancelContext) Deadline() (deadline time.Time, ok bool) {
@@ -43,15 +47,97 @@ func (c *cancelContext) Err() error {
 }
 
 func (c *cancelContext) cancel(err error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	internalRelease := func(err error) (*cancelContext, []*cancelContext) {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		select {
+		case <-c.done:
+			return nil, nil // already canceled
+		default:
+		}
+
+		children := make([]*cancelContext, 0, len(c.children))
+		for c := range c.children {
+			children = append(children, c)
+		}
+		c.children = nil
+
+		parent := c.parent
+		c.parent = nil
+
+		c.err = err
+		close(c.done)
+
+		return parent, children
+	}
+
+	parent, children := internalRelease(err)
+
+	// unsubscribe from parent
+	if parent != nil {
+		func() {
+			parent.mu.Lock()
+			defer parent.mu.Unlock()
+
+			if parent.children == nil {
+				return
+			}
+			delete(parent.children, c)
+		}()
+	}
+
+	// propagate cancel to children
+	for _, ch := range children {
+		ch.cancel(err)
+	}
+}
+
+func (c *cancelContext) propagateCancel(parent context.Context) {
+	done := parent.Done()
+	if done == nil {
+		return // parent is never canceled
+	}
 
 	select {
-	case <-c.done:
-		return // already canceled
+	case <-done:
+		// parent is already canceled
+		c.cancel(parent.Err())
+		return
 	default:
 	}
 
-	c.err = err
-	close(c.done)
+	// Creating extra-goroutines is bad because it requires either invoking cancel by parent or child context
+	if cc, ok := parent.(*cancelContext); ok {
+		c.parent = cc
+		subscribe := func() bool {
+			cc.mu.Lock()
+			defer cc.mu.Unlock()
+
+			select {
+			case <-cc.done:
+				// parent is already canceled
+				return false
+			default:
+			}
+
+			if cc.children == nil {
+				cc.children = make(map[*cancelContext]struct{})
+			}
+			cc.children[c] = struct{}{}
+			return true
+		}
+
+		if !subscribe() {
+			c.cancel(parent.Err())
+		}
+	} else {
+		go func() {
+			select {
+			case <-parent.Done():
+				c.cancel(parent.Err())
+			case <-c.Done():
+			}
+		}()
+	}
 }

--- a/pkg/statectx/cancel_context_test.go
+++ b/pkg/statectx/cancel_context_test.go
@@ -1,0 +1,80 @@
+package statectx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancellation(t *testing.T) {
+	ctx, cancel := newCancelContext(context.Background())
+	require.NotNil(t, ctx)
+	require.NotNil(t, cancel)
+
+	var blocked bool
+	select {
+	case <-ctx.Done():
+		blocked = true
+	default:
+	}
+	require.False(t, blocked)
+
+	cancel(ErrCanceled)
+	<-ctx.Done()
+	require.Equal(t, ErrCanceled, ctx.Err())
+
+	// further cancels do not affect the error code
+	cancel(ErrPaused)
+	require.Equal(t, ErrCanceled, ctx.Err())
+}
+
+func TestAbstractParentContext(t *testing.T) {
+	parCtx, parCancel := context.WithCancel(context.Background())
+	ctx, cancel := newCancelContext(parCtx)
+
+	parCancel()
+	<-ctx.Done()
+	require.Equal(t, context.Canceled, ctx.Err())
+
+	cancel(ErrPaused)
+	require.Equal(t, context.Canceled, ctx.Err())
+}
+
+func TestCancelContextAsParentContext(t *testing.T) {
+	t.Run("parent_cancel_propagated", func(t *testing.T) {
+		parCtx, parCancel := newCancelContext(context.Background())
+		ctx, cancel := newCancelContext(parCtx)
+
+		parCancel(ErrCanceled)
+		<-ctx.Done()
+		require.Equal(t, ErrCanceled, ctx.Err())
+
+		parCancel(ErrPaused)
+		cancel(ErrPaused)
+		require.Equal(t, ErrCanceled, ctx.Err())
+	})
+
+	t.Run("child_cancel_does_not_affect_parent", func(t *testing.T) {
+		parCtx, parCancel := newCancelContext(context.Background())
+		ctx, cancel := newCancelContext(parCtx)
+
+		cancel(ErrCanceled)
+		<-ctx.Done()
+		require.Equal(t, ErrCanceled, ctx.Err())
+
+		var blocked bool
+		select {
+		case <-parCtx.Done():
+			blocked = true
+		default:
+		}
+		require.False(t, blocked)
+		require.Nil(t, parCtx.Err())
+
+		parCancel(ErrPaused)
+		<-parCtx.Done()
+		require.Equal(t, ErrPaused, parCtx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
+	})
+}

--- a/pkg/statectx/context_test.go
+++ b/pkg/statectx/context_test.go
@@ -1,25 +1,39 @@
 package statectx
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+func TestBackgroundContext(t *testing.T) {
+	ctx := Background()
+
+	var blocked bool
+	select {
+	case <-time.After(5 * time.Microsecond):
+		blocked = true
+	case <-ctx.Done():
+	case <-ctx.PausedOrDone():
+	case <-ctx.Paused():
+	}
+
+	require.True(t, blocked)
+	require.Nil(t, ctx.Err())
+	require.Nil(t, ctx.PausedCtx().Err())
+	require.Nil(t, ctx.PausedOrDoneCtx().Err())
+}
+
 func TestContextBlocked(t *testing.T) {
-	ctx, _, _ := NewContext()
+	ctx, _, _ := New()
 	require.NotNil(t, ctx)
 
 	require.NoError(t, ctx.Err())
 
-	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 10*time.Microsecond)
-	defer timeoutCancel()
-
 	var blockedOnDone bool
 	select {
-	case <-timeoutCtx.Done():
+	case <-time.After(5 * time.Microsecond):
 		blockedOnDone = true
 	case <-ctx.Done():
 	case <-ctx.PausedOrDone():
@@ -33,7 +47,7 @@ func TestContextBlocked(t *testing.T) {
 }
 
 func TestContextCanceled(t *testing.T) {
-	ctx, _, cancel := NewContext()
+	ctx, _, cancel := New()
 	require.NotNil(t, ctx)
 
 	cancel()
@@ -55,7 +69,7 @@ func TestContextCanceled(t *testing.T) {
 }
 
 func TestContextPaused(t *testing.T) {
-	ctx, pause, _ := NewContext()
+	ctx, pause, _ := New()
 	require.NotNil(t, ctx)
 
 	pause()
@@ -77,7 +91,7 @@ func TestContextPaused(t *testing.T) {
 }
 
 func TestMultipleCancelPause(t *testing.T) {
-	ctx, pause, cancel := NewContext()
+	ctx, pause, cancel := New()
 	require.NotNil(t, ctx)
 
 	pause()
@@ -92,4 +106,49 @@ func TestMultipleCancelPause(t *testing.T) {
 	require.Equal(t, ErrCanceled, ctx.Err())
 	require.Equal(t, ErrPaused, ctx.PausedCtx().Err())
 	require.Equal(t, ErrPaused, ctx.PausedOrDoneCtx().Err())
+}
+
+func TestWithParent(t *testing.T) {
+	t.Run("pause_propagated", func(t *testing.T) {
+		parentCtx, parentPause, _ := New()
+		childCtx, _, _ := WithParent(parentCtx)
+
+		parentPause()
+		<-childCtx.Paused()
+		require.Equal(t, ErrPaused, childCtx.PausedCtx().Err())
+		<-childCtx.PausedOrDone()
+		require.Equal(t, ErrPaused, childCtx.PausedOrDoneCtx().Err())
+
+		require.Nil(t, childCtx.Err())
+	})
+	t.Run("cancel_propagated", func(t *testing.T) {
+		parentCtx, _, parentCancel := New()
+		childCtx, _, _ := WithParent(parentCtx)
+
+		parentCancel()
+		<-childCtx.Done()
+		require.Equal(t, ErrCanceled, childCtx.Err())
+		<-childCtx.PausedOrDone()
+		require.Equal(t, ErrCanceled, childCtx.PausedOrDoneCtx().Err())
+
+		require.Nil(t, childCtx.PausedCtx().Err())
+	})
+	t.Run("child_pause_cancel_do_not_affect_parent", func(t *testing.T) {
+		parentCtx, _, _ := New()
+		_, childPause, childCancel := WithParent(parentCtx)
+
+		childPause()
+		childCancel()
+
+		var blocked bool
+		select {
+		case <-parentCtx.Done():
+		case <-parentCtx.Paused():
+		case <-parentCtx.PausedOrDone():
+		default:
+			blocked = true
+		}
+
+		require.True(t, blocked)
+	})
 }

--- a/tests/integ/test/testrunner_test.go
+++ b/tests/integ/test/testrunner_test.go
@@ -126,7 +126,7 @@ func TestSuccessfulCompletion(t *testing.T) {
 	}
 
 	errCh := make(chan error, 1)
-	stateCtx, _, _ := statectx.NewContext()
+	stateCtx, _, _ := statectx.New()
 
 	go func() {
 		tr := runner.NewTestRunner()
@@ -158,7 +158,7 @@ func TestPanicStep(t *testing.T) {
 	}
 
 	errCh := make(chan error, 1)
-	stateCtx, _, _ := statectx.NewContext()
+	stateCtx, _, _ := statectx.New()
 
 	go func() {
 		tr := runner.NewTestRunner()
@@ -189,7 +189,7 @@ func TestNoReturnStepWithCorrectTargetForwarding(t *testing.T) {
 		test.TestStepBundle{TestStep: ts2, Parameters: params, TestStepLabel: "Example"},
 	}
 
-	stateCtx, _, _ := statectx.NewContext()
+	stateCtx, _, _ := statectx.New()
 	errCh := make(chan error, 1)
 
 	timeouts := runner.TestRunnerTimeouts{
@@ -232,7 +232,7 @@ func TestNoReturnStepWithoutTargetForwarding(t *testing.T) {
 		test.TestStepBundle{TestStep: ts2, TestStepLabel: "StageTwo", Parameters: params},
 	}
 
-	stateCtx, _, cancel := statectx.NewContext()
+	stateCtx, _, cancel := statectx.New()
 	errCh := make(chan error, 1)
 
 	var (
@@ -294,7 +294,7 @@ func TestStepClosesChannels(t *testing.T) {
 		test.TestStepBundle{TestStep: ts2, TestStepLabel: "StageTwo", Parameters: params},
 	}
 
-	stateCtx, _, _ := statectx.NewContext()
+	stateCtx, _, _ := statectx.New()
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -335,7 +335,7 @@ func TestCmdPlugin(t *testing.T) {
 		test.TestStepBundle{TestStep: ts1, Parameters: params},
 	}
 
-	stateCtx, _, cancel := statectx.NewContext()
+	stateCtx, _, cancel := statectx.New()
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -372,7 +372,7 @@ func TestNoRunTestStepIfNoTargets(t *testing.T) {
 		{TestStep: ts2, TestStepLabel: "StageTwo", Parameters: params},
 	}
 
-	stateCtx, _, _ := statectx.NewContext()
+	stateCtx, _, _ := statectx.New()
 	errCh := make(chan error, 1)
 
 	go func() {


### PR DESCRIPTION
Runner is required to make statectx.Context that it provides to its teststeps and it needs to propagate cancel/pause signals that it takes as a statectx.Context from contest