### PR TITLE
[checklicenses] Extend license pattern to cover SQL files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.6-0.20200504143853-81378bbcd8a1
 	github.com/stretchr/testify v1.5.1
+	github.com/u-root/u-root v7.0.0+incompatible // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/u-root/u-root v1.0.0 h1:3hJy0CG3mXIZtWRE+yrghG/3H0v8L1qEeZBlPr5nS9s=
+github.com/u-root/u-root v7.0.0+incompatible h1:u+KSS04pSxJGI5E7WE4Bs9+Zd75QjFv+REkjy/aoAc8=
+github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2 h1:00txxvfBM9muc0jiLIEAkAcIMJzfthRT6usrui8uGmg=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=

--- a/pkg/logging/default_options.go
+++ b/pkg/logging/default_options.go
@@ -1,3 +1,8 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
 package logging
 
 import (

--- a/tools/checklicenses-config.json
+++ b/tools/checklicenses-config.json
@@ -2,10 +2,10 @@
     "gopkg": "github.com/facebookincubator/contest",
     "licenses": [
         [
-            "^// Copyright \\(c\\) Facebook, Inc\\. and its affiliates\\.",
-            "//",
-            "// This source code is licensed under the MIT license found in the",
-            "// LICENSE file in the root directory of this source tree\\."
+            "^(//|--) Copyright \\(c\\) Facebook, Inc\\. and its affiliates\\.",
+            "(//|--)",
+            "(//|--) This source code is licensed under the MIT license found in the",
+            "(//|--) LICENSE file in the root directory of this source tree\\."
         ]
     ],
     "accept": [


### PR DESCRIPTION
The previous pattern only matched double-slash comments, but in SQL
files we need double-dash. The new pattern matches both comment styles.
Also added one missing copyright header that I discovered in the
process.
This change will take effect after
https://github.com/u-root/u-root/pull/1968 is merged.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>