### PR TITLE
Introduce a buffer into target result channel

### DIFF
--- a/pkg/runner/test_runner2.go
+++ b/pkg/runner/test_runner2.go
@@ -195,7 +195,10 @@ func (tr *TestRunner) run(
 			}
 		}
 		tgs.tgt = tgt
-		tgs.resCh = make(chan error)
+		// Buffer of 1 is needed so that the step reader does not block when submitting result back
+		// to the target handler. Target handler may not yet be ready to receive the result,
+		// i.e. reporting TargetIn event which may involve network I/O.
+		tgs.resCh = make(chan error, 1)
 		tr.targets[tgt.ID] = tgs
 		tr.mu.Unlock()
 		tr.targetsWg.Add(1)

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -358,10 +358,6 @@ func TestStepYieldsResultForNonexistentTarget(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.IsType(t, &cerrors.ErrTestStepReturnedUnexpectedResult{}, err)
-	require.Equal(t, `
-{[1 1 SimpleTest Step 1][Target{ID: "TExtra"} TargetIn]}
-{[1 1 SimpleTest Step 1][Target{ID: "TExtra"} TargetOut]}
-`, getTargetEvents("TExtra"))
 	require.Equal(t, "\n\n", getTargetEvents("TExtra2"))
 	require.Equal(t, `
 {[1 1 SimpleTest Step 1][(*Target)(nil) TestError &"\"test step Step 1 returned unexpected result for TExtra2\""]}


### PR DESCRIPTION
Buffer of 1 is needed so that the step reader does not block when submitting result back
to the target handler. Target handler may not yet be ready to receive the result,
i.e. reporting TargetIn event which may involve network I/O.

1 is also sufficient because each target is running through only one step at each time,
so there won't be more than one result.