### PR TITLE
refact(xcontext): Rename context statuses

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -153,11 +153,11 @@ func (j *Job) Pause() {
 
 // IsCancelled returns whether the job has been cancelled
 func (j *Job) IsCancelled() bool {
-	return j.StateCtx.IsSignaledWith(xcontext.Canceled)
+	return j.StateCtx.IsSignaledWith(xcontext.ErrCanceled)
 }
 
 func (j *Job) IsPaused() bool {
-	return j.StateCtx.IsSignaledWith(xcontext.Paused)
+	return j.StateCtx.IsSignaledWith(xcontext.ErrPaused)
 }
 
 // InfoFetcher defines how to fetch job information

--- a/pkg/jobmanager/job.go
+++ b/pkg/jobmanager/job.go
@@ -112,7 +112,7 @@ func newJob(ctx xcontext.Context, registry *pluginregistry.PluginRegistry, jobDe
 		FinalReporterBundles:        finalReportersBundle,
 	}
 
-	job.StateCtx, job.StateCtxPause = xcontext.WithNotify(ctx, xcontext.Paused)
+	job.StateCtx, job.StateCtxPause = xcontext.WithNotify(ctx, xcontext.ErrPaused)
 	job.StateCtx, job.StateCtxCancel = xcontext.WithCancel(job.StateCtx)
 	return &job, nil
 

--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -155,7 +155,7 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 						if err := tl.Unlock(j.StateCtx, j.ID, targets); err != nil {
 							j.StateCtx.Warnf("Failed to unlock targets (%v) for job ID %d: %v", targets, j.ID, err)
 						}
-					case <-j.StateCtx.Until(xcontext.Paused):
+					case <-j.StateCtx.Until(xcontext.ErrPaused):
 						j.StateCtx.Debugf("Received pause request, NOT releasing targets so the job can be resumed")
 						return
 					case <-done:
@@ -182,7 +182,7 @@ func (jr *JobRunner) Run(j *job.Job) ([][]*job.Report, []*job.Report, error) {
 				j.StateCtx.Infof("Run #%d: running test #%d for job '%s' (job ID: %d) on %d targets", run+1, idx, j.Name, j.ID, len(targets))
 				testRunner := NewTestRunner()
 				resumeState, err := testRunner.Run(j.StateCtx, t, targets, j.ID, types.RunID(run+1), nil)
-				if err == xcontext.Paused {
+				if err == xcontext.ErrPaused {
 					j.StateCtx.Debugf("Runner paused, state: %s", string(resumeState))
 					// TODO(rojer): Persist the state.
 				} else {

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -473,7 +473,7 @@ func TestPauseResumeSimple(t *testing.T) {
 	}
 	{
 		tr1 := newTestRunner()
-		ctx1, pause := xcontext.WithNotify(ctx, xcontext.Paused)
+		ctx1, pause := xcontext.WithNotify(ctx, xcontext.ErrPaused)
 		ctx1, cancel := xcontext.WithCancel(ctx1)
 		defer cancel()
 		go func() {
@@ -483,7 +483,7 @@ func TestPauseResumeSimple(t *testing.T) {
 		}()
 		resumeState, err = runWithTimeout(t, tr1, ctx1, nil, 1, 2*time.Second, targets, steps)
 		require.Error(t, err)
-		require.IsType(t, xcontext.Paused, err)
+		require.IsType(t, xcontext.ErrPaused, err)
 		require.NotNil(t, resumeState)
 	}
 	ctx.Debugf("Resume state: %s", string(resumeState))

--- a/pkg/xcontext/context.go
+++ b/pkg/xcontext/context.go
@@ -520,7 +520,7 @@ func (ctx *ctxValue) StdCtxUntil(err error) context.Context {
 		case <-garbageCollected:
 			return
 		case <-ctx.Until(err):
-			h.cancel(Canceled)
+			h.cancel(ErrCanceled)
 		}
 	}()
 

--- a/pkg/xcontext/context_test.go
+++ b/pkg/xcontext/context_test.go
@@ -17,7 +17,7 @@ import (
 func tryLeak() {
 	ctx := Background()
 	ctx, _ = WithCancel(ctx)
-	ctx, _ = WithNotify(ctx, Paused)
+	ctx, _ = WithNotify(ctx, ErrPaused)
 	ctx.Until(nil)
 	ctx = WithResetSignalers(ctx)
 	ctx = WithStdContext(ctx, context.Background())

--- a/pkg/xcontext/done_errors.go
+++ b/pkg/xcontext/done_errors.go
@@ -10,12 +10,12 @@ import (
 	"errors"
 )
 
-// Canceled is returned by Context.Err when the context was canceled
-var Canceled = context.Canceled
+// ErrCanceled is returned by Context.Err when the context was canceled
+var ErrCanceled = context.Canceled
 
-// DeadlineExceeded is returned by Context.Err when the context reached
+// ErrDeadlineExceeded is returned by Context.Err when the context reached
 // the deadline.
-var DeadlineExceeded = context.DeadlineExceeded
+var ErrDeadlineExceeded = context.DeadlineExceeded
 
-// Paused is returned by Context.Err when the context was paused
-var Paused = errors.New("job is paused")
+// ErrPaused is returned by Context.Err when the context was paused
+var ErrPaused = errors.New("job is paused")

--- a/pkg/xcontext/event_handler.go
+++ b/pkg/xcontext/event_handler.go
@@ -30,10 +30,10 @@ func WithDeadline(parent Context, t time.Time) (Context, CancelFunc) {
 	h := ctx.addEventHandler()
 	h.deadline = &t
 	time.AfterFunc(time.Until(t), func() {
-		h.cancel(DeadlineExceeded)
+		h.cancel(ErrDeadlineExceeded)
 	})
 	return ctx, func() {
-		h.cancel(Canceled)
+		h.cancel(ErrCanceled)
 	}
 }
 
@@ -248,7 +248,7 @@ func (h *eventHandler) cancel(errs ...error) {
 	defer h.locker.Unlock()
 
 	if len(errs) == 0 {
-		h.receivedCancels = append(h.receivedCancels, Canceled)
+		h.receivedCancels = append(h.receivedCancels, ErrCanceled)
 	} else {
 		h.receivedCancels = append(h.receivedCancels, errs...)
 	}

--- a/pkg/xcontext/event_handler_cancel_test.go
+++ b/pkg/xcontext/event_handler_cancel_test.go
@@ -29,11 +29,11 @@ func TestCancellation(t *testing.T) {
 
 	cancelFunc()
 	<-ctx.Done()
-	require.Equal(t, Canceled, ctx.Err())
+	require.Equal(t, ErrCanceled, ctx.Err())
 
 	// further cancels do not affect the error code
 	customCancelFunc()
-	require.Equal(t, Canceled, ctx.Err())
+	require.Equal(t, ErrCanceled, ctx.Err())
 }
 
 func TestAbstractParentContext(t *testing.T) {
@@ -58,11 +58,11 @@ func TestCancelContextAsParentContext(t *testing.T) {
 
 		parCancelFunc0()
 		<-ctx.Done()
-		require.Equal(t, Canceled, ctx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
 
 		parCancelFunc1()
 		ctxCancelFunc()
-		require.Equal(t, Canceled, ctx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
 	})
 
 	t.Run("child_cancel_does_not_affect_parent", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestCancelContextAsParentContext(t *testing.T) {
 
 		ctxCancelFunc()
 		<-ctx.Done()
-		require.Equal(t, Canceled, ctx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
 
 		var blocked bool
 		select {
@@ -87,7 +87,7 @@ func TestCancelContextAsParentContext(t *testing.T) {
 		parCancelFunc()
 		<-parCtx.Done()
 		require.Equal(t, customSignal, parCtx.Err())
-		require.Equal(t, Canceled, ctx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
 	})
 }
 
@@ -118,9 +118,9 @@ func TestParentInitiallyCancelled(t *testing.T) {
 		require.NotNil(t, ctx)
 
 		<-ctx.Done()
-		require.Equal(t, Canceled, ctx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
 
 		cancelFunc() // should be no effect
-		require.Equal(t, Canceled, ctx.Err())
+		require.Equal(t, ErrCanceled, ctx.Err())
 	})
 }

--- a/plugins/teststeps/teststeps_test.go
+++ b/plugins/teststeps/teststeps_test.go
@@ -33,7 +33,7 @@ type data struct {
 }
 
 func newData() data {
-	ctx, pause := xcontext.WithNotify(nil, xcontext.Paused)
+	ctx, pause := xcontext.WithNotify(nil, xcontext.ErrPaused)
 	ctx, cancel := xcontext.WithCancel(ctx)
 	inCh := make(chan *target.Target)
 	outCh := make(chan *target.Target)
@@ -235,7 +235,7 @@ func TestForEachTargetTenTargetsParallelism(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			d.ctx.Debugf("target %+v cancelled", tgt)
-		case <-ctx.Until(xcontext.Paused):
+		case <-ctx.Until(xcontext.ErrPaused):
 			d.ctx.Debugf("target %+v paused", tgt)
 		case <-time.After(sleepTime):
 			d.ctx.Debugf("target %+v processed", tgt)
@@ -312,7 +312,7 @@ func TestForEachTargetCancelSignalPropagation(t *testing.T) {
 		case <-ctx.Done():
 			d.ctx.Debugf("target %+v caneled", tgt)
 			atomic.AddInt32(&canceledTargets, 1)
-		case <-ctx.Until(xcontext.Paused):
+		case <-ctx.Until(xcontext.ErrPaused):
 			d.ctx.Debugf("target %+v paused", tgt)
 		case <-time.After(sleepTime):
 			d.ctx.Debugf("target %+v processed", tgt)
@@ -350,7 +350,7 @@ func TestForEachTargetCancelBeforeInputChannelClosed(t *testing.T) {
 		case <-ctx.Done():
 			d.ctx.Debugf("target %+v cancelled", tgt)
 			atomic.AddInt32(&canceledTargets, 1)
-		case <-ctx.Until(xcontext.Paused):
+		case <-ctx.Until(xcontext.ErrPaused):
 			d.ctx.Debugf("target %+v paused", tgt)
 		case <-time.After(sleepTime):
 			d.ctx.Debugf("target %+v processed", tgt)

--- a/tests/plugins/teststeps/badtargets/badtargets.go
+++ b/tests/plugins/teststeps/badtargets/badtargets.go
@@ -47,30 +47,30 @@ func (ts *badTargets) Run(ctx xcontext.Context, ch test.TestStepChannels, params
 				select {
 				case ch.Out <- &tgt2:
 				case <-ctx.Done():
-					return xcontext.Canceled
+					return xcontext.ErrCanceled
 				}
 			case "TDup":
 				select {
 				case ch.Out <- tgt:
 				case <-ctx.Done():
-					return xcontext.Canceled
+					return xcontext.ErrCanceled
 				}
 				select {
 				case ch.Out <- tgt:
 				case <-ctx.Done():
-					return xcontext.Canceled
+					return xcontext.ErrCanceled
 				}
 			case "TExtra":
 				tgt2 := &target.Target{ID: "TExtra2"}
 				select {
 				case ch.Out <- tgt:
 				case <-ctx.Done():
-					return xcontext.Canceled
+					return xcontext.ErrCanceled
 				}
 				select {
 				case ch.Out <- tgt2:
 				case <-ctx.Done():
-					return xcontext.Canceled
+					return xcontext.ErrCanceled
 				}
 			case "T1":
 				// Mangle the returned target name.
@@ -78,13 +78,13 @@ func (ts *badTargets) Run(ctx xcontext.Context, ch test.TestStepChannels, params
 				select {
 				case ch.Out <- tgt2:
 				case <-ctx.Done():
-					return xcontext.Canceled
+					return xcontext.ErrCanceled
 				}
 			default:
 				return fmt.Errorf("Unexpected target name: %q", tgt.ID)
 			}
 		case <-ctx.Done():
-			return xcontext.Canceled
+			return xcontext.ErrCanceled
 		}
 	}
 }

--- a/tests/plugins/teststeps/slowecho/slowecho.go
+++ b/tests/plugins/teststeps/slowecho/slowecho.go
@@ -87,7 +87,7 @@ func (e *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.T
 		case <-time.After(sleep):
 		case <-ctx.Done():
 			ctx.Infof("Returning because cancellation is requested")
-			return xcontext.Canceled
+			return xcontext.ErrCanceled
 		}
 		ctx.Infof("target %s: %s", t, params.GetOne("text"))
 		return nil

--- a/tests/plugins/teststeps/teststep/teststep.go
+++ b/tests/plugins/teststeps/teststep/teststep.go
@@ -79,7 +79,7 @@ func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.
 		select {
 		case <-time.After(delay):
 		case <-ctx.Done():
-			return xcontext.Canceled
+			return xcontext.ErrCanceled
 		}
 		if ts.shouldFail(target, params) {
 			if err := ev.Emit(ctx, testevent.Data{EventName: FailedEvent, Target: target, Payload: nil}); err != nil {


### PR DESCRIPTION
Still compiles:
```
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go run ./cmds/clients/contestcli/
Missing verb, see --help
exit status 1
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go run ./cmds/contest/
[2021-03-22T15:10:56.959Z I main.go:54] Using database URI for primary storage: contest:contest@tcp(localhost:3306)/contest?parseTime=true
[2021-03-22T15:10:56.959Z F main.go:59] Could not initialize database: unable to contact database: dial tcp 127.0.0.1:3306: connect: connection refused
exit status 1
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go test ./...
?       github.com/facebookincubator/contest/cmds/clients/contestcli    [no test files]
?       github.com/facebookincubator/contest/cmds/contest       [no test files]
?       github.com/facebookincubator/contest/cmds/plugins       [no test files]
?       github.com/facebookincubator/contest/db/rdbms/migration [no test files]
ok      github.com/facebookincubator/contest/pkg/api    (cached)
?       github.com/facebookincubator/contest/pkg/cerrors        [no test files]
?       github.com/facebookincubator/contest/pkg/config [no test files]
?       github.com/facebookincubator/contest/pkg/event  [no test files]
?       github.com/facebookincubator/contest/pkg/event/frameworkevent   [no test files]
?       github.com/facebookincubator/contest/pkg/event/internal/querytools      [no test files]
?       github.com/facebookincubator/contest/pkg/event/internal/reflecttools    [no test files]
ok      github.com/facebookincubator/contest/pkg/event/testevent        (cached)
ok      github.com/facebookincubator/contest/pkg/job    (cached)
?       github.com/facebookincubator/contest/pkg/jobmanager     [no test files]
ok      github.com/facebookincubator/contest/pkg/lib/comparison (cached)
?       github.com/facebookincubator/contest/pkg/logging        [no test files]
ok      github.com/facebookincubator/contest/pkg/pluginregistry (cached)
ok      github.com/facebookincubator/contest/pkg/runner (cached)
ok      github.com/facebookincubator/contest/pkg/storage        (cached)
ok      github.com/facebookincubator/contest/pkg/storage/limits (cached)
ok      github.com/facebookincubator/contest/pkg/target (cached)
ok      github.com/facebookincubator/contest/pkg/test   (cached)
?       github.com/facebookincubator/contest/pkg/transport      [no test files]
?       github.com/facebookincubator/contest/pkg/transport/http [no test files]
?       github.com/facebookincubator/contest/pkg/types  [no test files]
?       github.com/facebookincubator/contest/pkg/userfunctions/donothing        [no test files]
?       github.com/facebookincubator/contest/pkg/userfunctions/ocp      [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext       (cached)
?       github.com/facebookincubator/contest/pkg/xcontext/buildinfo     [no test files]
?       github.com/facebookincubator/contest/pkg/xcontext/bundles       [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx     (cached)
?       github.com/facebookincubator/contest/pkg/xcontext/bundles/zapctx        [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext/fields        (cached)
ok      github.com/facebookincubator/contest/pkg/xcontext/logger        (cached)
ok      github.com/facebookincubator/contest/pkg/xcontext/logger/internal       (cached)
ok      github.com/facebookincubator/contest/pkg/xcontext/logger/logadapter/logrus      (cached)
?       github.com/facebookincubator/contest/pkg/xcontext/logger/logadapter/zap [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext/metrics       (cached)
?       github.com/facebookincubator/contest/plugins/listeners/httplistener     [no test files]
?       github.com/facebookincubator/contest/plugins/reporters/noop     [no test files]
?       github.com/facebookincubator/contest/plugins/reporters/targetsuccess    [no test files]
ok      github.com/facebookincubator/contest/plugins/storage/memory     (cached)
?       github.com/facebookincubator/contest/plugins/storage/rdbms      [no test files]
?       github.com/facebookincubator/contest/plugins/targetlocker/dblocker      [no test files]
ok      github.com/facebookincubator/contest/plugins/targetlocker/inmemory      (cached)
ok      github.com/facebookincubator/contest/plugins/targetlocker/noop  (cached)
?       github.com/facebookincubator/contest/plugins/targetmanagers/csvtargetmanager    [no test files]
?       github.com/facebookincubator/contest/plugins/targetmanagers/targetlist  [no test files]
?       github.com/facebookincubator/contest/plugins/testfetchers/literal       [no test files]
?       github.com/facebookincubator/contest/plugins/testfetchers/uri   [no test files]
ok      github.com/facebookincubator/contest/plugins/teststeps  (cached)
?       github.com/facebookincubator/contest/plugins/teststeps/cmd      [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/echo     [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/example  [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/randecho [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/sshcmd   [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/terminalexpect   [no test files]
?       github.com/facebookincubator/contest/tests/common       [no test files]
ok      github.com/facebookincubator/contest/tests/common/goroutine_leak_check  (cached)
?       github.com/facebookincubator/contest/tests/integ/common [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/badtargets [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/channels   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/crash      [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/fail       [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/hanging    [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/noop       [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/noreturn   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/panicstep  [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/slowecho   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/teststep   [no test files]
?       github.com/facebookincubator/contest/tools/migration/rdbms      [no test files]
?       github.com/facebookincubator/contest/tools/migration/rdbms/migrate      [no test files]
?       github.com/facebookincubator/contest/tools/migration/rdbms/migrationlib [no test files]
```