### PR TITLE
Make migration step faster

### DIFF
--- a/db/rdbms/migration/0002_migrate_descriptor_to_extended_descriptor.go
+++ b/db/rdbms/migration/0002_migrate_descriptor_to_extended_descriptor.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const shardSize = uint64(50)
+const shardSize = uint64(5000)
 
 // DescriptorMigration represents a migration which moves steps description in jobs tables from old to new
 // schema. The migration consists in the following:

--- a/plugins/testfetchers/literal/literal.go
+++ b/plugins/testfetchers/literal/literal.go
@@ -10,16 +10,13 @@ package literal
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
-	"github.com/facebookincubator/contest/pkg/logging"
 	"github.com/facebookincubator/contest/pkg/test"
 )
 
 // Name defined the name of the plugin
 var (
 	Name = "Literal"
-	log  = logging.GetLogger("testfetchers/" + strings.ToLower(Name))
 )
 
 // FetchParameters contains the parameters necessary to fetch tests. This
@@ -56,7 +53,6 @@ func (tf *Literal) Fetch(params interface{}) (string, []*test.TestStepDescriptor
 	if !ok {
 		return "", nil, fmt.Errorf("Fetch expects uri.FetchParameters object")
 	}
-	log.Printf("Returning literal test steps")
 	return fetchParams.TestName, fetchParams.Steps, nil
 }
 


### PR DESCRIPTION
It uses offset query that becomes less efficient as the size of the database grows.
Processing in larger batches reduces the number of queries and makes the
process much faster.

With ~130K rows the time drops from 10+ minutes to 45 seconds.

Also silence an overly verbose log message.