### PR TITLE
Job resumption support

### DIFF
--- a/cmds/clients/contestcli/descriptors/test-resume.yaml
+++ b/cmds/clients/contestcli/descriptors/test-resume.yaml
@@ -1,0 +1,44 @@
+JobName: A job to test resumption
+Runs: 3
+RunInterval: 10s
+Tags: [test, resume]
+TestDescriptors:
+    - TargetManagerName: TargetList
+      TargetManagerAcquireParameters:
+        Targets:
+          - ID: T1
+          #- ID: T2
+      TargetManagerReleaseParameters:
+      TestFetcherName: literal
+      TestFetcherFetchParameters:
+          TestName: literal test
+          Steps:
+              - name: cmd
+                label: Step 1
+                parameters:
+                    executable: [echo]
+                    args: ["Step 1, target {{ .ID }}"]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+              - name: cmd
+                label: Step 2
+                parameters:
+                    executable: [sleep]
+                    args: [5]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+              - name: cmd
+                label: Step 3
+                parameters:
+                    executable: [echo]
+                    args: ["Step 3, target {{ .ID }}"]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+Reporting:
+    RunReporters:
+        - name: TargetSuccess
+          parameters:
+              SuccessExpression: "=100%"
+        - name: noop
+    FinalReporters:
+        - name: noop

--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/facebookincubator/contest/cmds/plugins"
 	"github.com/facebookincubator/contest/pkg/api"
@@ -19,6 +20,7 @@ import (
 	"github.com/facebookincubator/contest/pkg/pluginregistry"
 	"github.com/facebookincubator/contest/pkg/storage"
 	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/xcontext"
 	"github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx"
 	"github.com/facebookincubator/contest/pkg/xcontext/logger"
 	"github.com/facebookincubator/contest/plugins/listeners/httplistener"
@@ -35,6 +37,8 @@ var (
 	flagTargetLocker   = flag.String("targetLocker", inmemory.Name, "Target locker implementation to use")
 	flagInstanceTag    = flag.String("instanceTag", "", "A tag for this instance. Server will only operate on jobs with this tag and will add this tag to the jobs it creates.")
 	flagLogLevel       = flag.String("logLevel", "debug", "A log level, possible values: debug, info, warning, error, panic, fatal")
+	flagPauseTimeout   = flag.Int("pauseTimeout", 0, "SIGINT/SIGTERM shutdown timeout (seconds), after which pause will be escalated to cancellaton; -1 - no escalation, 0 - do not pause, cancel immediately")
+	flagResumeJobs     = flag.Bool("resumeJobs", false, "Attempt to resume paused jobs")
 )
 
 func main() {
@@ -44,7 +48,8 @@ func main() {
 		panic(err)
 	}
 
-	ctx := logrusctx.NewContext(logLevel, logging.DefaultOptions()...)
+	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logLevel, logging.DefaultOptions()...))
+	ctx, pause := xcontext.WithNotify(ctx, xcontext.ErrPaused)
 	log := ctx.Logger()
 
 	pluginRegistry := pluginregistry.NewPluginRegistry(ctx)
