### PR TITLE
Speed up tests by speeding up build of the mysql container

### DIFF
--- a/docker/contest/Dockerfile
+++ b/docker/contest/Dockerfile
@@ -1,8 +1,7 @@
-FROM golang:1.15.4-buster
+FROM golang:1.15.6-buster
 
 RUN apt-get update && apt-get install -y mariadb-client
 
-RUN go get -t -v ./...
 WORKDIR ${GOPATH}/src/github.com/facebookincubator/contest
 COPY  . .
 RUN go get -t -v ./...

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,22 @@
-FROM mysql
+FROM mysql:8.0
+
+# Configure golang environment to run migration against database
+RUN apt-get update && apt-get install -y curl && apt-get clean
+RUN curl -L https://golang.org/dl/go1.15.6.linux-amd64.tar.gz | tar xzf -
+ENV GOROOT=/go
+ENV PATH=$PATH:/go/bin
+
+RUN mkdir /home/mysql && chown mysql:mysql /home/mysql
+
+USER mysql
+
+COPY --chown=mysql:mysql . /home/mysql/contest
+
+WORKDIR /home/mysql
+
+# Pre-build the migration script, make sure it builds.
+RUN cd /home/mysql/contest && \
+    go build github.com/facebookincubator/contest/tools/migration/rdbms
 
 # All scripts in docker-entrypoint-initdb.d/ are automatically
 # executed during container startup
@@ -15,23 +33,3 @@ COPY db/rdbms/schema/v0/create_contest_db.sql /
 # order. 
 # """
 COPY docker/mysql/migration.sh /docker-entrypoint-initdb.d/
-
-# Configure golang environment to run migration against database
-RUN apt-get update && apt-get install -y curl git binutils bison gcc make golang
-
-RUN mkdir /home/mysql && chown mysql:mysql /home/mysql
-
-USER mysql
-
-RUN bash -c "bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer)"
-RUN bash -c "source /home/mysql/.gvm/scripts/gvm && gvm install go1.13"
-
-COPY --chown=mysql:mysql . /home/mysql/contest
-
-WORKDIR /home/mysql
-
-RUN bash -c "source .gvm/scripts/gvm && \
-             cd contest && \
-             gvm use 1.13 && gvm linkthis github.com/facebookincubator/contest"
-
-USER root

--- a/docker/mysql/migration.sh
+++ b/docker/mysql/migration.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 echo "Running database migrations..."
-source ${HOME}/.gvm/scripts/gvm 
-gvm use 1.13
-cd ${GOPATH}/src/github.com/facebookincubator/contest
+cd /home/mysql/contest
 # Migrate main db and integration tests db
 go run tools/migration/rdbms/main.go -dbURI "contest:contest@unix(/var/run/mysqld/mysqld.sock)/contest?parseTime=true" -dir db/rdbms/migration up
 go run tools/migration/rdbms/main.go -dbURI "contest:contest@unix(/var/run/mysqld/mysqld.sock)/contest_integ?parseTime=true" -dir db/rdbms/migration up


### PR DESCRIPTION
GVM builds Go from source, this takes a long time.
Instead, install and use official Linux binaries.

This shaves off 3 minutes from test runs (8 down to 5).