### PR TITLE
Fix goroutine leak for state Context

### DIFF
--- a/pkg/statectx/context.go
+++ b/pkg/statectx/context.go
@@ -67,6 +67,9 @@ func WithParent(ctx Context) (Context, func(), func()) {
 	if ctx == nil {
 		return New()
 	}
+	if stCtx, ok := ctx.(*stateCtx); ok {
+		return newInternal(stCtx.cancelCtx, stCtx.pauseCtx, stCtx.pauseOrDoneCtx)
+	}
 	return newInternal(ctx, ctx.PausedCtx(), ctx.PausedOrDoneCtx())
 }
 

--- a/pkg/statectx/context_test.go
+++ b/pkg/statectx/context_test.go
@@ -172,8 +172,5 @@ func TestWithParent(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	common.LeakCheckingTestMain(m,
-		// TODO: fix the leak
-		"github.com/facebookincubator/contest/pkg/statectx.(*cancelContext).propagateCancel.*",
-	)
+	common.LeakCheckingTestMain(m)
 }


### PR DESCRIPTION
Current cancelContext's delegation of a cancel signal from an arbitrary parent's Context object obliges the user to invoke cancel/pause functions to return from goroutine and prevent it's leak.

In order to prevent leaks in case when user doesn't explicitly invoke cancel() we should use cancelContext's special processing of parent's context in case it has type cancelContext.

The same logic is implemented in a standard context.WithCancel function