@@ -139,12 +144,55 @@ func main() {
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
-	log.Debugf("JobManager %+v", jm)
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 
-	if err := jm.Start(ctx, sigs); err != nil {
+	go func() {
+		intLevel := 0
+		// cancel immediately if pauseTimeout is zero
+		if *flagPauseTimeout == 0 {
+			intLevel = 1
+		}
+		for {
+			sig, ok := <-sigs
+			if !ok {
+				return
+			}
+			switch sig {
+			case syscall.SIGUSR1:
+				// Gentle shutdown: stop accepting requests, drain without asserting pause signal.
+				jm.StopAPI()
+			case syscall.SIGINT:
+				fallthrough
+			case syscall.SIGTERM:
+				// First signal - pause and drain, second - cancel.
+				jm.StopAPI()
+				if intLevel == 0 {
+					log.Infof("Signal %q, pausing jobs", sig)
+					pause()
+					if *flagPauseTimeout > 0 {
+						go func() {
+							select {
+							case <-ctx.Done():
+							case <-time.After(time.Duration(*flagPauseTimeout) * time.Second):
+								log.Errorf("Timed out waiting for jobs to pause, canceling")
+								cancel()
+							}
+						}()
+					}
+					intLevel++
+				} else {
+					log.Infof("Signal %q, canceling", sig)
+					cancel()
+				}
+			}
+		}
+	}()
+
+	if err := jm.Run(ctx, *flagResumeJobs); err != nil {
 		log.Fatalf("%v", err)
 	}
+	close(sigs)
+	log.Infof("Exiting")
 }

--- a/docker/contest/Dockerfile
+++ b/docker/contest/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.6-buster
+FROM golang:1.16.2-buster
 
 RUN apt-get update && apt-get install -y mariadb-client
 

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -2,7 +2,7 @@ FROM mysql:8.0
 
 # Configure golang environment to run migration against database
 RUN apt-get update && apt-get install -y curl && apt-get clean
-RUN curl -L https://golang.org/dl/go1.15.6.linux-amd64.tar.gz | tar xzf -
+RUN curl -L https://golang.org/dl/go1.16.2.linux-amd64.tar.gz | tar xzf -
 ENV GOROOT=/go
 ENV PATH=$PATH:/go/bin
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,8 @@ require (
 	github.com/pressly/goose v2.7.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/objx v0.3.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/u-root/u-root v7.0.0+incompatible // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	go.uber.org/atomic v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -67,11 +67,14 @@ github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1 h1:zrNp7OPtn2fjeNHI9CghvwxqQvvkK0RxUo86hE86vhU=
 github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/u-root/u-root v1.0.0 h1:3hJy0CG3mXIZtWRE+yrghG/3H0v8L1qEeZBlPr5nS9s=
 github.com/u-root/u-root v7.0.0+incompatible h1:u+KSS04pSxJGI5E7WE4Bs9+Zd75QjFv+REkjy/aoAc8=
 github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
@@ -143,6 +146,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/types"
-	"github.com/facebookincubator/contest/pkg/xcontext"
 
 	"github.com/insomniacslk/xjson"
 )
@@ -74,12 +73,6 @@ type Job struct {
 	// subsequently use to search and aggregate.
 	Tags []string
 
-	// TODO: StateCtx should be owned by the JobManager
-	// cancel or pause is a job-wide channel used to request and detect job's state change.
-	StateCtx       xcontext.Context
-	StateCtxPause  func()
-	StateCtxCancel func()
-
 	// How many times a job has to run. 0 means infinite.
 	// A "run" is the execution of a sequence of tests. For example, setting
 	// Runs to 2 will execute all the tests defined in `Tests` once, and then
@@ -139,25 +132,6 @@ func (js State) String() string {
 		string(EventJobCancelled),
 		string(EventJobCancellationFailed),
 	}[js]
-}
-
-// Cancel closes the cancel channel to signal cancellation
-func (j *Job) Cancel() {
-	j.StateCtxCancel()
-}
-
-// Pause closes the pause channel to signal pause
-func (j *Job) Pause() {
-	j.StateCtxPause()
-}
-
-// IsCancelled returns whether the job has been cancelled
-func (j *Job) IsCancelled() bool {
-	return j.StateCtx.IsSignaledWith(xcontext.ErrCanceled)
-}
-
-func (j *Job) IsPaused() bool {
-	return j.StateCtx.IsSignaledWith(xcontext.ErrPaused)
 }
 
 // InfoFetcher defines how to fetch job information

--- a/pkg/jobmanager/job.go
+++ b/pkg/jobmanager/job.go
@@ -112,10 +112,7 @@ func newJob(ctx xcontext.Context, registry *pluginregistry.PluginRegistry, jobDe
 		FinalReporterBundles:        finalReportersBundle,
 	}
 
-	job.StateCtx, job.StateCtxPause = xcontext.WithNotify(ctx, xcontext.ErrPaused)
-	job.StateCtx, job.StateCtxCancel = xcontext.WithCancel(job.StateCtx)
 	return &job, nil
-
 }
 
 // NewJobFromDescriptor creates a job object from a job descriptor

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -9,9 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/insomniacslk/xjson"
@@ -27,8 +25,6 @@ import (
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/pkg/xcontext"
 )
