### PR TITLE
feat(logger): Reduce logger output

### DIFF
--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/facebookincubator/contest/pkg/api"
 	"github.com/facebookincubator/contest/pkg/config"
 	"github.com/facebookincubator/contest/pkg/jobmanager"
+	"github.com/facebookincubator/contest/pkg/logging"
 	"github.com/facebookincubator/contest/pkg/pluginregistry"
 	"github.com/facebookincubator/contest/pkg/storage"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -43,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	ctx := logrusctx.NewContext(logLevel)
+	ctx := logrusctx.NewContext(logLevel, logging.DefaultOptions()...)
 	log := ctx.Logger()
 
 	pluginRegistry := pluginregistry.NewPluginRegistry(ctx)

--- a/pkg/logging/default_options.go
+++ b/pkg/logging/default_options.go
@@ -6,5 +6,8 @@ import (
 
 // DefaultOptions is a set options recommended to use by default.
 func DefaultOptions() []bundles.Option {
-	return []bundles.Option{bundles.OptionTimestampFormat("2006-01-02T15:04:05.000Z07:00")}
+	return []bundles.Option{
+		bundles.OptionLogFormat(bundles.LogFormatPlainTextCompact),
+		bundles.OptionTimestampFormat("2006-01-02T15:04:05.000Z07:00"),
+	}
 }

--- a/pkg/logging/default_options.go
+++ b/pkg/logging/default_options.go
@@ -1,0 +1,10 @@
+package logging
+
+import (
+	"github.com/facebookincubator/contest/pkg/xcontext/bundles"
+)
+
+// DefaultOptions is a set options recommended to use by default.
+func DefaultOptions() []bundles.Option {
+	return []bundles.Option{bundles.OptionTimestampFormat("2006-01-02T15:04:05.000Z07:00")}
+}

--- a/pkg/xcontext/bundles/logrusctx/compact_text_formatter.go
+++ b/pkg/xcontext/bundles/logrusctx/compact_text_formatter.go
@@ -1,0 +1,56 @@
+package logrusctx
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/xcontext/logger"
+	"github.com/sirupsen/logrus"
+)
+
+var logLevelSymbol [logger.EndOfLevel]byte
+
+func init() {
+	for level := logger.Level(0); level < logger.EndOfLevel; level++ {
+		logLevelSymbol[level] = strings.ToUpper(level.String()[:1])[0]
+	}
+}
+
+type CompactTextFormatter struct {
+	TimestampFormat string
+}
+
+func (f *CompactTextFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	var str, header strings.Builder
+	timestamp := time.RFC3339
+	if f.TimestampFormat != "" {
+		timestamp = f.TimestampFormat
+	}
+	header.WriteString(fmt.Sprintf("%s %c",
+		entry.Time.Format(timestamp),
+		logLevelSymbol[entry.Level],
+	))
+	if entry.Caller != nil {
+		header.WriteString(fmt.Sprintf(" %s:%d", filepath.Base(entry.Caller.File), entry.Caller.Line))
+	}
+	str.WriteString(fmt.Sprintf("[%s] %s",
+		header.String(),
+		entry.Message,
+	))
+
+	keys := make([]string, 0, len(entry.Data))
+	for key := range entry.Data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		str.WriteString(fmt.Sprintf("\t%s=%s", key, entry.Data[key]))
+	}
+
+	str.WriteByte('\n')
+	return []byte(str.String()), nil
+}

