### PR TITLE
Add instance tag

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -36,12 +36,14 @@ var (
 	flagServerID       = flag.String("serverID", "", "Set a static server ID, e.g. the host name or another unique identifier. If unset, will use the listener's default")
 	flagProcessTimeout = flag.Duration("processTimeout", api.DefaultEventTimeout, "API request processing timeout")
 	flagTargetLocker   = flag.String("targetLocker", inmemory.Name, "Target locker implementation to use")
+	flagInstanceTag    = flag.String("instanceTag", "", "A tag for this instance. Server will only operate on jobs with this tag and will add this tag to the jobs it creates.")
 )
 
 func main() {
 	flag.Parse()
 	log := logging.GetLogger("contest")
 	log.Level = logrus.DebugLevel
+	logging.Debug()
 
 	pluginRegistry := pluginregistry.NewPluginRegistry()
 
@@ -126,6 +128,9 @@ func main() {
 	}
 	if *flagServerID != "" {
 		opts = append(opts, jobmanager.APIOption(api.OptionServerID(*flagServerID)))
+	}
+	if *flagInstanceTag != "" {
+		opts = append(opts, jobmanager.OptionInstanceTag(*flagInstanceTag))
 	}
 
 	jm, err := jobmanager.New(&listener, pluginRegistry, opts...)

--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/facebookincubator/contest/pkg/target"
 
 	"github.com/facebookincubator/contest/plugins/listeners/httplistener"
+	"github.com/facebookincubator/contest/plugins/storage/memory"
 	"github.com/facebookincubator/contest/plugins/storage/rdbms"
 
 	"github.com/facebookincubator/contest/plugins/targetlocker/dblocker"
@@ -45,46 +46,60 @@ func main() {
 	pluginRegistry := pluginregistry.NewPluginRegistry()
 
 	// primary storage initialization
-	log.Infof("Using database URI for primary storage: %s", *flagDBURI)
+	if *flagDBURI != "" {
+		log.Infof("Using database URI for primary storage: %s", *flagDBURI)
 
-	primaryDBURI := *flagDBURI
-	s, err := rdbms.New(primaryDBURI)
-	if err != nil {
-		log.Fatalf("Could not initialize database: %v", err)
-	}
-	if err := storage.SetStorage(s); err != nil {
-		log.Fatalf("Could not set storage: %v", err)
-	}
+		primaryDBURI := *flagDBURI
+		s, err := rdbms.New(primaryDBURI)
+		if err != nil {
+			log.Fatalf("Could not initialize database: %v", err)
+		}
+		if err := storage.SetStorage(s); err != nil {
+			log.Fatalf("Could not set storage: %v", err)
+		}
 
-	dbVerPrim, err := s.Version()
-	if err != nil {
-		log.Warningf("Could not determine storage version: %v", err)
+		dbVerPrim, err := s.Version()
+		if err != nil {
+			log.Warningf("Could not determine storage version: %v", err)
+		} else {
+			log.Infof("Storage version: %d", dbVerPrim)
+		}
+
+		// replica storage initialization
+		log.Infof("Using database URI for replica storage: %s", *flagDBURI)
+
+		// pointing to main database for now but can be used to point to replica
+		replicaDBURI := *flagDBURI
+		r, err := rdbms.New(replicaDBURI)
+		if err != nil {
+			log.Fatalf("Could not initialize replica database: %v", err)
+		}
+		if err := storage.SetAsyncStorage(r); err != nil {
+			log.Fatalf("Could not set replica storage: %v", err)
+		}
+
+		dbVerRepl, err := r.Version()
+		if err != nil {
+			log.Warningf("Could not determine storage version: %v", err)
+		} else {
+			log.Infof("Storage version: %d", dbVerRepl)
+		}
+
+		if dbVerPrim != dbVerRepl {
+			log.Fatalf("Primary and Replica DB Versions are different: %v and %v", dbVerPrim, dbVerRepl)
+		}
 	} else {
-		log.Infof("Storage version: %d", dbVerPrim)
-	}
-
-	// replica storage initialization
-	log.Infof("Using database URI for replica storage: %s", *flagDBURI)
-
-	// pointing to main database for now but can be used to point to replica
-	replicaDBURI := *flagDBURI
-	r, err := rdbms.New(replicaDBURI)
-	if err != nil {
-		log.Fatalf("Could not initialize replica database: %v", err)
-	}
-	if err := storage.SetAsyncStorage(r); err != nil {
-		log.Fatalf("Could not set replica storage: %v", err)
-	}
-
-	dbVerRepl, err := r.Version()
-	if err != nil {
-		log.Warningf("Could not determine storage version: %v", err)
-	} else {
-		log.Infof("Storage version: %d", dbVerRepl)
-	}
-
-	if dbVerPrim != dbVerRepl {
-		log.Fatalf("Primary and Replica DB Versions are different: %v and %v", dbVerPrim, dbVerRepl)
+		log.Warningf("Using in-memory storage")
+		if ms, err := memory.New(); err == nil {
+			if err := storage.SetStorage(ms); err != nil {
+				log.Fatalf("Could not set storage: %v", err)
+			}
+			if err := storage.SetAsyncStorage(ms); err != nil {
+				log.Fatalf("Could not set replica storage: %v", err)
+			}
+		} else {
+			log.Fatalf("Could not create storage: %v", err)
+		}
 	}
 
 	// set Locker engine

--- a/cmds/plugins/plugins.go
+++ b/cmds/plugins/plugins.go
@@ -24,7 +24,6 @@ import (
 	"github.com/facebookincubator/contest/plugins/teststeps/echo"
 	"github.com/facebookincubator/contest/plugins/teststeps/example"
 	"github.com/facebookincubator/contest/plugins/teststeps/randecho"
-	"github.com/facebookincubator/contest/plugins/teststeps/slowecho"
 	"github.com/facebookincubator/contest/plugins/teststeps/sshcmd"
 	"github.com/sirupsen/logrus"
 )
@@ -41,7 +40,6 @@ var testFetchers = []test.TestFetcherLoader{
 
 var testSteps = []test.TestStepLoader{
 	echo.Load,
-	slowecho.Load,
 	example.Load,
 	cmd.Load,
 	sshcmd.Load,

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -7,7 +7,6 @@ package job
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/facebookincubator/contest/pkg/statectx"
@@ -20,12 +19,12 @@ import (
 // JobDescriptor models the JSON encoded blob which is given as input to the
 // job creation request. A JobDescriptor embeds a list of TestDescriptor.
 type JobDescriptor struct {
-	JobName         string
-	Tags            []string
-	Runs            uint
-	RunInterval     xjson.Duration
-	TestDescriptors []*test.TestDescriptor
-	Reporting       Reporting
+	JobName                     string
+	Tags                        []string
+	Runs                        uint
+	RunInterval                 xjson.Duration
+	TestDescriptors             []*test.TestDescriptor
+	Reporting                   Reporting
 	TargetManagerAcquireTimeout *xjson.Duration // optional
 	TargetManagerReleaseTimeout *xjson.Duration // optional
 }
@@ -127,17 +126,4 @@ type InfoFetcher interface {
 	FetchJob(types.JobID) (*Job, error)
 	FetchJobs([]types.JobID) ([]*Job, error)
 	FetchJobIDsByServerID(serverID string) ([]types.JobID, error)
-}
-
-// Note that at present we depend on this regex for SQL query safety.
-var validTagRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
-
-// CheckTags validates the format of tags, only allowing [a-zA-Z0-9_-].
-func CheckTags(tags []string) error {
-	for _, tag := range tags {
-		if !validTagRegex.MatchString(tag) {
-			return fmt.Errorf("%q is not a valid tag", tag)
-		}
-	}
-	return nil
 }

--- a/pkg/job/tags.go
+++ b/pkg/job/tags.go
@@ -1,0 +1,62 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package job
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// InternalTagPrefix denotes tags that can only be manipulated by the server.
+const InternalTagPrefix = "_"
+
+var validTagRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// IsValidTag validates the format of tags, only allowing [a-zA-Z0-9_-].
+func IsValidTag(tag string, allowInternal bool) error {
+	if !validTagRegex.MatchString(tag) {
+		return fmt.Errorf("%q is not a valid tag", tag)
+	}
+	if !allowInternal && IsInternalTag(tag) {
+		return fmt.Errorf("%q is an internal tag and is not allowed", tag)
+	}
+	return nil
+}
+
+// IsInternalTag returns true if a tag is an internal tag.
+func IsInternalTag(tag string) bool {
+	return strings.HasPrefix(tag, InternalTagPrefix)
+}
+
+// CheckTags validates the format of tags, only allowing [a-zA-Z0-9_-] and checking for dups.
+func CheckTags(tags []string, allowInternal bool) error {
+	tm := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		if err := IsValidTag(tag, allowInternal); err != nil {
+			return err
+		}
+		if tm[tag] {
+			return fmt.Errorf("duplicate tag %q", tag)
+		}
+		tm[tag] = true
+	}
+	return nil
+}
+
+// AddTags adds one ore more tags to tags unless already present.
+func AddTags(tags []string, moreTags ...string) []string {
+loop:
+	for _, newTag := range moreTags {
+		for _, tag := range tags {
+			if tag == newTag {
+				continue loop
+			}
+		}
+		tags = append(tags, newTag)
+	}
+	return tags
+}

--- a/pkg/jobmanager/list.go
+++ b/pkg/jobmanager/list.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/facebookincubator/contest/pkg/api"
+	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/storage"
 )
 
@@ -26,8 +27,13 @@ func (jm *JobManager) list(ev *api.Event) *api.EventResponse {
 	if len(msg.States) > 0 {
 		queryFields = append(queryFields, storage.QueryJobStates(msg.States...))
 	}
-	if len(msg.Tags) > 0 {
-		queryFields = append(queryFields, storage.QueryJobTags(msg.Tags...))
+	var tags []string
+	if jm.config.instanceTag != "" {
+		tags = job.AddTags(tags, jm.config.instanceTag)
+	}
+	job.AddTags(tags, msg.Tags...)
+	if len(tags) > 0 {
+		queryFields = append(queryFields, storage.QueryJobTags(tags...))
 	}
 	jobQuery, err := storage.BuildJobQuery(queryFields...)
 	if err != nil {

--- a/pkg/jobmanager/options.go
+++ b/pkg/jobmanager/options.go
@@ -16,7 +16,8 @@ type Option interface {
 }
 
 type config struct {
-	apiOptions []api.Option
+	apiOptions  []api.Option
+	instanceTag string
 }
 
 // OptionAPI wraps api.Option to implement Option.
@@ -33,6 +34,13 @@ func (opt OptionAPI) apply(config *config) {
 // into OptionAPI.
 func APIOption(option api.Option) Option {
 	return OptionAPI{Option: option}
+}
+
+// OptionInstanceTag wraps a string to be used as instance tag.
+type OptionInstanceTag string
+
+func (opt OptionInstanceTag) apply(config *config) {
+	config.instanceTag = string(opt)
 }
 
 // getConfig converts a set of Option-s into one structure "Config".

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -215,7 +215,7 @@ func (m *Memory) ListJobs(query *storage.JobQuery) ([]types.JobID, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	res := []types.JobID{}
-	if err := job.CheckTags(query.Tags); err != nil {
+	if err := job.CheckTags(query.Tags, true /* allowInternal */); err != nil {
 		return nil, err
 	}
 jobLoop:

--- a/plugins/storage/rdbms/list_jobs.go
+++ b/plugins/storage/rdbms/list_jobs.go
@@ -19,7 +19,7 @@ func (r *RDBMS) ListJobs(query *storage.JobQuery) ([]types.JobID, error) {
 
 	// Quoting SQL strings is hard. https://github.com/golang/go/issues/18478
 	// For now, just disallow anything that is not [a-zA-Z0-9_-]
-	if err := job.CheckTags(query.Tags); err != nil {
+	if err := job.CheckTags(query.Tags, true /* allowInternal */); err != nil {
 		return nil, err
 	}
 

--- a/plugins/storage/rdbms/request.go
+++ b/plugins/storage/rdbms/request.go
@@ -29,7 +29,7 @@ func (r *RDBMS) StoreJobRequest(request *job.Request) (types.JobID, error) {
 	if err := json.Unmarshal([]byte(request.JobDescriptor), &desc); err != nil {
 		return 0, fmt.Errorf("invalid job descriptor: %w", err)
 	}
-	if err := job.CheckTags(desc.Tags); err != nil {
+	if err := job.CheckTags(desc.Tags, true /* allowInternal */); err != nil {
 		return 0, err
 	}
 

--- a/tests/integ/jobmanager/jobdescriptors.go
+++ b/tests/integ/jobmanager/jobdescriptors.go
@@ -19,10 +19,10 @@ var jobDescriptorTemplate = template.Must(template.New("jobDescriptor").Parse(`
     "ReporterParameters": {
         "SuccessExpression": ">10%"
     },
-    "RunInterval": "5s",
-    "Runs": 1,
+    "Runs": {{ .Runs }},
+    "RunInterval": "{{ .RunInterval }}",
     "Tags": [
-        "integration_testing"
+        "integration_testing" {{ .ExtraTags }}
     ],
     "TestDescriptors": [
         {
@@ -42,7 +42,7 @@ var jobDescriptorTemplate = template.Must(template.New("jobDescriptor").Parse(`
             },
             "TargetManagerReleaseParameters": {},
             "TestFetcherName": "literal",
-            {{ . }}
+            {{ .Def }}
         }
     ],
     "Reporting": {
@@ -58,12 +58,23 @@ var jobDescriptorTemplate = template.Must(template.New("jobDescriptor").Parse(`
 }
 `))
 
-func descriptorMust(data string) string {
+type templateData struct {
+	Runs        int
+	RunInterval string
+	ExtraTags   string
+	Def         string
+}
+
+func descriptorMust2(data *templateData) string {
 	var buf bytes.Buffer
 	if err := jobDescriptorTemplate.Execute(&buf, data); err != nil {
 		panic(err)
 	}
 	return buf.String()
+}
+
+func descriptorMust(def string) string {
+	return descriptorMust2(&templateData{Runs: 1, RunInterval: "1s", Def: def})
 }
 
 var jobDescriptorNoop = descriptorMust(`
@@ -78,14 +89,14 @@ var jobDescriptorNoop = descriptorMust(`
         "TestName": "IntegrationTest: noop"
     }`)
 
-var jobDescriptorSlowecho = descriptorMust(`
+var jobDescriptorSlowEcho = descriptorMust(`
    "TestFetcherFetchParameters": {
        "Steps": [
            {
                "name": "slowecho",
                "label": "slowecho_label",
                "parameters": {
-                 "sleep": ["5"],
+                 "sleep": ["0.5"],
                  "text": ["Hello world"]
                }
            }
@@ -154,7 +165,7 @@ var jobDescriptorLabelDuplication = descriptorMust(`
                "parameters": {}
            }
        ],
-       "TestName": "IntegrationTest: label_duplication"
+       "TestName": "TestTestStepLabelDuplication"
    }`)
 
 var jobDescriptorNullStep = descriptorMust(`
@@ -191,3 +202,62 @@ var jobDescriptorNullTest = `
     }
 }
 `
+var jobDescriptorBadTag = descriptorMust2(&templateData{
+	Runs:        2,
+	RunInterval: "1s",
+	ExtraTags:   `, "a bad one"`,
+	Def: `
+   "TestFetcherFetchParameters": {
+       "Steps": [
+           {
+               "name": "slowecho",
+               "label": "slowecho_label",
+               "parameters": {
+                 "sleep": ["2"],
+                 "text": ["Hello world"]
+               }
+           }
+       ],
+       "TestName": "IntegrationTest: slow echo"
+   }`,
+})
+
+var jobDescriptorInternalTag = descriptorMust2(&templateData{
+	Runs:        2,
+	RunInterval: "1s",
+	ExtraTags:   `, "_foo"`,
+	Def: `
+   "TestFetcherFetchParameters": {
+       "Steps": [
+           {
+               "name": "slowecho",
+               "label": "slowecho_label",
+               "parameters": {
+                 "sleep": ["2"],
+                 "text": ["Hello world"]
+               }
+           }
+       ],
+       "TestName": "IntegrationTest: slow echo"
+   }`,
+})
+
+var jobDescriptorDuplicateTag = descriptorMust2(&templateData{
+	Runs:        2,
+	RunInterval: "1s",
+	ExtraTags:   `, "qwe", "qwe"`,
+	Def: `
+   "TestFetcherFetchParameters": {
+       "Steps": [
+           {
+               "name": "slowecho",
+               "label": "slowecho_label",
+               "parameters": {
+                 "sleep": ["2"],
+                 "text": ["Hello world"]
+               }
+           }
+       ],
+       "TestName": "IntegrationTest: slow echo"
+   }`,
+})


### PR DESCRIPTION
An instance tag allows multiple instances to share a database without
stepping on each other's toes.

If `-instanceTag=XXX` is specified at server startup, the server will
limit its actions to jobs that have that tag, specifically:
 * Any job started through that instance will have this tag added (if not already present).
 * Listing jobs will only include jobs that have this tag.
 * Server will only return status of jobs with this tag.