-
-var cancellationTimeout = 60 * time.Second
 
 // ErrorEventPayload represents the payload carried by a failure event (e.g. JobStateFailed, JobStateCancelled, etc.)
 type ErrorEventPayload struct {
@@ -47,19 +43,25 @@ type ErrorEventPayload struct {
 type JobManager struct {
 	config
 
-	jobs      map[types.JobID]*job.Job
+	jobs      map[types.JobID]*jobInfo
 	jobRunner *runner.JobRunner
 
 	jobsMu sync.Mutex
-	jobsWg sync.WaitGroup
 
-	jobStorageManager storage.JobStorageManager
+	jsm storage.JobStorageManager
 
 	frameworkEvManager frameworkevent.EmitterFetcher
 	testEvManager      testevent.Fetcher
 
 	apiListener    api.Listener
 	pluginRegistry *pluginregistry.PluginRegistry
+
+	apiCancel xcontext.CancelFunc
+}
+
+type jobInfo struct {
+	job           *job.Job
+	pause, cancel func()
 }
 
 // New initializes and returns a new JobManager with the given API listener.
@@ -67,7 +69,7 @@ func New(l api.Listener, pr *pluginregistry.PluginRegistry, opts ...Option) (*Jo
 	if pr == nil {
 		return nil, errors.New("plugin registry cannot be nil")
 	}
-	jobStorageManager := storage.NewJobStorageManager()
+	jsm := storage.NewJobStorageManager()
 
 	frameworkEvManager := storage.NewFrameworkEventEmitterFetcher()
 	testEvManager := storage.NewTestEventFetcher()
@@ -86,8 +88,8 @@ func New(l api.Listener, pr *pluginregistry.PluginRegistry, opts ...Option) (*Jo
 		config:             cfg,
 		apiListener:        l,
 		pluginRegistry:     pr,
-		jobs:               make(map[types.JobID]*job.Job),
-		jobStorageManager:  jobStorageManager,
+		jobs:               make(map[types.JobID]*jobInfo),
+		jsm:                jsm,
 		frameworkEvManager: frameworkEvManager,
 		testEvManager:      testEvManager,
 	}
@@ -95,7 +97,7 @@ func New(l api.Listener, pr *pluginregistry.PluginRegistry, opts ...Option) (*Jo
 	return &jm, nil
 }
 
-func (jm *JobManager) handleEvent(ev *api.Event) {
+func (jm *JobManager) handleEvent(ctx xcontext.Context, ev *api.Event) {
 	var resp *api.EventResponse
 
 	switch ev.Type {
@@ -130,24 +132,27 @@ func (jm *JobManager) handleEvent(ev *api.Event) {
 	}
 }
 
-// Start is responsible for starting the API listener and responding to incoming
-// events. It also responds to cancellation requests coming from SIGINT/SIGTERM
-// signals, propagating the signals downwards to all jobs.
-func (jm *JobManager) Start(ctx xcontext.Context, sigs chan os.Signal) error {
-	log := ctx.Logger()
-	log.Debugf("Starting JobManager")
-	defer log.Debugf("Stopped JobManager")
-
+// Run is responsible for starting the API listener and responding to incoming events.
+func (jm *JobManager) Run(ctx xcontext.Context, resumeJobs bool) error {
 	a, err := api.New(jm.config.apiOptions...)
 	if err != nil {
-		return fmt.Errorf("Cannot start JobManager: %w", err)
+		return fmt.Errorf("Cannot start API: %w", err)
+	}
+
+	// First, resume paused jobs.
+	if resumeJobs {
+		if err := jm.resumeJobs(ctx); err != nil {
+			return fmt.Errorf("failed to resume jobs: %w", err)
+		}
 	}
 
 	apiCtx, apiCancel := xcontext.WithCancel(ctx)
+	jm.apiCancel = apiCancel
+
 	errCh := make(chan error, 1)
 	go func() {
 		lErr := jm.apiListener.Serve(apiCtx, a)
-		ctx.Debugf("Server shut down successfully.")
+		ctx.Infof("Listener shut down successfully.")
 		errCh <- lErr
 	}()
 
@@ -156,114 +161,100 @@ loop:
 		select {
 		// handle events from the API
 		case ev := <-a.Events:
-			ev.Context.Debugf("Handling event %+v", ev)
+			ctx.Debugf("Handling event %+v", ev)
 			// send the response, and wait for the given timeout
-			jm.handleEvent(ev)
+			jm.handleEvent(ctx, ev)
 		// check for errors or premature termination from the listener.
 		case err := <-errCh:
-			log.Infof("JobManager: API listener failed, triggering a cancellation of all jobs")
-			jm.CancelAll(ctx)
 			if err != nil {
-				return fmt.Errorf("error reported by API listener: %v", err)
+				ctx.Infof("JobManager: API listener failed (%v)", err)
 			}
-			return errors.New("API listener terminated prematurely without errors")
-		// handle signals to shut down gracefully. If the cancellation takes too
-		// long, it will be terminated.
-		case sig := <-sigs:
-			// TODO: stop processing signals inside jobmanager, this is
-			//       as responsibility of "main".
-			// We were interrupted by a signal, time to leave!
-			if sig == syscall.SIGUSR1 {
-				log.Debugf("Interrupted by signal '%s': wait for jobs and exit", sig)
-				apiCancel()
-			} else {
-				log.Debugf("Interrupted by signal '%s': pause jobs and exit", sig)
-				apiCancel()
-				jm.PauseJobs(ctx)
-			}
-			select {
-			case err := <-errCh:
-				if err != nil {
-					return fmt.Errorf("API listener terminated with error: %v", err)
-				}
-				// break the outer loop
-				break loop
-			case <-time.After(cancellationTimeout):
-				return fmt.Errorf("API listener didn't shut down within %v, exiting", cancellationTimeout)
-			}
+			break loop
+		case <-ctx.Until(xcontext.ErrPaused):
+			ctx.Infof("Paused")
+			jm.PauseAll(ctx)
+			break loop
+		case <-ctx.Done():
+			break loop
 		}
 	}
-	// Downstream runner are guaranteed to have shutdown control path protected
-	// by timeouts, therefore here we can wait for all jobs registered in the
-	// WaitGroup to terminate correctly or timeout during termination
-	jm.jobsWg.Wait()
+	// Stop the API (if not already)
+	jm.StopAPI()
+	// Wait for jobs to complete or for cancellation signal.
+	for !jm.checkIdle(ctx) {
+		select {
+		case <-ctx.Done():
+			ctx.Infof("Canceled")
+			jm.CancelAll(ctx)
+			// Note that we do not break out of the loop here, we expect runner to wind down and exit.
+		case <-time.After(1 * time.Second):
+		}
+	}
 	return nil
+}
+
+func (jm *JobManager) checkIdle(ctx xcontext.Context) bool {
+	jm.jobsMu.Lock()
+	defer jm.jobsMu.Unlock()
+	if len(jm.jobs) == 0 {
+		return true
+	}
+	ctx.Infof("Waiting for %d jobs", len(jm.jobs))
+	return false
 }
 
 // CancelJob sends a cancellation request to a specific job.
 func (jm *JobManager) CancelJob(jobID types.JobID) error {
 	jm.jobsMu.Lock()
+	defer jm.jobsMu.Unlock()
 	// get the job from the local cache rather than the storage layer. We can
 	// only cancel jobs that we are actively handling.
-	j, ok := jm.jobs[jobID]
+	ji, ok := jm.jobs[jobID]
 	if !ok {
-		jm.jobsMu.Unlock()
 		return fmt.Errorf("unknown job ID: %d", jobID)
 	}
-	j.Cancel()
-	delete(jm.jobs, jobID)
-	jm.jobsMu.Unlock()
+	ji.cancel()
 	return nil
 }
 
-// CancelAll sends a cancellation request to the API listener and to every running
-// job.
+// StopAPI stops accepting new requests.
+func (jm *JobManager) StopAPI() {
+	jm.apiCancel()
+}
+
+// CancelAll cancels all running jobs.
 func (jm *JobManager) CancelAll(ctx xcontext.Context) {
-	log := ctx.Logger()
-	// TODO This doesn't seem the right thing to do, if the listener fails we should
-	// pause, not cancel.
-
-	// Get the job from the local cache rather than the storage layer. We can
-	// only cancel jobs that we are actively handling.
-	log.Infof("JobManager: cancelling all jobs")
-	for jobID, job := range jm.jobs {
-		log.Debugf("JobManager: cancelling job with ID %v", jobID)
-		job.Cancel()
+	jm.jobsMu.Lock()
+	defer jm.jobsMu.Unlock()
+	for jobID, ji := range jm.jobs {
+		ctx.Debugf("JobManager: cancelling job %d", jobID)
+		ji.cancel()
 	}
 }
 
-// PauseJobs sends a pause request to every running job.
-func (jm *JobManager) PauseJobs(ctx xcontext.Context) {
-	log := ctx.Logger()
-
-	log.Infof("JobManager: requested pausing")
-	for jobID, job := range jm.jobs {
-		log.Debugf("JobManager: pausing job with ID %v", jobID)
-		job.Pause()
+// CancelAll pauses all running jobs.
+func (jm *JobManager) PauseAll(ctx xcontext.Context) {
+	jm.jobsMu.Lock()
+	defer jm.jobsMu.Unlock()
+	for jobID, ji := range jm.jobs {
+		ctx.Debugf("JobManager: pausing job %d", jobID)
+		ji.pause()
 	}
 }
 
-func (jm *JobManager) emitErrEvent(ctx xcontext.Context, jobID types.JobID, eventName event.Name, err error) error {
-	var (
-		rawPayload json.RawMessage
-		payloadPtr *json.RawMessage
-	)
-	if err != nil {
-		ctx.Errorf(err.Error())
-		payload := ErrorEventPayload{Err: *xjson.NewError(err)}
-		payloadJSON, err := json.Marshal(payload)
-		if err != nil {
-			ctx.Warnf("Could not serialize payload for event %s: %v", eventName, err)
+func (jm *JobManager) emitEventPayload(ctx xcontext.Context, jobID types.JobID, eventName event.Name, payload interface{}) error {
+	var payloadJSON json.RawMessage
+	if payload != nil {
+		if p, err := json.Marshal(payload); err == nil {
+			payloadJSON = json.RawMessage(p)
 		} else {
-			rawPayload = json.RawMessage(payloadJSON)
-			payloadPtr = &rawPayload
+			return fmt.Errorf("Could not serialize payload for event %s: %v", eventName, err)
 		}
 	}
-
 	ev := frameworkevent.Event{
 		JobID:     jobID,
 		EventName: eventName,
-		Payload:   payloadPtr,
+		Payload:   &payloadJSON,
 		EmitTime:  time.Now(),
 	}
 	if err := jm.frameworkEvManager.Emit(ctx, ev); err != nil {
@@ -271,6 +262,14 @@ func (jm *JobManager) emitErrEvent(ctx xcontext.Context, jobID types.JobID, even
 		return err
 	}
 	return nil
+}
+
+func (jm *JobManager) emitErrEvent(ctx xcontext.Context, jobID types.JobID, eventName event.Name, err error) error {
+	if err != nil {
+		ctx.Errorf(err.Error())
+		return jm.emitEventPayload(ctx, jobID, eventName, &ErrorEventPayload{Err: *xjson.NewError(err)})
+	}
+	return jm.emitEventPayload(ctx, jobID, eventName, nil)
 }
 
 func (jm *JobManager) emitEvent(ctx xcontext.Context, jobID types.JobID, eventName event.Name) error {

--- a/pkg/jobmanager/list.go
+++ b/pkg/jobmanager/list.go
@@ -41,7 +41,7 @@ func (jm *JobManager) list(ev *api.Event) *api.EventResponse {
 		evResp.Err = fmt.Errorf("failed to build job query: %w", err)
 		return evResp
 	}
-	res, err := jm.jobStorageManager.ListJobs(ctx, jobQuery)
+	res, err := jm.jsm.ListJobs(ctx, jobQuery)
 	if err != nil {
 		evResp.Err = fmt.Errorf("failed to list jobs: %w", err)
 		return evResp

--- a/pkg/jobmanager/resume.go
+++ b/pkg/jobmanager/resume.go
@@ -1,0 +1,85 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package jobmanager
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/storage"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+)
+
+func (jm *JobManager) resumeJobs(ctx xcontext.Context) error {
+	queryFields := []storage.JobQueryField{
+		storage.QueryJobStates(job.JobStatePaused),
+	}
+	if jm.config.instanceTag != "" {
+		queryFields = append(queryFields, storage.QueryJobTags(jm.config.instanceTag))
+	}
+	q, err := storage.BuildJobQuery(queryFields...)
+	if err != nil {
+		return fmt.Errorf("failed to build job query: %w", err)
+	}
+	pausedJobs, err := jm.jsm.ListJobs(ctx, q)
+	if err != nil {
+		return fmt.Errorf("failed to list paused jobs: %w", err)
+	}
+	ctx.Infof("Found %d paused jobs", len(pausedJobs))
+	for _, jobID := range pausedJobs {
+		if err := jm.resumeJob(ctx, jobID); err != nil {
+			ctx.Errorf("failed to resume job %d: %v, failing it", jobID, err)
+			if err = jm.emitErrEvent(ctx, jobID, job.EventJobFailed, fmt.Errorf("failed to resume job %d: %w", jobID, err)); err != nil {
+				ctx.Warnf("Failed to emit event for %d: %v", jobID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (jm *JobManager) resumeJob(ctx xcontext.Context, jobID types.JobID) error {
+	ctx.Debugf("attempting to resume job %d", jobID)
+	results, err := jm.frameworkEvManager.Fetch(
+		ctx,
+		frameworkevent.QueryJobID(jobID),
+		frameworkevent.QueryEventName(job.EventJobPaused),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to query resume state for job %d: %w", jobID, err)
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("no resume state found for job %d", jobID)
+	}
+	// Sort by EmitTime in descending order.
+	sort.Slice(results, func(i, j int) bool { return results[i].EmitTime.After(results[j].EmitTime) })
+	var resumeState job.PauseEventPayload
+	if results[0].Payload == nil {
+		return fmt.Errorf("invald resume state for job %d: %+v", jobID, results[0])
+	}
+	if err := json.Unmarshal(*results[0].Payload, &resumeState); err != nil {
+		return fmt.Errorf("invald resume state for job %d: %w", jobID, err)
+	}
+	if resumeState.Version != job.CurrentPauseEventPayloadVersion {
+		return fmt.Errorf("incompatible resume state version (want %d, got %d)",
+			job.CurrentPauseEventPayloadVersion, resumeState.Version)
+	}
+	req, err := jm.jsm.GetJobRequest(ctx, jobID)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve job descriptor for %d: %w", jobID, err)
+	}
+	j, err := NewJobFromExtendedDescriptor(ctx, jm.pluginRegistry, req.ExtendedDescriptor)
+	if err != nil {
+		return fmt.Errorf("failed to create job %d: %w", jobID, err)
+	}
+	j.ID = jobID
+	ctx.Debugf("running resumed job %d", j.ID)
+	jm.startJob(ctx, j, &resumeState)
+	return nil
+}

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -30,7 +30,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 	}
 
 	// Look up job request.
-	req, err := jm.jobStorageManager.GetJobRequestAsync(ctx, jobID)
+	req, err := jm.jsm.GetJobRequestAsync(ctx, jobID)
 	if err != nil {
 		evResp.Err = fmt.Errorf("failed to fetch request for job ID %d: %w", jobID, err)
 		return &evResp
@@ -112,7 +112,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 		}
 	}
 
-	report, err := jm.jobStorageManager.GetJobReportAsync(ctx, jobID)
+	report, err := jm.jsm.GetJobReportAsync(ctx, jobID)
 	if err != nil {
 		evResp.Err = fmt.Errorf("could not fetch job report: %v", err)
 		return &evResp
@@ -134,7 +134,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 		return &evResp
 	}
 	runCoordinates := job.RunCoordinates{JobID: jobID, RunID: runID}
-	runStatus, err := jm.jobRunner.BuildRunStatus(runCoordinates, currentJob)
+	runStatus, err := jm.jobRunner.BuildRunStatus(ctx, runCoordinates, currentJob)
 	if err != nil {
 		evResp.Err = fmt.Errorf("could not rebuild the status of the job: %v", err)
 		return &evResp

--- a/pkg/runner/job_status_test.go
+++ b/pkg/runner/job_status_test.go
@@ -64,16 +64,19 @@ func (fem dummyFrameworkEventManager) FetchAsync(ctx xcontext.Context, fields ..
 }
 
 func TestBuildRunStatuses(t *testing.T) {
+	ctx := xcontext.Background()
 	jr := &JobRunner{
 		targetMap:             nil,
 		targetLock:            nil,
 		frameworkEventManager: dummyFrameworkEventManager{t: t},
 		testEvManager:         nil,
 	}
-	runStatuses, err := jr.BuildRunStatuses(&job.Job{
-		ID:   1,
-		Runs: 3,
-	})
+	runStatuses, err := jr.BuildRunStatuses(
+		ctx, &job.Job{
+			ID:   1,
+			Runs: 3,
+		},
+	)
 	require.NoError(t, err)
 	require.Len(t, runStatuses, 2)
 }

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -163,7 +163,7 @@ func runWithTimeout(t *testing.T, tr *TestRunner, ctx xcontext.Context, resumeSt
 func Test1Step1Success(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			newTestStep("Step 1", 0, "", ""),
@@ -187,7 +187,7 @@ func Test1Step1Success(t *testing.T) {
 func Test1StepLongerThanShutdown1Success(t *testing.T) {
 	resetEventStorage()
 	tr := NewTestRunnerWithTimeouts(100 * time.Millisecond)
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			newTestStep("Step 1", 0, "", "T1=500"),
@@ -210,7 +210,7 @@ func Test1StepLongerThanShutdown1Success(t *testing.T) {
 func Test1Step1Fail(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			newTestStep("Step 1", 100, "", ""),
@@ -233,7 +233,7 @@ func Test1Step1Fail(t *testing.T) {
 func Test1Step1Success1Fail(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1"), tgt("T2")},
 		[]test.TestStepBundle{
 			newTestStep("Step 1", 0, "T1", "T2=100"),
@@ -263,7 +263,7 @@ func Test1Step1Success1Fail(t *testing.T) {
 func Test3StepsNotReachedStepNotRun(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1"), tgt("T2")},
 		[]test.TestStepBundle{
 			newTestStep("Step 1", 0, "T1", ""),
@@ -320,7 +320,7 @@ func TestNoReturnStepWithCorrectTargetForwarding(t *testing.T) {
 func TestStepPanics(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			newStep("Step 1", panicstep.Name, nil),
@@ -336,7 +336,7 @@ func TestStepPanics(t *testing.T) {
 func TestStepClosesChannels(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
 			newStep("Step 1", channels.Name, nil),
@@ -357,7 +357,7 @@ func TestStepClosesChannels(t *testing.T) {
 func TestStepYieldsResultForNonexistentTarget(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("TExtra")},
 		[]test.TestStepBundle{
 			newStep("Step 1", badtargets.Name, nil),
@@ -375,7 +375,7 @@ func TestStepYieldsResultForNonexistentTarget(t *testing.T) {
 func TestStepYieldsDuplicateResult(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("TGood"), tgt("TDup")},
 		[]test.TestStepBundle{
 			// TGood makes it past here unscathed and gets delayed in Step 2,
@@ -392,7 +392,7 @@ func TestStepYieldsDuplicateResult(t *testing.T) {
 func TestStepLosesTargets(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("TGood"), tgt("TDrop")},
 		[]test.TestStepBundle{
 			newStep("Step 1", badtargets.Name, nil),
@@ -408,7 +408,7 @@ func TestStepLosesTargets(t *testing.T) {
 func TestStepYieldsResultForUnexpectedTarget(t *testing.T) {
 	resetEventStorage()
 	tr := newTestRunner()
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("TExtra"), tgt("TExtra2")},
 		[]test.TestStepBundle{
 			// TExtra2 fails here.
@@ -429,7 +429,7 @@ func TestRandomizedMultiStep(t *testing.T) {
 	for i := 1; i <= 100; i++ {
 		targets = append(targets, tgt(fmt.Sprintf("T%d", i)))
 	}
-	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
+	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
 		targets,
 		[]test.TestStepBundle{
 			newTestStep("Step 1", 0, "", "*=10"),  // All targets pass the first step, with a slight delay

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -28,6 +28,9 @@ var EventTargetErr = event.Name("TargetErr")
 // EventTargetAcquired indicates that a target has been acquired for a Test
 var EventTargetAcquired = event.Name("TargetAcquired")
 
+// EventTargetAcquired indicates that a target has been released
+var EventTargetReleased = event.Name("TargetReleased")
+
 // ErrPayload represents the payload associated with a TargetErr event
 type ErrPayload struct {
 	Error string

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,8 +5,18 @@
 
 package types
 
+import "strconv"
+
 // JobID represents a unique job identifier
 type JobID uint64
 
 // RunID represents the id of a run within the Job
 type RunID uint64
+
+func (v JobID) String() string {
+	return strconv.FormatUint(uint64(v), 10)
+}
+
+func (v RunID) String() string {
+	return strconv.FormatUint(uint64(v), 10)
+}

--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -49,8 +49,8 @@ func ForEachTarget(pluginName string, ctx xcontext.Context, ch test.TestStepChan
 	func() {
 		for {
 			select {
-			case tgt := <-ch.In:
-				if tgt == nil {
+			case tgt, ok := <-ch.In:
+				if !ok {
 					ctx.Debugf("%s: ForEachTarget: all targets have been received", pluginName)
 					return
 				}

--- a/plugins/teststeps/teststeps_test.go
+++ b/plugins/teststeps/teststeps_test.go
@@ -63,8 +63,7 @@ func TestForEachTargetOneTarget(t *testing.T) {
 	}
 	go func() {
 		d.inCh <- &target.Target{ID: "target001"}
-		// signal end of input
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 	ctx, cancel := xcontext.WithCancel(ctx)
 	defer cancel()
@@ -94,8 +93,7 @@ func TestForEachTargetOneTargetAllFail(t *testing.T) {
 	}
 	go func() {
 		d.inCh <- &target.Target{ID: "target001"}
-		// signal end of input
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 	ctx, cancel := xcontext.WithCancel(ctx)
 	defer cancel()
@@ -125,8 +123,7 @@ func TestForEachTargetTenTargets(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			d.inCh <- &target.Target{ID: fmt.Sprintf("target%00d", i)}
 		}
-		// signal end of input
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -156,8 +153,7 @@ func TestForEachTargetTenTargetsAllFail(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			d.inCh <- &target.Target{ID: fmt.Sprintf("target%00d", i)}
 		}
-		// signal end of input
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -193,8 +189,7 @@ func TestForEachTargetTenTargetsOneFails(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
-		// signal end of input
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -228,7 +223,7 @@ func TestForEachTargetTenTargetsOneFails(t *testing.T) {
 // I am using a deadline of 3s to give it some margin, knowing that if it is sequential
 // it will take ~10s.
 func TestForEachTargetTenTargetsParallelism(t *testing.T) {
-	sleepTime := time.Second
+	sleepTime := 300 * time.Millisecond
 	d := newData()
 	fn := func(ctx xcontext.Context, tgt *target.Target) error {
 		d.ctx.Debugf("Handling target %+v", tgt)
@@ -248,8 +243,7 @@ func TestForEachTargetTenTargetsParallelism(t *testing.T) {
 		for i := 0; i < numTargets; i++ {
 			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
-		// signal end of input
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 
 	deadlineExceeded := false
@@ -301,7 +295,7 @@ func TestForEachTargetTenTargetsParallelism(t *testing.T) {
 }
 
 func TestForEachTargetCancelSignalPropagation(t *testing.T) {
-	sleepTime := time.Second * 5
+	sleepTime := 300 * time.Millisecond
 	numTargets := 10
 	var canceledTargets int32
 	d := newData()
@@ -324,7 +318,7 @@ func TestForEachTargetCancelSignalPropagation(t *testing.T) {
 		for i := 0; i < numTargets; i++ {
 			d.inCh <- &target.Target{ID: fmt.Sprintf("target%03d", i)}
 		}
-		d.inCh <- nil
+		close(d.inCh)
 	}()
 
 	go func() {
@@ -339,7 +333,7 @@ func TestForEachTargetCancelSignalPropagation(t *testing.T) {
 }
 
 func TestForEachTargetCancelBeforeInputChannelClosed(t *testing.T) {
-	sleepTime := time.Second * 5
+	sleepTime := 300 * time.Millisecond
 	numTargets := 10
 	var canceledTargets int32
 	d := newData()

--- a/tests/integ/jobmanager/jobdescriptors.go
+++ b/tests/integ/jobmanager/jobdescriptors.go
@@ -265,3 +265,30 @@ var jobDescriptorDuplicateTag = descriptorMust2(&templateData{
        "TestName": "IntegrationTest: slow echo"
    }`,
 })
+
+var jobDescriptorSlowEcho2 = descriptorMust2(&templateData{
+	Runs:        2,
+	RunInterval: "0.5s",
+	Def: `
+   "TestFetcherFetchParameters": {
+       "Steps": [
+           {
+               "name": "slowecho",
+               "label": "Step 1",
+               "parameters": {
+                 "sleep": ["0.5"],
+                 "text": ["Hello step 1"]
+               }
+           },
+           {
+               "name": "slowecho",
+               "label": "Step 2",
+               "parameters": {
+                 "sleep": ["0"],
+                 "text": ["Hello step 2"]
+               }
+           }
+       ],
+       "TestName": "IntegrationTest: resume"
+   }`,
+})

--- a/tests/integ/jobmanager/jobmanager_memory_test.go
+++ b/tests/integ/jobmanager/jobmanager_memory_test.go
@@ -12,9 +12,7 @@ import (
 	"testing"
 
 	"github.com/facebookincubator/contest/pkg/storage"
-	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/plugins/storage/memory"
-	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -32,9 +30,6 @@ func TestJobManagerSuiteMemoryStorage(t *testing.T) {
 	testSuite.storage = storagelayer
 	err = storage.SetStorage(storagelayer)
 	require.NoError(t, err)
-
-	targetLocker := inmemory.New()
-	target.SetLocker(targetLocker)
 
 	suite.Run(t, &testSuite)
 }

--- a/tests/integ/jobmanager/jobmanager_rdbms_test.go
+++ b/tests/integ/jobmanager/jobmanager_rdbms_test.go
@@ -13,9 +13,7 @@ import (
 	"time"
 
 	"github.com/facebookincubator/contest/pkg/storage"
-	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/plugins/storage/rdbms"
-	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
 	"github.com/facebookincubator/contest/tests/integ/common"
 
 	"github.com/stretchr/testify/require"
@@ -36,9 +34,6 @@ func TestJobManagerSuiteRdbmsStorage(t *testing.T) {
 	err = storage.SetStorage(storageLayer)
 	require.NoError(t, err)
 	testSuite.storage = storageLayer
-
-	targetLocker := inmemory.New()
-	target.SetLocker(targetLocker)
 
 	suite.Run(t, &testSuite)
 }

--- a/tests/plugins/teststeps/teststep/teststep.go
+++ b/tests/plugins/teststeps/teststep/teststep.go
@@ -68,7 +68,7 @@ func (ts *Step) shouldFail(t *target.Target, params test.TestStepParameters) boo
 func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	f := func(ctx xcontext.Context, target *target.Target) error {
 		// Sleep to ensure TargetIn fires first. This simplifies test assertions.
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		if err := ev.Emit(ctx, testevent.Data{EventName: StartedEvent, Target: target, Payload: nil}); err != nil {
 			return fmt.Errorf("failed to emit start event: %v", err)
 		}


### PR DESCRIPTION
This adds plumbing to support storage and retrieval of resume state when job run is paused.
It's disabled by default and requires two flags to enable:
 * Non-zero `-pauseTimeout` to pause jobs and store state. By defualt jobs are canceled, not paused.
 * `-resumeJobs` to attempt to resume paused jobs on startup.

There are a number of ancillary changes:
 * Refactored JobManager to use Context for pause/cancel control (a TODO)
 * Moved signal handling out of JobManager to main() (another TODO)
 * Updated github.com/stretchr/testify to 1.7.0 (to pick up TearDownSuite fix)

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>