### PR TITLE
Add ability to list jobs

### DIFF
--- a/cmds/clients/contestcli/main.go
+++ b/cmds/clients/contestcli/main.go
@@ -24,6 +24,15 @@ import (
 //
 // Get the status of a job whose ID is 10
 //   ./contestcli-http status 10
+//
+// List all the jobs:
+//   ./contestcli-http list
+//
+// List all the failed jobs:
+//   ./contestcli-http list -state JobStateFailed
+//
+// List all the failed jobs with tags "foo" and "bar":
+//   ./contestcli-http list -state JobStateFailed -tags foo,bar
 
 const (
 	defaultRequestor = "contestcli-http"
@@ -35,6 +44,10 @@ var (
 	flagRequestor = flag.StringP("requestor", "r", defaultRequestor, "Identifier of the requestor of the API call")
 	flagWait      = flag.BoolP("wait", "w", false, "After starting a job, wait for it to finish, and exit 0 only if it is successful")
 	flagYAML      = flag.BoolP("yaml", "Y", false, "Parse job descriptor as YAML instead of JSON")
+
+	// Flags for the "list" command.
+	flagStates = flag.StringSlice("states", []string{}, "List of job states for the list command. A job must be in any of the specified states to match.")
+	flagTags   = flag.StringSlice("tags", []string{}, "List of tags for the list command. A job must have all the tags to match.")
 )
 
 func main() {
@@ -52,6 +65,8 @@ func main() {
 		fmt.Fprintf(flag.CommandLine.Output(), "        get the status of a job by job ID\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  retry int\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "        retry a job by job ID\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "  list [--states=JobStateStarted,...] [--tags=foo,...]\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "        list jobs by state and/or tags\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "  version\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "        request the API version to the server\n")
 		fmt.Fprintf(flag.CommandLine.Output(), "\nargs:\n")

--- a/cmds/clients/contestcli/verbs.go
+++ b/cmds/clients/contestcli/verbs.go
@@ -17,10 +17,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/facebookincubator/contest/pkg/transport"
 	"github.com/facebookincubator/contest/pkg/api"
 	"github.com/facebookincubator/contest/pkg/config"
-	"github.com/facebookincubator/contest/pkg/jobmanager"
+	"github.com/facebookincubator/contest/pkg/event"
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/transport"
 	"github.com/facebookincubator/contest/pkg/types"
 
 	flag "github.com/spf13/pflag"
@@ -104,6 +105,19 @@ func run(requestor string, transport transport.Transport) error {
 		if err != nil {
 			return err
 		}
+	case "list":
+		var states []job.State
+		for _, sts := range *flagStates {
+			st, err := job.EventNameToJobState(event.Name(sts))
+			if err != nil {
+				return err
+			}
+			states = append(states, st)
+		}
+		resp, err = transport.List(context.Background(), requestor, states, *flagTags)
+		if err != nil {
+			return err
+		}
 	case "version":
 		resp, err = transport.Version(context.Background(), requestor)
 		if err != nil {
@@ -137,7 +151,7 @@ func wait(ctx context.Context, jobID types.JobID, jobWaitPoll time.Duration, req
 
 		jobState := resp.Data.Status.State
 
-		for _, eventName := range jobmanager.JobCompletionEvents {
+		for _, eventName := range job.JobCompletionEvents {
 			if string(jobState) == string(eventName) {
 				return resp, nil
 			}

--- a/db/rdbms/migration/0003_add_jobs_state_column.sql
+++ b/db/rdbms/migration/0003_add_jobs_state_column.sql
@@ -1,0 +1,63 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+
+-- +goose Up
+
+ALTER TABLE jobs ADD COLUMN state tinyint DEFAULT 0 AFTER extended_descriptor;
+CREATE INDEX job_state ON jobs (state, job_id);
+
+-- Populate the column.
+
+SET SQL_BIG_SELECTS=1;
+
+UPDATE
+  jobs
+INNER JOIN
+  ( -- This query retrieves job state event by its id.
+    SELECT
+      jobs.job_id AS job_id,
+      fe2.event_name AS state
+    FROM
+      jobs
+    INNER JOIN
+      ( -- This query finds id of the last job state event for each job.
+        SELECT
+          job_id,
+          MAX(event_id) AS max_event
+        FROM
+          framework_events fe
+        WHERE
+          fe.event_name IN ("JobStateStarted", "JobStateCompleted", "JobStateFailed",
+                            "JobStatePaused", "JobStatePauseFailed", "JobStateCancelling",
+                            "JobStateCancelled", "JobStateCancellationFailed")
+        GROUP BY
+          job_id
+      ) fe1
+    ON
+      fe1.job_id = jobs.job_id
+    INNER JOIN
+      framework_events fe2
+    ON
+      fe2.event_id = fe1.max_event
+  ) tt
+ON
+  jobs.job_id = tt.job_id
+SET
+  jobs.state =
+      -- Translate string to numeric representation.
+      IF(tt.state = "JobStateStarted", 1,
+      IF(tt.state = "JobStateCompleted", 2,
+      IF(tt.state = "JobStateFailed", 3,
+      IF(tt.state = "JobStatePaused", 4,
+      IF(tt.state = "JobStatePauseFailed", 5,
+      IF(tt.state = "JobStateCancelling", 6,
+      IF(tt.state = "JobStateCancelled", 7,
+      IF(tt.state = "JobStateCancellationFailed", 8,
+      0))))))));
+
+-- +goose Down
+
+DROP INDEX job_state ON jobs
+ALTER TABLE jobs DROP COLUMN state;

--- a/db/rdbms/migration/0004_add_job_tags_table.sql
+++ b/db/rdbms/migration/0004_add_job_tags_table.sql
@@ -1,0 +1,28 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+
+-- +goose Up
+
+CREATE TABLE job_tags (
+  job_id BIGINT NOT NULL,
+  tag VARCHAR(32),
+  PRIMARY KEY (job_id, tag),
+  KEY(tag)
+);
+
+-- Extract tags from the descriptor field.
+SET SQL_BIG_SELECTS=1;
+INSERT INTO
+  job_tags
+SELECT
+  job_id,
+  job_tags.tag AS tag
+FROM
+  jobs,
+  JSON_TABLE(jobs.descriptor, '$.Tags[*]' COLUMNS (tag TEXT PATH '$[0]')) AS job_tags;
+
+-- +goose Down
+
+DROP TABLE job_tags;

--- a/db/rdbms/migration/README.md
+++ b/db/rdbms/migration/README.md
@@ -13,3 +13,11 @@ The [add_extended_descriptor](https://github.com/facebookincubator/contest/blob/
 # 0002_migrate_descriptor_to_extended_descriptor.go
 
 The [migrate_descriptor_to_extended_descrptor](https://github.com/facebookincubator/contest/blob/master/db/rdbms/migration/0002_migrate_descriptor_to_extended_descriptor.go) migration backfills existing entries in the `jobs` table and populates them with an `extended_descriptor`.  After [#118](https://github.com/facebookincubator/contest/pull/118), ConTest has a dependency over the `extended_descriptor` being populated and it won't be able to re-build status for any job which hasn't had the `extended_descriptor` backfilled.
+
+# 0003_add_jobs_state_column.sql
+
+The [add_jobs_state_column](https://github.com/facebookincubator/contest/blob/master/db/rdbms/migration/0003_add_jobs_state_column.sql) migration adds the `state` column to the jobs table to keep track of the job state without making queries against the framework_events table. Migration script backfills the column for existing jobs and server maintains the column going forward.
+
+# 0004_add_job_tags_table.sql
+
+The [add_job_tags_table](https://github.com/facebookincubator/contest/blob/master/db/rdbms/migration/0004_add_job_tags_table.sql) migration creates the `job_tags` table that maintains the relationship between job id and job tags to facilitate efficient lookups of jobs by tag(s). Migration script backfills the column for existing jobs and server maintains the column going forward.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/storage/limits"
 	"github.com/facebookincubator/contest/pkg/types"
 )
@@ -249,6 +250,30 @@ func (a *API) Retry(requestor EventRequestor, jobID types.JobID) (Response, erro
 		JobID: jobID,
 		// TODO this should set the new Job ID
 		// NewJobID: ...
+	}
+	resp.Err = respEv.Err
+	return resp, nil
+}
+
+// List will list jobs matching the specified criteria.
+func (a *API) List(requestor EventRequestor, states []job.State, tags []string) (Response, error) {
+	resp := a.newResponse(ResponseTypeList)
+	ev := &Event{
+		Type:     EventTypeList,
+		ServerID: resp.ServerID,
+		Msg: EventListMsg{
+			requestor: requestor,
+			States:    states,
+			Tags:      tags,
+		},
+		RespCh: make(chan *EventResponse, 1),
+	}
+	respEv, err := a.SendReceiveEvent(ev, nil)
+	if err != nil {
+		return resp, err
+	}
+	resp.Data = ResponseDataList{
+		JobIDs: respEv.JobIDs,
 	}
 	resp.Err = respEv.Err
 	return resp, nil

--- a/pkg/api/event.go
+++ b/pkg/api/event.go
@@ -32,6 +32,7 @@ var eventTypeNames = map[EventType]string{
 	EventTypeStop:   "event_type_stop",
 	EventTypeRetry:  "event_type_retry",
 	EventTypeError:  "event_type_error",
+	EventTypeList:   "event_type_list",
 }
 
 // list of existing API event types.
@@ -41,6 +42,7 @@ const (
 	EventTypeStop
 	EventTypeRetry
 	EventTypeError
+	EventTypeList
 )
 
 // Event represents an event that the API can generate. This is used by the API
@@ -107,4 +109,22 @@ type EventResponse struct {
 	JobID     types.JobID
 	Err       error
 	Status    *job.Status
+	JobIDs    []types.JobID
+}
+
+// EventListMsg contains the arguments for an event of type List.
+type EventListMsg struct {
+	requestor EventRequestor
+	States    []job.State
+	Tags      []string
+}
+
+// Requestor returns the requestor of the API call as reported by the client.
+func (e EventListMsg) Requestor() EventRequestor { return e.requestor }
+
+// EventListResponse is a response to EventListMsg.
+type EventListResponse struct {
+	Requestor EventRequestor
+	Jobs      []types.JobID
+	Err       error
 }

--- a/pkg/api/response.go
+++ b/pkg/api/response.go
@@ -22,6 +22,7 @@ const (
 	ResponseTypeStatus
 	ResponseTypeRetry
 	ResponseTypeVersion
+	ResponseTypeList
 )
 
 // ResponseTypeToName maps response types to their names.
@@ -31,6 +32,7 @@ var ResponseTypeToName = map[ResponseType]string{
 	ResponseTypeStatus:  "ResponseTypeStatus",
 	ResponseTypeRetry:   "ResponseTypeRetry",
 	ResponseTypeVersion: "ResponseTypeVersion",
+	ResponseTypeList:    "ResponseTypeList",
 }
 
 // Response is the type returned to any API request.
@@ -86,6 +88,16 @@ func (r ResponseDataRetry) Type() ResponseType {
 	return ResponseTypeRetry
 }
 
+// ResponseDataList is the response type for a List request.
+type ResponseDataList struct {
+	JobIDs []types.JobID
+}
+
+// Type returns the response type.
+func (r ResponseDataList) Type() ResponseType {
+	return ResponseTypeList
+}
+
 // ResponseDataVersion is the response type for a Version request.
 type ResponseDataVersion struct {
 	Version uint32
@@ -124,6 +136,13 @@ type StopResponse struct {
 type RetryResponse struct {
 	ServerID string
 	Data     ResponseDataRetry
+	Err      *xjson.Error
+}
+
+// ListResponse is a typesafe version of Response with a List payload
+type ListResponse struct {
+	ServerID string
+	Data     ResponseDataList
 	Err      *xjson.Error
 }
 

--- a/pkg/job/events.go
+++ b/pkg/job/events.go
@@ -3,9 +3,11 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-package jobmanager
+package job
 
 import (
+	"fmt"
+
 	"github.com/facebookincubator/contest/pkg/event"
 )
 
@@ -52,4 +54,25 @@ var JobStateEvents = []event.Name{
 	EventJobCancelling,
 	EventJobCancelled,
 	EventJobCancellationFailed,
+}
+
+// States corresponding to events.
+var jobStates = []State{
+	JobStateStarted,
+	JobStateCompleted,
+	JobStateFailed,
+	JobStatePaused,
+	JobStatePauseFailed,
+	JobStateCancelling,
+	JobStateCancelled,
+	JobStateCancellationFailed,
+}
+
+func EventNameToJobState(ev event.Name) (State, error) {
+	for i, e := range JobStateEvents {
+		if e == ev {
+			return jobStates[i], nil
+		}
+	}
+	return JobStateUnknown, fmt.Errorf("invalid job state %q", ev)
 }

--- a/pkg/job/events_test.go
+++ b/pkg/job/events_test.go
@@ -1,0 +1,26 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/facebookincubator/contest/pkg/event"
+)
+
+func TestEventToJobStateMapping(t *testing.T) {
+	m := map[State]event.Name{}
+	for _, e := range JobStateEvents {
+		st, err := EventNameToJobState(e)
+		require.NoError(t, err)
+		m[st] = e
+	}
+	require.Equal(t, 8, len(m))
+	st, err := EventNameToJobState(event.Name("foo"))
+	require.Error(t, err)
+	require.Equal(t, JobStateUnknown, st)
+	for k, v := range m {
+		require.Equal(t, k.String(), string(v))
+	}
+	require.Equal(t, JobStateUnknown.String(), "JobStateUnknown")
+}

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -296,6 +296,8 @@ func (jm *JobManager) handleEvent(ev *api.Event) {
 		resp = jm.stop(ev)
 	case api.EventTypeRetry:
 		resp = jm.retry(ev)
+	case api.EventTypeList:
+		resp = jm.list(ev)
 	default:
 		resp = &api.EventResponse{
 			Requestor: ev.Msg.Requestor(),

--- a/pkg/jobmanager/list.go
+++ b/pkg/jobmanager/list.go
@@ -1,0 +1,44 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package jobmanager
+
+import (
+	"fmt"
+
+	"github.com/facebookincubator/contest/pkg/api"
+	"github.com/facebookincubator/contest/pkg/storage"
+)
+
+func (jm *JobManager) list(ev *api.Event) *api.EventResponse {
+	evResp := &api.EventResponse{
+		Requestor: ev.Msg.Requestor(),
+		Err:       nil,
+	}
+	msg, ok := ev.Msg.(api.EventListMsg)
+	if !ok {
+		evResp.Err = fmt.Errorf("invaid argument type %T", ev.Msg)
+		return evResp
+	}
+	var queryFields []storage.JobQueryField
+	if len(msg.States) > 0 {
+		queryFields = append(queryFields, storage.QueryJobStates(msg.States...))
+	}
+	if len(msg.Tags) > 0 {
+		queryFields = append(queryFields, storage.QueryJobTags(msg.Tags...))
+	}
+	jobQuery, err := storage.BuildJobQuery(queryFields...)
+	if err != nil {
+		evResp.Err = fmt.Errorf("failed to build job query: %w", err)
+		return evResp
+	}
+	res, err := jm.jobStorageManager.ListJobs(jobQuery)
+	if err != nil {
+		evResp.Err = fmt.Errorf("failed to list jobs: %w", err)
+		return evResp
+	}
+	evResp.JobIDs = res
+	return evResp
+}

--- a/pkg/jobmanager/start.go
+++ b/pkg/jobmanager/start.go
@@ -37,7 +37,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 			Err:       fmt.Errorf("could not create job request: %v", err)}
 	}
 	j.ID = jobID
-	if err := jm.emitEvent(j.ID, EventJobStarted); err != nil {
+	if err := jm.emitEvent(j.ID, job.EventJobStarted); err != nil {
 		return &api.EventResponse{
 			Requestor: ev.Msg.Requestor(),
 			Err:       err,
@@ -63,18 +63,18 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 			if err != nil {
 				errCancellation := fmt.Errorf("Job %+v failed cancellation: %v", j, err)
 				log.Error(errCancellation)
-				_ = jm.emitErrEvent(jobID, EventJobCancellationFailed, errCancellation)
+				_ = jm.emitErrEvent(jobID, job.EventJobCancellationFailed, errCancellation)
 			} else {
-				_ = jm.emitEvent(jobID, EventJobCancelled)
+				_ = jm.emitEvent(jobID, job.EventJobCancelled)
 			}
 			return
 		case j.IsPaused():
 			if err != nil {
 				errPausing := fmt.Errorf("Job %+v failed pausing: %v", j, err)
 				log.Error(errPausing)
-				_ = jm.emitErrEvent(jobID, EventJobPauseFailed, errPausing)
+				_ = jm.emitErrEvent(jobID, job.EventJobPauseFailed, errPausing)
 			} else {
-				_ = jm.emitEvent(jobID, EventJobPaused)
+				_ = jm.emitEvent(jobID, job.EventJobPaused)
 			}
 			return
 		}
@@ -95,7 +95,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 		if err != nil {
 			errMsg := fmt.Sprintf("Job %+v failed after %s : %v", j, duration, err)
 			log.Errorf(errMsg)
-			_ = jm.emitErrEvent(jobID, EventJobFailed, err)
+			_ = jm.emitErrEvent(jobID, job.EventJobFailed, err)
 		} else {
 			// If the JobManager doesn't return any error, the outcome of the Job
 			// might have been any of the following:
@@ -106,13 +106,13 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 			switch {
 			case j.IsCancelled():
 				log.Infof("Job %+v completed cancellation", j)
-				eventToEmit = EventJobCancelled
+				eventToEmit = job.EventJobCancelled
 			case j.IsPaused():
 				log.Infof("Job %+v completed pausing", j)
-				eventToEmit = EventJobPaused
+				eventToEmit = job.EventJobPaused
 			default:
 				log.Infof("Job %+v completed after %s", j, duration)
-				eventToEmit = EventJobCompleted
+				eventToEmit = job.EventJobCompleted
 			}
 			log.Debugf("emitting: %v", eventToEmit)
 			err = jm.emitEvent(jobID, eventToEmit)
@@ -128,7 +128,7 @@ func (jm *JobManager) start(ev *api.Event) *api.EventResponse {
 		Err:       nil,
 		Status: &job.Status{
 			Name:      j.Name,
-			State:     string(EventJobStarted),
+			State:     string(job.EventJobStarted),
 			StartTime: time.Now(),
 		},
 	}

--- a/pkg/jobmanager/status.go
+++ b/pkg/jobmanager/status.go
@@ -28,7 +28,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 	// Fetch all the events associated to changes of state of the Job
 	jobEvents, err := jm.frameworkEvManager.FetchAsync(
 		frameworkevent.QueryJobID(jobID),
-		frameworkevent.QueryEventNames(JobStateEvents),
+		frameworkevent.QueryEventNames(job.JobStateEvents),
 	)
 	if err != nil {
 		evResp.Err = fmt.Errorf("could not fetch events associated to job state: %v", err)
@@ -52,12 +52,12 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 	)
 
 	completionEvents := make(map[event.Name]bool)
-	for _, eventName := range JobCompletionEvents {
+	for _, eventName := range job.JobCompletionEvents {
 		completionEvents[eventName] = true
 	}
 
 	for _, ev := range jobEvents {
-		if ev.EventName == EventJobStarted {
+		if ev.EventName == job.EventJobStarted {
 			startTime = ev.EmitTime
 		} else if _, ok := completionEvents[ev.EventName]; ok {
 			// A completion event has been seen for this Job. Only one completion event can be associated to the job
@@ -73,7 +73,7 @@ func (jm *JobManager) status(ev *api.Event) *api.EventResponse {
 	if len(jobEvents) > 0 {
 		je := jobEvents[len(jobEvents)-1]
 		state = string(je.EventName)
-		if je.EventName == EventJobFailed {
+		if je.EventName == job.EventJobFailed {
 			// if there was a framework failure, retrieve the failure event and
 			// the associated error message, so it can be exposed in the status.
 			if je.Payload == nil {

--- a/pkg/jobmanager/stop.go
+++ b/pkg/jobmanager/stop.go
@@ -26,14 +26,14 @@ func (jm *JobManager) stop(ev *api.Event) *api.EventResponse {
 		log.Errorf("Cannot stop job: %v", err)
 		return &api.EventResponse{Err: fmt.Errorf("could not stop job: %v", err)}
 	}
-	_ = jm.emitEvent(jobID, EventJobCancelling)
+	_ = jm.emitEvent(jobID, job.EventJobCancelling)
 	return &api.EventResponse{
 		JobID:     jobID,
 		Requestor: ev.Msg.Requestor(),
 		Err:       nil,
 		Status: &job.Status{
 			Name:      "UnknownJobName",
-			State:     string(EventJobCancelling),
+			State:     string(job.EventJobCancelling),
 			StartTime: time.Now(),
 		},
 	}

--- a/pkg/storage/events.go
+++ b/pkg/storage/events.go
@@ -14,6 +14,16 @@ import (
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 )
 
+type EventStorage interface {
+	// Test events storage interface
+	StoreTestEvent(event testevent.Event) error
+	GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, error)
+
+	// Framework events storage interface
+	StoreFrameworkEvent(event frameworkevent.Event) error
+	GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]frameworkevent.Event, error)
+}
+
 // TestEventEmitter implements Emitter interface from the testevent package
 type TestEventEmitter struct {
 	header testevent.Header

--- a/pkg/storage/events_test.go
+++ b/pkg/storage/events_test.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/types"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -46,6 +47,7 @@ func (n *nullStorage) StoreJobRequest(request *job.Request) (types.JobID, error)
 func (n *nullStorage) GetJobRequest(jobID types.JobID) (*job.Request, error)  { return nil, nil }
 func (n *nullStorage) StoreJobReport(report *job.JobReport) error             { return nil }
 func (n *nullStorage) GetJobReport(jobID types.JobID) (*job.JobReport, error) { return nil, nil }
+func (n *nullStorage) ListJobs(query *JobQuery) ([]types.JobID, error)        { return nil, nil }
 func (n *nullStorage) StoreTestEvent(event testevent.Event) error             { return nil }
 func (n *nullStorage) GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, error) {
 	return nil, nil

--- a/pkg/storage/job.go
+++ b/pkg/storage/job.go
@@ -12,27 +12,33 @@ import (
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
+// JobStorage defines the interface that implements persistence for job
+// related information
+type JobStorage interface {
+	// Job request interface
+	StoreJobRequest(request *job.Request) (types.JobID, error)
+	GetJobRequest(jobID types.JobID) (*job.Request, error)
+
+	// Job report interface
+	StoreJobReport(report *job.JobReport) error
+	GetJobReport(jobID types.JobID) (*job.JobReport, error)
+
+	// Job enumeration interface
+	ListJobs(query *JobQuery) ([]types.JobID, error)
+}
+
 // JobStorageManager implements JobStorage interface
 type JobStorageManager struct {
 }
 
 // StoreJobRequest submits a job request to the storage layer
 func (jsm JobStorageManager) StoreJobRequest(request *job.Request) (types.JobID, error) {
-	var jobID types.JobID
-	jobID, err := storage.StoreJobRequest(request)
-	if err != nil {
-		return jobID, fmt.Errorf("could not store job request: %v", err)
-	}
-	return jobID, nil
+	return storage.StoreJobRequest(request)
 }
 
 // GetJobRequest fetches a job request from the storage layer
 func (jsm JobStorageManager) GetJobRequest(jobID types.JobID) (*job.Request, error) {
-	request, err := storage.GetJobRequest(jobID)
-	if err != nil {
-		return nil, fmt.Errorf("could not fetch job request: %v", err)
-	}
-	return request, nil
+	return storage.GetJobRequest(jobID)
 }
 
 // GetJobRequest fetches a job request from the read-only storage layer
@@ -46,19 +52,17 @@ func (jsm JobStorageManager) GetJobRequestAsync(jobID types.JobID) (*job.Request
 
 // StoreJobReport submits a job report to the storage layer
 func (jsm JobStorageManager) StoreJobReport(report *job.JobReport) error {
-	if err := storage.StoreJobReport(report); err != nil {
-		return fmt.Errorf("could not persist job report: %v", err)
-	}
-	return nil
+	return storage.StoreJobReport(report)
 }
 
 // GetJobReport fetches a job report from the storage layer
 func (jsm JobStorageManager) GetJobReport(jobID types.JobID) (*job.JobReport, error) {
-	report, err := storage.GetJobReport(jobID)
-	if err != nil {
-		return nil, err
-	}
-	return report, nil
+	return storage.GetJobReport(jobID)
+}
+
+// ListJobs returns list of job IDs matching the query
+func (jsm JobStorageManager) ListJobs(query *JobQuery) ([]types.JobID, error) {
+	return storage.ListJobs(query)
 }
 
 // GetJobReportAsync fetches a job report from the read-only storage layer

--- a/pkg/storage/job_query.go
+++ b/pkg/storage/job_query.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/facebookincubator/contest/pkg/job"
+)
+
+type JobQueryField interface {
+	queryFieldPointer(query *JobQuery) interface{}
+}
+
+type JobQueryFields []JobQueryField
+
+type JobQuery struct {
+	States []job.State
+	Tags   []string
+}
+
+type jobQueryFieldStates []job.State
+type jobQueryFieldTags []string
+
+func QueryJobStates(states ...job.State) JobQueryField { return jobQueryFieldStates(states) }
+func (value jobQueryFieldStates) queryFieldPointer(query *JobQuery) interface{} {
+	return &query.States
+}
+
+func QueryJobTags(tags ...string) JobQueryField { return jobQueryFieldTags(tags) }
+func (value jobQueryFieldTags) queryFieldPointer(query *JobQuery) interface{} {
+	return &query.Tags
+}
+
+func BuildJobQuery(queryFields ...JobQueryField) (*JobQuery, error) {
+	return JobQueryFields(queryFields).BuildQuery()
+}
+
+func (queryFields JobQueryFields) BuildQuery() (*JobQuery, error) {
+	query := &JobQuery{}
+	for idx, queryField := range queryFields {
+		if err := ApplyJobQueryField(queryField.queryFieldPointer(query), queryField); err != nil {
+			return nil, fmt.Errorf("unable to apply field %d:%T(%v): %w", idx, queryField, queryField, err)
+		}
+	}
+	return query, nil
+}
+
+type ErrJobQueryFieldIsAlreadySet struct {
+	FieldValue interface{}
+	QueryField JobQueryField
+}
+
+func (err ErrJobQueryFieldIsAlreadySet) Error() string {
+	return fmt.Sprintf("field %T is set multiple times: cur_value:%v new_value:%v",
+		err.QueryField, err.FieldValue, err.QueryField)
+}
+
+// ErrQueryFieldHasZeroValue is returned when a QueryFields failed validation
+// due to a QueryField with a zero value (this is unexpected and forbidden).
+type ErrJobQueryFieldHasZeroValue struct {
+	QueryField JobQueryField
+}
+
+func (err ErrJobQueryFieldHasZeroValue) Error() string {
+	return fmt.Sprintf("field %T has a zero value", err.QueryField)
+}
+
+func ApplyJobQueryField(fieldPtr interface{}, queryField JobQueryField) error {
+	if reflect.ValueOf(queryField).IsZero() {
+		return ErrJobQueryFieldHasZeroValue{QueryField: queryField}
+	}
+	field := reflect.ValueOf(fieldPtr).Elem()
+	if !reflect.ValueOf(field.Interface()).IsZero() {
+		return ErrJobQueryFieldIsAlreadySet{FieldValue: field.Interface(), QueryField: queryField}
+	}
+	field.Set(reflect.ValueOf(queryField).Convert(field.Type()))
+	return nil
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -9,10 +9,6 @@ import (
 	"fmt"
 
 	"github.com/facebookincubator/contest/pkg/config"
-	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
-	"github.com/facebookincubator/contest/pkg/event/testevent"
-	"github.com/facebookincubator/contest/pkg/job"
-	"github.com/facebookincubator/contest/pkg/types"
 )
 
 // storage defines the storage engine used by ConTest. It can be overridden
@@ -20,29 +16,10 @@ import (
 var storage Storage
 var storageAsync Storage
 
-// JobStorage defines the interface that implements persistence for job
-// related information
-type JobStorage interface {
-	// Job request interface
-	StoreJobRequest(request *job.Request) (types.JobID, error)
-	GetJobRequest(jobID types.JobID) (*job.Request, error)
-
-	// Job report interface
-	StoreJobReport(report *job.JobReport) error
-	GetJobReport(jobID types.JobID) (*job.JobReport, error)
-}
-
 // Storage defines the interface that storage engines must implement
 type Storage interface {
 	JobStorage
-
-	// Test events storage interface
-	StoreTestEvent(event testevent.Event) error
-	GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, error)
-
-	// Framework events storage interface
-	StoreFrameworkEvent(event frameworkevent.Event) error
-	GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]frameworkevent.Event, error)
+	EventStorage
 
 	// Version returns the version of the storage being used
 	Version() (uint64, error)

--- a/pkg/transport/http/http.go
+++ b/pkg/transport/http/http.go
@@ -15,8 +15,10 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/facebookincubator/contest/pkg/api"
+	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/plugins/listeners/httplistener"
 
@@ -26,9 +28,9 @@ import (
 // HttpPartiallyDecodedResponse is a httplistener.HTTPAPIResponse, but with the Data not fully decoded yet
 type HTTPPartiallyDecodedResponse struct {
 	ServerID string
-	Type  string
-	Data  json.RawMessage
-	Error *xjson.Error
+	Type     string
+	Data     json.RawMessage
+	Error    *xjson.Error
 }
 
 // HTTP communicates with ConTest Server via http(s)/json transport
@@ -39,7 +41,7 @@ type HTTP struct {
 
 func (h *HTTP) Version(ctx context.Context, requestor string) (*api.VersionResponse, error) {
 	resp, err := h.request(requestor, "version", url.Values{})
-	if err != nil  {
+	if err != nil {
 		return nil, err
 	}
 	data := api.ResponseDataVersion{}
@@ -48,11 +50,12 @@ func (h *HTTP) Version(ctx context.Context, requestor string) (*api.VersionRespo
 	}
 	return &api.VersionResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
+
 func (h *HTTP) Start(ctx context.Context, requestor string, jobDescriptor string) (*api.StartResponse, error) {
 	params := url.Values{}
 	params.Add("jobDesc", jobDescriptor)
 	resp, err := h.request(requestor, "start", params)
-	if err != nil  {
+	if err != nil {
 		return nil, err
 	}
 	data := api.ResponseDataStart{}
@@ -61,11 +64,12 @@ func (h *HTTP) Start(ctx context.Context, requestor string, jobDescriptor string
 	}
 	return &api.StartResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
+
 func (h *HTTP) Stop(ctx context.Context, requestor string, jobID types.JobID) (*api.StopResponse, error) {
 	params := url.Values{}
 	params.Add("jobID", strconv.Itoa(int(jobID)))
 	resp, err := h.request(requestor, "stop", params)
-	if err != nil  {
+	if err != nil {
 		return nil, err
 	}
 	data := api.ResponseDataStop{}
@@ -74,11 +78,12 @@ func (h *HTTP) Stop(ctx context.Context, requestor string, jobID types.JobID) (*
 	}
 	return &api.StopResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
+
 func (h *HTTP) Status(ctx context.Context, requestor string, jobID types.JobID) (*api.StatusResponse, error) {
 	params := url.Values{}
 	params.Add("jobID", strconv.Itoa(int(jobID)))
 	resp, err := h.request(requestor, "status", params)
-	if err != nil  {
+	if err != nil {
 		return nil, err
 	}
 	data := api.ResponseDataStatus{}
@@ -87,11 +92,12 @@ func (h *HTTP) Status(ctx context.Context, requestor string, jobID types.JobID) 
 	}
 	return &api.StatusResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
+
 func (h *HTTP) Retry(ctx context.Context, requestor string, jobID types.JobID) (*api.RetryResponse, error) {
 	params := url.Values{}
 	params.Add("jobID", strconv.Itoa(int(jobID)))
 	resp, err := h.request(requestor, "retry", params)
-	if err != nil  {
+	if err != nil {
 		return nil, err
 	}
 	data := api.ResponseDataRetry{}
@@ -99,6 +105,29 @@ func (h *HTTP) Retry(ctx context.Context, requestor string, jobID types.JobID) (
 		return nil, fmt.Errorf("cannot decode json response: %v", err)
 	}
 	return &api.RetryResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
+}
+
+func (h *HTTP) List(ctx context.Context, requestor string, states []job.State, tags []string) (*api.ListResponse, error) {
+	params := url.Values{}
+	if len(states) > 0 {
+		sts := make([]string, len(states))
+		for i, st := range states {
+			sts[i] = st.String()
+		}
+		params.Set("states", strings.Join(sts, ","))
+	}
+	if len(tags) > 0 {
+		params.Set("tags", strings.Join(tags, ","))
+	}
+	resp, err := h.request(requestor, "list", params)
+	if err != nil {
+		return nil, err
+	}
+	var data api.ResponseDataList
+	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	}
+	return &api.ListResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
 
 func (h *HTTP) request(requestor string, verb string, params url.Values) (*HTTPPartiallyDecodedResponse, error) {

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/facebookincubator/contest/pkg/api"
+	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
@@ -20,4 +21,5 @@ type Transport interface {
 	Stop(ctx context.Context, requestor string, jobID types.JobID) (*api.StopResponse, error)
 	Status(ctx context.Context, requestor string, jobID types.JobID) (*api.StatusResponse, error)
 	Retry(ctx context.Context, requestor string, jobID types.JobID) (*api.RetryResponse, error)
+	List(ctx context.Context, requestor string, states []job.State, tags []string) (*api.ListResponse, error)
 }

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -6,7 +6,9 @@
 package memory
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -26,8 +28,14 @@ type Memory struct {
 	testEvents      []testevent.Event
 	frameworkEvents []frameworkevent.Event
 	jobIDCounter    types.JobID
-	jobRequests     map[types.JobID]*job.Request
-	jobReports      map[types.JobID]*job.JobReport
+	jobInfo         map[types.JobID]*jobInfo
+}
+
+type jobInfo struct {
+	request *job.Request
+	desc    *job.JobDescriptor
+	report  *job.JobReport
+	state   job.State
 }
 
 func emptyEventQuery(eventQuery *event.Query) bool {
@@ -139,8 +147,7 @@ func (m *Memory) Reset() error {
 	defer m.lock.Unlock()
 	m.testEvents = []testevent.Event{}
 	m.frameworkEvents = []frameworkevent.Event{}
-	m.jobRequests = make(map[types.JobID]*job.Request)
-	m.jobReports = make(map[types.JobID]*job.JobReport)
+	m.jobInfo = make(map[types.JobID]*jobInfo)
 	m.jobIDCounter = 1
 	return nil
 }
@@ -150,21 +157,30 @@ func (m *Memory) StoreJobRequest(request *job.Request) (types.JobID, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	request.JobID = m.jobIDCounter
+	jobID := m.jobIDCounter
 	m.jobIDCounter++
-	m.jobRequests[request.JobID] = request
-	return request.JobID, nil
+	request.JobID = jobID
+	info := &jobInfo{
+		request: request,
+		desc:    &job.JobDescriptor{},
+		state:   job.JobStateUnknown,
+	}
+	if err := json.Unmarshal([]byte(request.JobDescriptor), info.desc); err != nil {
+		return 0, fmt.Errorf("invalid job descriptor: %w", err)
+	}
+	m.jobInfo[jobID] = info
+	return jobID, nil
 }
 
 // GetJobRequest retrieves a job request from the in memory list
 func (m *Memory) GetJobRequest(jobID types.JobID) (*job.Request, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	v, ok := m.jobRequests[jobID]
-	if !ok {
+	v := m.jobInfo[jobID]
+	if v == nil || v.request == nil {
 		return nil, fmt.Errorf("could not find job request with id %v", jobID)
 	}
-	return v, nil
+	return v.request, nil
 }
 
 // StoreJobReport stores a report associated to a job. Returns an error if there is
@@ -172,11 +188,14 @@ func (m *Memory) GetJobRequest(jobID types.JobID) (*job.Request, error) {
 func (m *Memory) StoreJobReport(report *job.JobReport) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	_, ok := m.jobReports[report.JobID]
-	if ok {
+	v := m.jobInfo[report.JobID]
+	if v == nil {
+		return fmt.Errorf("could not find job with id %v", report.JobID)
+	}
+	if v.report != nil {
 		return fmt.Errorf("job report already present for job id %v", report.JobID)
 	}
-	m.jobReports[report.JobID] = report
+	v.report = report
 	return nil
 }
 
@@ -184,11 +203,62 @@ func (m *Memory) StoreJobReport(report *job.JobReport) error {
 func (m *Memory) GetJobReport(jobID types.JobID) (*job.JobReport, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if _, ok := m.jobReports[jobID]; !ok {
+	v := m.jobInfo[jobID]
+	if v == nil || v.report == nil {
 		// return a job report with no results
 		return &job.JobReport{JobID: jobID}, nil
 	}
-	return m.jobReports[jobID], nil
+	return v.report, nil
+}
+
+func (m *Memory) ListJobs(query *storage.JobQuery) ([]types.JobID, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	res := []types.JobID{}
+	if err := job.CheckTags(query.Tags); err != nil {
+		return nil, err
+	}
+jobLoop:
+	for jobId, jobInfo := range m.jobInfo {
+		if len(query.Tags) > 0 {
+			for _, qTag := range query.Tags {
+				found := false
+				for _, jTag := range jobInfo.desc.Tags {
+					if jTag == qTag {
+						found = true
+					}
+				}
+				if !found {
+					continue jobLoop
+				}
+			}
+		}
+		if len(query.States) > 0 {
+			var lastEventTime time.Time
+			jobState := job.JobStateUnknown
+			for _, event := range m.frameworkEvents {
+				if eventJobMatch(jobId, event.JobID) &&
+					eventNameMatch(job.JobStateEvents, event.EventName) &&
+					event.EmitTime.After(lastEventTime) {
+					jobState, _ = job.EventNameToJobState(event.EventName)
+					lastEventTime = event.EmitTime
+				}
+			}
+			found := false
+			for _, queryState := range query.States {
+				if jobState == queryState {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue jobLoop
+			}
+		}
+		res = append(res, jobId)
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i] < res[j] })
+	return res, nil
 }
 
 // StoreFrameworkEvent stores a framework event into the database
@@ -227,8 +297,7 @@ func (m *Memory) Version() (uint64, error) {
 // New create a new Memory events storage backend
 func New() (storage.Storage, error) {
 	m := Memory{lock: &sync.Mutex{}}
-	m.jobRequests = make(map[types.JobID]*job.Request)
-	m.jobReports = make(map[types.JobID]*job.JobReport)
+	m.jobInfo = make(map[types.JobID]*jobInfo)
 	m.jobIDCounter = 1
 	return &m, nil
 }

--- a/plugins/storage/rdbms/events.go
+++ b/plugins/storage/rdbms/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/types"
 )
@@ -250,8 +251,8 @@ func (r *RDBMS) GetTestEvents(eventQuery *testevent.Query) ([]testevent.Event, e
 
 	// TargetID might be null, so a type which supports null should be used with Scan
 	var (
-		targetID   sql.NullString
-		payload    sql.NullString
+		targetID sql.NullString
+		payload  sql.NullString
 	)
 
 	defer func() {
@@ -334,23 +335,36 @@ func (r *RDBMS) StoreFrameworkEvent(event frameworkevent.Event) error {
 	return nil
 }
 
+const (
+	insertFEStmt       = "INSERT INTO framework_events (job_id, event_name, payload, emit_time) VALUES (?, ?, ?, ?)"
+	updateJobStateStmt = "UPDATE jobs SET state = ? WHERE job_id = ?"
+)
+
 // FlushFrameworkEvents forces a flush of the pending frameworks events to the database
 // Requires that the caller has already locked the corresponding buffer
 func (r *RDBMS) flushFrameworkEvents() error {
-
 	r.lockTx()
 	defer r.unlockTx()
 
-	insertStatement := "insert into framework_events (job_id, event_name, payload, emit_time) values (?, ?, ?, ?)"
+	// TODO: put this into a transaction.
+	jobStateUpdates := map[types.JobID]job.State{}
 	for _, event := range r.buffFrameworkEvents {
 		_, err := r.db.Exec(
-			insertStatement,
+			insertFEStmt,
 			FrameworkEventJobID(event),
 			FrameworkEventName(event),
 			FrameworkEventPayload(event),
 			FrameworkEventEmitTime(event))
 		if err != nil {
 			return fmt.Errorf("could not store event in database: %v", err)
+		}
+		if sn, err := job.EventNameToJobState(event.EventName); err == nil {
+			jobStateUpdates[event.JobID] = sn
+		}
+	}
+	for jobID, state := range jobStateUpdates {
+		if _, err := r.db.Exec(updateJobStateStmt, state, jobID); err != nil {
+			return fmt.Errorf("could not update state of job %d: %w", jobID, err)
 		}
 	}
 	r.buffFrameworkEvents = nil
@@ -364,7 +378,6 @@ func (r *RDBMS) GetFrameworkEvent(eventQuery *frameworkevent.Query) ([]framework
 	r.frameworkEventsLock.Lock()
 	err := r.flushFrameworkEvents()
 	r.frameworkEventsLock.Unlock()
-
 	if err != nil {
 		return nil, fmt.Errorf("could not flush events before reading events: %v", err)
 	}

--- a/plugins/storage/rdbms/init.go
+++ b/plugins/storage/rdbms/init.go
@@ -54,8 +54,8 @@ type RDBMS struct {
 	buffTestEvents      []testevent.Event
 	buffFrameworkEvents []frameworkevent.Event
 
-	testEventsLock      *sync.Mutex
-	frameworkEventsLock *sync.Mutex
+	testEventsLock      sync.Mutex
+	frameworkEventsLock sync.Mutex
 
 	// sql.Tx is not safe for concurrent use. This means that both Query, Exec operations
 	// and rows scanning should be serialized. txLock is acquired and released by all
@@ -99,7 +99,7 @@ func (r *RDBMS) BeginTx() (storage.TransactionalStorage, error) {
 	if err != nil {
 		return nil, err
 	}
-	txRDBMS := RDBMS{testEventsLock: &sync.Mutex{}, frameworkEventsLock: &sync.Mutex{}, txLock: sync.Mutex{}, db: tx}
+	txRDBMS := RDBMS{db: tx}
 	return &txRDBMS, nil
 }
 
@@ -218,7 +218,7 @@ func DriverName(name string) Opt {
 func New(dbURI string, opts ...Opt) (storage.Storage, error) {
 
 	// Default flushInterval and buffer sizes are zero (i.e., by default the backend is not buffered)
-	rdbms := RDBMS{testEventsLock: &sync.Mutex{}, frameworkEventsLock: &sync.Mutex{}, dbURI: dbURI}
+	rdbms := RDBMS{dbURI: dbURI}
 	for _, Opt := range opts {
 		Opt(&rdbms)
 	}

--- a/plugins/storage/rdbms/list_jobs.go
+++ b/plugins/storage/rdbms/list_jobs.go
@@ -1,0 +1,84 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package rdbms
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/storage"
+	"github.com/facebookincubator/contest/pkg/types"
+)
+
+func (r *RDBMS) ListJobs(query *storage.JobQuery) ([]types.JobID, error) {
+	res := []types.JobID{}
+
+	// Quoting SQL strings is hard. https://github.com/golang/go/issues/18478
+	// For now, just disallow anything that is not [a-zA-Z0-9_-]
+	if err := job.CheckTags(query.Tags); err != nil {
+		return nil, err
+	}
+
+	// Job state is updated by framework events, ensure there aren't any pending.
+	r.frameworkEventsLock.Lock()
+	err := r.flushFrameworkEvents()
+	r.frameworkEventsLock.Unlock()
+	if err != nil {
+		return nil, fmt.Errorf("could not flush events before reading events: %v", err)
+	}
+
+	// Construct the query.
+	parts := []string{"SELECT jobs.job_id FROM jobs"}
+	qargs := []interface{}{}
+	// Tag filtering uses joins, 1 per tag.
+	for i := range query.Tags {
+		parts = append(parts, fmt.Sprintf(`INNER JOIN job_tags jt%d ON jobs.job_id = jt%d.job_id`, i, i))
+	}
+	var conds []string
+	if len(query.States) > 0 {
+		stst := make([]string, len(query.States))
+		for i, st := range query.States {
+			stst[i] = "?"
+			qargs = append(qargs, st)
+		}
+		conds = append(conds, fmt.Sprintf("jobs.state IN (%s)", strings.Join(stst, ", ")))
+	}
+	// Now the corresponding conditions.
+	for i, tag := range query.Tags {
+		conds = append(conds, fmt.Sprintf("jt%d.tag = ?", i))
+		qargs = append(qargs, tag)
+	}
+	if len(conds) > 0 {
+		parts = append(parts, "WHERE", strings.Join(conds, " AND "))
+	}
+	/* Examples of the resulting queries:
+	SELECT jobs.job_id FROM jobs
+	SELECT jobs.job_id FROM jobs WHERE jobs.state IN (0)
+	SELECT jobs.job_id FROM jobs WHERE jobs.state IN (2, 3)
+	SELECT jobs.job_id FROM jobs INNER JOIN job_tags jt0 ON jobs.job_id = jt0.job_id WHERE jt0.tag = "tests"
+	SELECT jobs.job_id FROM jobs INNER JOIN job_tags jt0 ON jobs.job_id = jt0.job_id INNER JOIN job_tags jt1 ON jobs.job_id = jt1.job_id WHERE jobs.state IN (2, 3, 4) AND jt0.tag = "tests" AND jt1.tag = "foo"
+	*/
+	parts = append(parts, "ORDER BY jobs.job_id")
+	stmt := strings.Join(parts, " ")
+
+	rows, err := r.db.Query(stmt, qargs...)
+	if err != nil {
+		return nil, fmt.Errorf("could not list jobs in states (sql: %q): %w", stmt, err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+	for rows.Next() {
+		var jobID types.JobID
+		if err := rows.Scan(&jobID); err != nil {
+			return nil, fmt.Errorf("could not list jobs in states (sql: %q): %w", stmt, err)
+		}
+		res = append(res, jobID)
+	}
+
+	return res, nil
+}

--- a/plugins/storage/rdbms/request.go
+++ b/plugins/storage/rdbms/request.go
@@ -14,17 +14,30 @@ import (
 	"github.com/facebookincubator/contest/pkg/types"
 )
 
+const (
+	insertJobStmt    = "insert into jobs (name, descriptor, teststeps, requestor, server_id, request_time) values (?, ?, ?, ?, ?, ?)"
+	insertJobTagStmt = "insert into job_tags (job_id, tag) values (?, ?)"
+)
+
 // StoreJobRequest stores a new job request in the database
 func (r *RDBMS) StoreJobRequest(request *job.Request) (types.JobID, error) {
 
 	var jobID types.JobID
 
+	// Extract job tags for insertion.
+	var desc job.JobDescriptor
+	if err := json.Unmarshal([]byte(request.JobDescriptor), &desc); err != nil {
+		return 0, fmt.Errorf("invalid job descriptor: %w", err)
+	}
+	if err := job.CheckTags(desc.Tags); err != nil {
+		return 0, err
+	}
+
 	r.lockTx()
 	defer r.unlockTx()
 
 	// store job descriptor
-	insertStatement := "insert into jobs (name, descriptor, teststeps, requestor, server_id, request_time) values (?, ?, ?, ?, ?, ?)"
-	result, err := r.db.Exec(insertStatement, request.JobName, request.JobDescriptor, request.TestDescriptors, request.Requestor, request.ServerID, request.RequestTime)
+	result, err := r.db.Exec(insertJobStmt, request.JobName, request.JobDescriptor, request.TestDescriptors, request.Requestor, request.ServerID, request.RequestTime)
 	if err != nil {
 		return jobID, fmt.Errorf("could not store job request in database: %w", err)
 	}
@@ -33,6 +46,12 @@ func (r *RDBMS) StoreJobRequest(request *job.Request) (types.JobID, error) {
 		return jobID, fmt.Errorf("could not extract id of last request inserted into db")
 	}
 	jobID = types.JobID(lastID)
+
+	for _, tag := range desc.Tags {
+		if _, err := r.db.Exec(insertJobTagStmt, jobID, tag); err != nil {
+			return 0, fmt.Errorf("could not store job tag in the database: %w", err)
+		}
+	}
 
 	return jobID, nil
 }

--- a/tests/integ/job/common.go
+++ b/tests/integ/job/common.go
@@ -10,13 +10,14 @@ package test
 import (
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/storage"
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/tests/integ/common"
-
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 var jobDescriptorFirst = `
@@ -24,14 +25,15 @@ var jobDescriptorFirst = `
     "JobName": "FirstJob",
     "Runs": 1,
     "RunInterval": "5s",
-    "Tags": ["integ", "tests"]
+    "Tags": ["integ", "tests", "foo"]
   }
 `
 var jobDescriptorSecond = `
   {
     "JobName": "SecondJob",
     "Runs": 1,
-    "RunInterval": "5s"
+    "RunInterval": "5s",
+    "Tags": ["integ"]
   }
 `
 
@@ -68,6 +70,7 @@ func (suite *JobSuite) TearDownTest() {
 }
 
 func (suite *JobSuite) TestGetJobRequest() {
+	t := suite.T()
 
 	jobRequestFirst := job.Request{
 		JobName:         "AName",
@@ -77,7 +80,7 @@ func (suite *JobSuite) TestGetJobRequest() {
 		TestDescriptors: testDescs,
 	}
 	jobIDa, err := suite.txStorage.StoreJobRequest(&jobRequestFirst)
-	require.NoError(suite.T(), err)
+	require.NoError(t, err)
 
 	jobRequestSecond := job.Request{
 		JobName:         "BName",
@@ -87,31 +90,133 @@ func (suite *JobSuite) TestGetJobRequest() {
 		TestDescriptors: testDescs,
 	}
 	jobIDb, err := suite.txStorage.StoreJobRequest(&jobRequestSecond)
-	require.NoError(suite.T(), err)
+	require.NoError(t, err)
 
 	request, err := suite.txStorage.GetJobRequest(jobIDa)
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), types.JobID(jobIDa), request.JobID)
-	require.Equal(suite.T(), request.Requestor, "AIntegrationTest")
-	require.Equal(suite.T(), request.JobDescriptor, jobDescriptorFirst)
+	require.NoError(t, err)
+	require.Equal(t, types.JobID(jobIDa), request.JobID)
+	require.Equal(t, request.Requestor, "AIntegrationTest")
+	require.Equal(t, request.JobDescriptor, jobDescriptorFirst)
 
 	// Creation timestamp corresponds to the timestamp of the insertion into the
 	// database. Assert that the timestamp retrieved from the database is within
 	// and acceptable range
-	require.True(suite.T(), request.RequestTime.After(time.Now().Add(-2*time.Second)))
-	require.True(suite.T(), request.RequestTime.Before(time.Now().Add(2*time.Second)))
+	require.True(t, request.RequestTime.After(time.Now().Add(-2*time.Second)))
+	require.True(t, request.RequestTime.Before(time.Now().Add(2*time.Second)))
 
 	request, err = suite.txStorage.GetJobRequest(jobIDb)
 
 	// Creation timestamp corresponds to the timestamp of the insertion into the
 	// database. Assert that the timestamp retrieved from the database is within
 	// and acceptable range
-	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), types.JobID(jobIDb), request.JobID)
-	require.Equal(suite.T(), request.Requestor, "BIntegrationTest")
-	require.Equal(suite.T(), request.JobDescriptor, jobDescriptorSecond)
+	require.NoError(t, err)
+	require.Equal(t, types.JobID(jobIDb), request.JobID)
+	require.Equal(t, request.Requestor, "BIntegrationTest")
+	require.Equal(t, request.JobDescriptor, jobDescriptorSecond)
 
-	require.True(suite.T(), request.RequestTime.After(time.Now().Add(-2*time.Second)))
-	require.True(suite.T(), request.RequestTime.Before(time.Now().Add(2*time.Second)))
+	require.True(t, request.RequestTime.After(time.Now().Add(-2*time.Second)))
+	require.True(t, request.RequestTime.Before(time.Now().Add(2*time.Second)))
 
+}
+
+func mustBuildQuery(t require.TestingT, queryFields ...storage.JobQueryField) *storage.JobQuery {
+	jobQuery, err := storage.BuildJobQuery(queryFields...)
+	require.NoError(t, err)
+	return jobQuery
+}
+
+func (suite *JobSuite) TestListJobs() {
+	t := suite.T()
+
+	jobRequestFirst := job.Request{
+		JobName:         "AName",
+		Requestor:       "AIntegrationTest",
+		RequestTime:     time.Now(),
+		JobDescriptor:   jobDescriptorFirst,
+		TestDescriptors: testDescs,
+	}
+	jobIDa, err := suite.txStorage.StoreJobRequest(&jobRequestFirst)
+	require.NoError(t, err)
+
+	jobRequestSecond := job.Request{
+		JobName:         "BName",
+		Requestor:       "BIntegrationTest",
+		RequestTime:     time.Now(),
+		JobDescriptor:   jobDescriptorSecond,
+		TestDescriptors: testDescs,
+	}
+	jobIDb, err := suite.txStorage.StoreJobRequest(&jobRequestSecond)
+	require.NoError(t, err)
+
+	var res []types.JobID
+
+	// No match criteria - returns all jobs.
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa, jobIDb}, res)
+
+	// List by states - matching any state is enough.
+	// Both jobs are currently in Unknown state.
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobStates(job.JobStateCompleted, job.JobStateFailed),
+	))
+	require.NoError(t, err)
+	require.Empty(t, res)
+	require.NotNil(t, res)
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobStates(job.JobStateCompleted, job.JobStateFailed, job.JobStateUnknown),
+	))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa, jobIDb}, res)
+
+	// Tag matching - single tag.
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobTags("tests")))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa}, res)
+
+	// Tag matching - must match all tags.
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobTags("integ", "tests")))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa}, res)
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobTags("integ", "tests", "no_such_tag")))
+	require.NoError(t, err)
+	require.Empty(t, res)
+	require.NotNil(t, res)
+
+	// Match by state - without any events both jobs are in unknown state.
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobStates(job.JobStateUnknown)))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa, jobIDb}, res)
+
+	// Inject state events
+	require.NoError(t, suite.txStorage.StoreFrameworkEvent(frameworkevent.Event{
+		JobID: jobIDa, EventName: job.EventJobStarted, EmitTime: time.Unix(1, 0),
+	}))
+	require.NoError(t, suite.txStorage.StoreFrameworkEvent(frameworkevent.Event{
+		JobID: jobIDb, EventName: job.EventJobStarted, EmitTime: time.Unix(2, 0),
+	}))
+	require.NoError(t, suite.txStorage.StoreFrameworkEvent(frameworkevent.Event{
+		JobID: jobIDb, EventName: job.EventJobFailed, EmitTime: time.Unix(3, 0),
+	}))
+	require.NoError(t, suite.txStorage.StoreFrameworkEvent(frameworkevent.Event{
+		JobID: jobIDa, EventName: job.EventJobCompleted, EmitTime: time.Unix(4, 0),
+	}))
+
+	// Multiple states - match any of them
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobStates(job.JobStateCompleted, job.JobStateFailed, job.JobStatePaused)))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa, jobIDb}, res)
+
+	// State and tag match - must match both
+	res, err = suite.txStorage.ListJobs(mustBuildQuery(t,
+		storage.QueryJobStates(job.JobStateCompleted, job.JobStateFailed, job.JobStatePaused),
+		storage.QueryJobTags("tests", "foo"),
+	))
+	require.NoError(t, err)
+	require.Equal(t, []types.JobID{jobIDa}, res)
 }

--- a/tests/integ/jobmanager/common.go
+++ b/tests/integ/jobmanager/common.go
@@ -249,7 +249,7 @@ func (suite *TestJobManagerSuite) TearDownTest() {
 }
 
 func (suite *TestJobManagerSuite) TestPauseAndExit() {
-	suite.testExit(syscall.SIGINT, jobmanager.EventJobPaused, time.Second)
+	suite.testExit(syscall.SIGINT, job.EventJobPaused, time.Second)
 }
 
 func (suite *TestJobManagerSuite) testExit(
@@ -266,7 +266,7 @@ func (suite *TestJobManagerSuite) testExit(
 	require.NoError(suite.T(), err)
 
 	// JobManager will emit an EventJobStarted when the Job is started
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobStarted, jobID)
+	ev, err := pollForEvent(suite.eventManager, job.EventJobStarted, jobID)
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -315,12 +315,12 @@ func (suite *TestJobManagerSuite) TestJobManagerJobStartSingle() {
 	require.NotEqual(suite.T(), nil, r)
 
 	// JobManager will emit an EventJobStarted when the Job is started
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobStarted, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobStarted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
 	// JobManager will emit an EventJobCompleted when the Job completes
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCompleted, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, job.EventJobCompleted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -336,7 +336,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobReport() {
 	require.NoError(suite.T(), err)
 
 	// JobManager will emit an EventJobCompleted when the Job completes
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobCompleted, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobCompleted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -365,7 +365,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellation() {
 
 	// Wait EventJobStarted event. This is necessary so that we can later issue a
 	// Stop command for a Job that we know is already running.
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobStarted, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobStarted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -375,7 +375,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellation() {
 
 	// JobManager will emit an EventJobCancelling as soon as the cancellation signal
 	// is asserted
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancelling, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, job.EventJobCancelling, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -383,7 +383,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellation() {
 	// cancellation successfully (completing cancellation successfully means that
 	// the TestRunner returns within the timeout and that TargetManage.Release()
 	// all targets)
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancelled, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, job.EventJobCancelled, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 }
@@ -400,7 +400,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobNotSuccessful() {
 
 	// If the Job completes, but the result of the reporting phase indicates a failure,
 	// an EventJobCompleted is emitted and the Report will indicate that the Job was unsuccessful
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobCompleted, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobCompleted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -422,7 +422,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobFailure() {
 
 	// If the Job completes, but the result of the reporting phase indicates a failure,
 	// an EventJobCompleted is emitted and the Report will indicate that the Job was unsuccessful
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobCompleted, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobCompleted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -443,7 +443,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCrash() {
 	// If the Job does not complete and returns an error instead, an EventJobFailed
 	// is emitted. The report will indicate that the job was unsuccessful, and
 	// the report calculate by the plugin will be nil
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobFailed, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobFailed, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 	require.Equal(suite.T(), "{\"Err\":\"TestStep crashed\"}", string(*ev[0].Payload))
@@ -469,7 +469,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellationFailure() {
 
 	// Wait EventJobStarted event. This is necessary so that we can later issue a
 	// Stop command for a Job that we know is already running.
-	ev, err := pollForEvent(suite.eventManager, jobmanager.EventJobStarted, types.JobID(jobID))
+	ev, err := pollForEvent(suite.eventManager, job.EventJobStarted, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -478,7 +478,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellationFailure() {
 
 	// JobManager will emit an EventJobCancelling as soon as the cancellation signal
 	// is asserted
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancelling, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, job.EventJobCancelling, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 
@@ -486,7 +486,7 @@ func (suite *TestJobManagerSuite) TestJobManagerJobCancellationFailure() {
 	// completed cancellation successfully (completing cancellation successfully
 	// means that the TestRunner returns within the timeout and that
 	// TargetManage.Release() all targets)
-	ev, err = pollForEvent(suite.eventManager, jobmanager.EventJobCancelling, types.JobID(jobID))
+	ev, err = pollForEvent(suite.eventManager, job.EventJobCancelling, types.JobID(jobID))
 	require.NoError(suite.T(), err)
 	require.Equal(suite.T(), 1, len(ev))
 

--- a/tests/integ/migration/0002_migrate_descriptor_to_extended_descriptor_test.go
+++ b/tests/integ/migration/0002_migrate_descriptor_to_extended_descriptor_test.go
@@ -38,7 +38,7 @@ type TestDescriptorMigrationSuite struct {
 func (suite *TestDescriptorMigrationSuite) SetupTest() {
 	// Setup raw connection to the db. We cannoit use storage plugin directly
 	// because we need to populate data into the db in a format
-	db, err := sql.Open("mysql", common.DbURI)
+	db, err := sql.Open("mysql", common.GetDatabaseURI())
 	if err != nil {
 		panic(fmt.Sprintf("could not initialize TestDescriptorMigrationSuite: %v", err))
 	}

--- a/tests/plugins/targetlocker/dblocker/dblocker_test.go
+++ b/tests/plugins/targetlocker/dblocker/dblocker_test.go
@@ -12,15 +12,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/facebookincubator/contest/pkg/logging"
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/plugins/targetlocker/dblocker"
-	"github.com/stretchr/testify/assert"
+	"github.com/facebookincubator/contest/tests/integ/common"
 )
 
 var (
-	jobID = types.JobID(123)
+	jobID                                 = types.JobID(123)
 	defaultJobTargetManagerAcquireTimeout = 2 * time.Second
 
 	targetOne  = target.Target{ID: "001"}
@@ -37,8 +39,7 @@ func TestMain(m *testing.M) {
 	logging.GetLogger("tests/integ")
 	logging.Disable()
 
-	dbURI := "contest:contest@tcp(mysql:3306)/contest_integ?parseTime=true"
-	locker, err := dblocker.New(dbURI)
+	locker, err := dblocker.New(common.GetDatabaseURI())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
With filtering by state and tags.

ListJobs call is added to the Storage interface and implemented for both
in-memory and RDBMS storage plugins. RDBMS implementation requires
database schema changes to allow efficient lookups:
 * "state" column is added to the jobs table
 * "job_tags" table is added to map tags to job_id

Database migration script is provided to create and populate the new
columns. Going forward, they will be maintained by the server.

This is take 2, first was #213 but was reverted due to unrelated issue.
There are no substantial changes here.