--- a/pkg/xcontext/bundles/logrusctx/compact_text_formatter_test.go
+++ b/pkg/xcontext/bundles/logrusctx/compact_text_formatter_test.go
@@ -1,0 +1,32 @@
+package logrusctx
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompactTextFormatterFormat(t *testing.T) {
+	formatter := &CompactTextFormatter{
+		TimestampFormat: "05.999999999",
+	}
+
+	b, err := formatter.Format(&logrus.Entry{
+		Data: map[string]interface{}{
+			"key0": "value0",
+			"key1": "value1",
+		},
+		Time: time.Unix(1, 2),
+		Caller: &runtime.Frame{
+			Function: "func",
+			File:     "/directory/file",
+			Line:     3,
+		},
+		Message: "message",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "[01.000000002 U file:3] message\tkey0=value0\tkey1=value1\n", string(b))
+}

--- a/pkg/xcontext/bundles/logrusctx/new_context.go
+++ b/pkg/xcontext/bundles/logrusctx/new_context.go
@@ -7,6 +7,9 @@ package logrusctx
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
 
 	"github.com/sirupsen/logrus"
 
@@ -44,11 +47,29 @@ func NewContext(logLevel logger.Level, opts ...bundles.Option) xcontext.Context 
 	loggerRaw.SetLevel(logrusadapter.Adapter.Level(logLevel))
 	loggerRaw.ReportCaller = cfg.LoggerReportCaller
 	entry := logrus.NewEntry(loggerRaw)
+
+	var callerFormatter func(frame *runtime.Frame) (function string, file string)
+	if !cfg.VerboseCaller {
+		callerFormatter = func(frame *runtime.Frame) (function string, file string) {
+			if frame == nil {
+				return
+			}
+			file = fmt.Sprintf("%s:%d", filepath.Base(frame.File), frame.Line)
+			return
+		}
+	}
 	switch cfg.Format {
-	case bundles.LogFormatPlainText:
-		entry.Logger.SetFormatter(&logrus.TextFormatter{})
 	case bundles.LogFormatJSON:
-		entry.Logger.SetFormatter(&logrus.JSONFormatter{})
+		entry.Logger.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat:  cfg.TimestampFormat,
+			CallerPrettyfier: callerFormatter,
+		})
+	default:
+		entry.Logger.SetFormatter(&logrus.TextFormatter{
+			TimestampFormat:  cfg.TimestampFormat,
+			FullTimestamp:    cfg.TimestampFormat != "",
+			CallerPrettyfier: callerFormatter,
+		})
 	}
 	ctx := xcontext.NewContext(
 		context.Background(), "",

--- a/pkg/xcontext/bundles/logrusctx/new_context.go
+++ b/pkg/xcontext/bundles/logrusctx/new_context.go
@@ -64,6 +64,10 @@ func NewContext(logLevel logger.Level, opts ...bundles.Option) xcontext.Context 
 			TimestampFormat:  cfg.TimestampFormat,
 			CallerPrettyfier: callerFormatter,
 		})
+	case bundles.LogFormatPlainTextCompact:
+		entry.Logger.SetFormatter(&CompactTextFormatter{
+			TimestampFormat: cfg.TimestampFormat,
+		})
 	default:
 		entry.Logger.SetFormatter(&logrus.TextFormatter{
 			TimestampFormat:  cfg.TimestampFormat,

--- a/pkg/xcontext/bundles/options.go
+++ b/pkg/xcontext/bundles/options.go
@@ -38,6 +38,11 @@ const (
 	// LogFormatPlainText means to write logs as a plain text.
 	LogFormatPlainText = LogFormat(iota)
 
+	// LogFormatPlainTextCompact means to write logs as a compact plain text.
+	//
+	// Falls back to LogFormatPlainText if the compact format is not supported.
+	LogFormatPlainTextCompact
+
 	// LogFormatJSON means to write logs as JSON objects.
 	LogFormatJSON
 )

--- a/pkg/xcontext/bundles/options.go
+++ b/pkg/xcontext/bundles/options.go
@@ -58,10 +58,19 @@ func (opt OptionTracer) apply(cfg *Config) {
 	cfg.Tracer = opt.Tracer
 }
 
+// OptionTimestampFormat defines the format of timestamps while logging.
+type OptionTimestampFormat string
+
+func (opt OptionTimestampFormat) apply(cfg *Config) {
+	cfg.TimestampFormat = string(opt)
+}
+
 // Config is a configuration state resulted from Option-s.
 type Config struct {
 	LoggerReportCaller bool
 	TracerReportCaller bool
+	TimestampFormat    string
+	VerboseCaller      bool
 	Tracer             xcontext.Tracer
 	Format             LogFormat
 }

--- a/pkg/xcontext/bundles/zapctx/new_context.go
+++ b/pkg/xcontext/bundles/zapctx/new_context.go
@@ -7,8 +7,10 @@ package zapctx
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/facebookincubator/contest/pkg/xcontext"
 	"github.com/facebookincubator/contest/pkg/xcontext/bundles"
@@ -37,6 +39,10 @@ func NewContext(logLevel logger.Level, opts ...bundles.Option) xcontext.Context 
 	case bundles.LogFormatJSON:
 		loggerCfg.Encoding = "json"
 	}
+	if cfg.TimestampFormat != "" {
+		loggerCfg.EncoderConfig.EncodeTime = timeEncoder(cfg.TimestampFormat)
+	}
+	// TODO: cfg.VerboseCaller is currently ignored, fix it.
 	var zapOpts []zap.Option
 	stdCtx := context.Background()
 	loggerRaw, err := loggerCfg.Build(zapOpts...)
@@ -49,4 +55,19 @@ func NewContext(logLevel logger.Level, opts ...bundles.Option) xcontext.Context 
 		loggerInstance, metrics.NewSimpleMetrics(), cfg.Tracer,
 		nil, nil)
 	return ctx
