### PR TITLE
actually run all integration tests

### DIFF
--- a/docker/contest/tests.sh
+++ b/docker/contest/tests.sh
@@ -51,7 +51,7 @@ done
 # Run integration tests collecting coverage only for the business logic (pkg directory)
 for tag in integration integration_storage; do
     echo "Running integration tests with tag \"${tag}\""
-    for d in $(go list -tags=${tag} ./... | grep integ | grep -Ev "integ$|common$|vendor"); do
+    for d in $(go list -tags=${tag} ./tests/... | grep -Ev "integ$|common$|vendor"); do
         pflag=""
         if test ${tag} = "integration_storage"; then
           # Storage tests are split across TestSuites in multiple packages. Within a TestSuite,


### PR DESCRIPTION
Turns out we were not running a good chunk of the integration and integration_storage tests :D

## Before:
```
tfleig@tfleig-mbp contest % for tag in integration integration_storage; do
    echo "Running integration tests with tag \"${tag}\""
    for d in $(go list -tags=${tag} ./... | grep integ | grep -Ev "integ$|common$|vendor"); do
       echo $d
    done
done
Running integration tests with tag "integration"
github.com/facebookincubator/contest/tests/integ/events/frameworkevents
github.com/facebookincubator/contest/tests/integ/events/testevents
github.com/facebookincubator/contest/tests/integ/job
github.com/facebookincubator/contest/tests/integ/jobmanager
github.com/facebookincubator/contest/tests/integ/migration
github.com/facebookincubator/contest/tests/integ/test
Running integration tests with tag "integration_storage"
github.com/facebookincubator/contest/tests/integ/events/frameworkevents
github.com/facebookincubator/contest/tests/integ/events/testevents
github.com/facebookincubator/contest/tests/integ/job
github.com/facebookincubator/contest/tests/integ/jobmanager
github.com/facebookincubator/contest/tests/integ/migration
tfleig@tfleig-mbp contest %
```

## Now:
```
tfleig@tfleig-mbp contest % for tag in integration integration_storage; do
    echo "Running integration tests with tag \"${tag}\""
    for d in $(go list -tags=${tag} ./tests/... | grep -Ev "integ$|common$|vendor"); do
       echo $d
    done
done
Running integration tests with tag "integration"
github.com/facebookincubator/contest/tests/integ/events/frameworkevents
github.com/facebookincubator/contest/tests/integ/events/testevents
github.com/facebookincubator/contest/tests/integ/job
github.com/facebookincubator/contest/tests/integ/jobmanager
github.com/facebookincubator/contest/tests/integ/migration
github.com/facebookincubator/contest/tests/integ/test
github.com/facebookincubator/contest/tests/plugins/teststeps/channels
github.com/facebookincubator/contest/tests/plugins/teststeps/crash
github.com/facebookincubator/contest/tests/plugins/teststeps/fail
github.com/facebookincubator/contest/tests/plugins/teststeps/hanging
github.com/facebookincubator/contest/tests/plugins/teststeps/noop
github.com/facebookincubator/contest/tests/plugins/teststeps/noreturn
github.com/facebookincubator/contest/tests/plugins/teststeps/panicstep
Running integration tests with tag "integration_storage"
github.com/facebookincubator/contest/tests/integ/events/frameworkevents
github.com/facebookincubator/contest/tests/integ/events/testevents
github.com/facebookincubator/contest/tests/integ/job
github.com/facebookincubator/contest/tests/integ/jobmanager
github.com/facebookincubator/contest/tests/integ/migration
github.com/facebookincubator/contest/tests/plugins/targetlocker/dblocker
github.com/facebookincubator/contest/tests/plugins/teststeps/channels
github.com/facebookincubator/contest/tests/plugins/teststeps/crash
github.com/facebookincubator/contest/tests/plugins/teststeps/fail
github.com/facebookincubator/contest/tests/plugins/teststeps/hanging
github.com/facebookincubator/contest/tests/plugins/teststeps/noop
github.com/facebookincubator/contest/tests/plugins/teststeps/noreturn
github.com/facebookincubator/contest/tests/plugins/teststeps/panicstep
```