### PR TITLE
Bugfix/xcontext racecondition

### DIFF
--- a/pkg/xcontext/context_atomic.go
+++ b/pkg/xcontext/context_atomic.go
@@ -10,24 +10,24 @@ import (
 	"unsafe"
 )
 
-func (ctx *ctxValue) loadLoggerInstance() Logger {
-	return *(*Logger)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.loggerInstance))))
+func (ctx *ctxValue) loadLoggerInstance() *Logger {
+	return (*Logger)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.loggerInstance))))
 }
 
 func (ctx *ctxValue) storeLoggerInstance(newLogger Logger) {
 	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.loggerInstance)), unsafe.Pointer(&newLogger))
 }
 
-func (ctx *ctxValue) loadMetricsInstance() Metrics {
-	return *(*Metrics)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.metricsInstance))))
+func (ctx *ctxValue) loadMetricsInstance() *Metrics {
+	return (*Metrics)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.metricsInstance))))
 }
 
 func (ctx *ctxValue) storeMetricsInstance(newMetrics Metrics) {
 	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.metricsInstance)), unsafe.Pointer(&newMetrics))
 }
 
-func (ctx *ctxValue) loadTracerInstance() Tracer {
-	return *(*Tracer)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.tracerInstance))))
+func (ctx *ctxValue) loadTracerInstance() *Tracer {
+	return (*Tracer)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.tracerInstance))))
 }
 
 func (ctx *ctxValue) storeTracerInstance(newTracer Tracer) {


### PR DESCRIPTION
```
go test -v -race -count=1 -tags=integration,integration_storage -failfast ./tests/integ/jobmanager
```
now results into:
```
--- PASS: TestJobManagerSuiteRdbmsStorage (8.14s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestBadTag (0.01s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestCancelAndExit (0.16s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestDuplicateTag (0.01s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestInternalTag (0.01s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobListing (0.15s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerDifferentInstances (0.10s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerJobCancellation (0.07s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerJobCrash (0.06s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerJobFailure (0.06s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerJobNotSuccessful (0.07s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerJobReport (0.08s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestJobManagerJobStartSingle (0.08s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestPauseAndExit (0.57s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestPauseAndFailToResume (1.61s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestPauseAndResumeBetweenRuns (1.66s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestPauseAndResumeDuringRun1 (1.67s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestPauseAndResumeDuringRun2 (1.66s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestTestNull (0.01s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestTestStepLabelDuplication (0.01s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestTestStepNoLabel (0.01s)
    --- PASS: TestJobManagerSuiteRdbmsStorage/TestTestStepNull (0.01s)
PASS
ok      github.com/facebookincubator/contest/tests/integ/jobmanager     15.582s
```