+}
+
+func timeEncoder(layout string) func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	return func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		type appendTimeEncoder interface {
+			AppendTimeLayout(time.Time, string)
+		}
+
+		if enc, ok := enc.(appendTimeEncoder); ok {
+			enc.AppendTimeLayout(t, layout)
+			return
+		}
+
+		enc.AppendString(t.Format(layout))
+	}
 }

--- a/pkg/xcontext/bundles/zapctx/new_context.go
+++ b/pkg/xcontext/bundles/zapctx/new_context.go
@@ -34,7 +34,7 @@ func NewContext(logLevel logger.Level, opts ...bundles.Option) xcontext.Context 
 		ErrorOutputPaths: []string{"stderr"},
 	}
 	switch cfg.Format {
-	case bundles.LogFormatPlainText:
+	case bundles.LogFormatPlainText, bundles.LogFormatPlainTextCompact:
 		loggerCfg.Encoding = "console"
 	case bundles.LogFormatJSON:
 		loggerCfg.Encoding = "json"

--- a/pkg/xcontext/event_handler_test.go
+++ b/pkg/xcontext/event_handler_test.go
@@ -50,7 +50,7 @@ func TestWaiterGC(t *testing.T) {
 	wg.Wait()
 
 	runtime.GC()
-	require.Equal(t, goroutines, runtime.NumGoroutine())
+	require.GreaterOrEqual(t, goroutines, runtime.NumGoroutine())
 }
 
 func TestContextCanceled(t *testing.T) {

--- a/pkg/xcontext/logger/log_level.go
+++ b/pkg/xcontext/logger/log_level.go
@@ -34,6 +34,9 @@ const (
 
 	// LevelDebug will report about Debugf-s, Infof-s, ...
 	LevelDebug = internal.LevelDebug
+
+	// EndOfLevel is just used as a limiter for `for`-s.
+	EndOfLevel
 )
 
 // ParseLogLevel parses incoming string into a Level and returns


### PR DESCRIPTION
Before:
```
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go run ./cmds/contest/
INFO[0000]/home/xaionaro/go/src/github.com/facebookincubator/contest/cmds/contest/main.go:53 main.main() Using database URI for primary storage: contest:contest@tcp(localhost:3306)/contest?parseTime=true 
FATA[0000]/home/xaionaro/go/src/github.com/facebookincubator/contest/cmds/contest/main.go:58 main.main() Could not initialize database: unable to contact database: dial tcp 127.0.0.1:3306: connect: connection refused 
exit status 1
```

After:
```
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go run ./cmds/contest/
[2021-03-19T21:43:05.815Z W main.go:54] Using database URI for primary storage: contest:contest@tcp(localhost:3306)/contest?parseTime=true
[2021-03-19T21:43:05.816Z F main.go:59] Could not initialize database: unable to contact database: dial tcp 127.0.0.1:3306: connect: connection refused
exit status 1
```