### PR TITLE
Remove StepInjectTimeout and associated logic

### DIFF
--- a/pkg/cerrors/cerrors.go
+++ b/pkg/cerrors/cerrors.go
@@ -43,17 +43,6 @@ func (e *ErrTestStepsNeverReturned) Error() string {
 	return fmt.Sprintf("test step [%s] did not return", strings.Join(e.StepNames, ", "))
 }
 
-// ErrTestTargetInjectionTimedOut indicates that test step did not ingest a target
-// within allotted time.
-type ErrTestTargetInjectionTimedOut struct {
-	StepName string
-}
-
-// Error returns the error string associated with the error
-func (e *ErrTestTargetInjectionTimedOut) Error() string {
-	return fmt.Sprintf("test step %v failed to ingest a target", e.StepName)
-}
-
 // ErrTestStepClosedChannels indicates that the test step returned after
 // closing its output channels, which constitutes an API violation
 type ErrTestStepClosedChannels struct {

--- a/pkg/config/timeouts.go
+++ b/pkg/config/timeouts.go
@@ -15,10 +15,6 @@ var TargetManagerAcquireTimeout = 5 * time.Minute
 // for the execution of Release function from the chosen TargetManager
 var TargetManagerReleaseTimeout = 5 * time.Minute
 
-// StepInjectTimeout represents the maximum time that TestRunner will wait for
-// the first TestStep of the pipeline to accept a Target
-var StepInjectTimeout = 30 * time.Second
-
 // TestRunnerMsgTimeout represents the maximum time that any component of the
 // TestRunner will wait for the delivery of a message to any other subsystem
 // of the TestRunner

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -36,9 +36,8 @@ import (
 )
 
 const (
-	testName          = "SimpleTest"
-	stepInjectTimeout = 3 * time.Second
-	shutdownTimeout   = 3 * time.Second
+	testName        = "SimpleTest"
+	shutdownTimeout = 3 * time.Second
 )
 
 var (
@@ -83,7 +82,7 @@ func TestMain(m *testing.M) {
 }
 
 func newTestRunner() *TestRunner {
-	return NewTestRunnerWithTimeouts(stepInjectTimeout, shutdownTimeout)
+	return NewTestRunnerWithTimeouts(shutdownTimeout)
 }
 
 func resetEventStorage() {
@@ -180,7 +179,7 @@ func Test1Step1Success(t *testing.T) {
 // We block for longer than the shutdown timeout of the test runner.
 func Test1StepLongerThanShutdown1Success(t *testing.T) {
 	resetEventStorage()
-	tr := NewTestRunnerWithTimeouts(stepInjectTimeout, 100*time.Millisecond)
+	tr := NewTestRunnerWithTimeouts(100 * time.Millisecond)
 	_, err := runWithTimeout(t, tr, nil, nil, 1, 2*time.Second,
 		[]*target.Target{tgt("T1")},
 		[]test.TestStepBundle{
@@ -297,7 +296,7 @@ func Test3StepsNotReachedStepNotRun(t *testing.T) {
 // and does not return.
 func TestNoReturnStepWithCorrectTargetForwarding(t *testing.T) {
 	resetEventStorage()
-	tr := NewTestRunnerWithTimeouts(100*time.Millisecond, 200*time.Millisecond)
+	tr := NewTestRunnerWithTimeouts(200 * time.Millisecond)
 	ctx, _, cancel := statectx.New()
 	defer cancel()
 	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
@@ -308,22 +307,6 @@ func TestNoReturnStepWithCorrectTargetForwarding(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.IsType(t, &cerrors.ErrTestStepsNeverReturned{}, err)
-}
-
-// A misbehaving step that does not process any targets.
-func TestNoReturnStepWithoutTargetForwarding(t *testing.T) {
-	resetEventStorage()
-	tr := NewTestRunnerWithTimeouts(100*time.Millisecond, 200*time.Millisecond)
-	ctx, _, cancel := statectx.New()
-	defer cancel()
-	_, err := runWithTimeout(t, tr, ctx, nil, 1, 2*time.Second,
-		[]*target.Target{tgt("T1")},
-		[]test.TestStepBundle{
-			newStep("Step 1", hanging.Name, nil),
-		},
-	)
-	require.Error(t, err)
-	require.IsType(t, &cerrors.ErrTestTargetInjectionTimedOut{}, err)
 }
 
 // A misbehaving step that panics.


### PR DESCRIPTION
Rationale: overall job timeout is enough, it shouldn't matter how much
time it takes to inject targets into each individual step if the job completes within its allotted time.