### PR TITLE
Consolidate test step output channels into one

### DIFF
--- a/pkg/cerrors/cerrors.go
+++ b/pkg/cerrors/cerrors.go
@@ -8,17 +8,7 @@ package cerrors
 import (
 	"fmt"
 	"strings"
-
-	"github.com/facebookincubator/contest/pkg/target"
 )
-
-// TargetError is used by TestSteps to indicate that a Target encountered
-// an error while running the test. A Target that encounters a TargetError
-// does not proceed further in the test run.
-type TargetError struct {
-	Target *target.Target
-	Err    error
-}
 
 // ErrResumeNotSupported indicates that a test step cannot resume. This can
 // be checked explicitly by the framework

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -49,6 +49,7 @@ type Target struct {
 	PrimaryIPv6 net.IP `json:"PrimaryIPv6,omitempty"`
 }
 
+// String produces a string representation for a Target.
 func (t *Target) String() string {
 	if t == nil {
 		return "(*Target)(nil)"

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -92,12 +91,19 @@ type TestStepBundle struct {
 	AllowedEvents map[event.Name]bool
 }
 
+// TestStepResult is used by TestSteps to report result for a particular target.
+// Empty Err means success, non-empty indicates failure.
+// Failed targets do not proceed to further steps in this run.
+type TestStepResult struct {
+	Target *target.Target
+	Err    error
+}
+
 // TestStepChannels represents the input and output  channels used by a TestStep
 // to communicate with the TestRunner
 type TestStepChannels struct {
 	In  <-chan *target.Target
-	Out chan<- *target.Target
-	Err chan<- cerrors.TargetError
+	Out chan<- TestStepResult
 }
 
 // TestStep is the interface that all steps need to implement to be executed

--- a/plugins/teststeps/echo/echo.go
+++ b/plugins/teststeps/echo/echo.go
@@ -53,13 +53,12 @@ func (e Step) Name() string {
 func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	for {
 		select {
-		case target := <-ch.In:
-			if target == nil {
-				// no more targets incoming
+		case target, ok := <-ch.In:
+			if !ok {
 				return nil
 			}
 			ctx.Infof("Running on target %s with text '%s'", target, params.GetOne("text"))
-			ch.Out <- target
+			ch.Out <- test.TestStepResult{Target: target}
 		case <-ctx.Done():
 			return nil
 		}

--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -8,7 +8,6 @@ package teststeps
 import (
 	"sync"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/xcontext"
@@ -30,18 +29,13 @@ func ForEachTarget(pluginName string, ctx xcontext.Context, ch test.TestStepChan
 	reportTarget := func(t *target.Target, err error) {
 		if err != nil {
 			ctx.Errorf("%s: ForEachTarget: failed to apply test step function on target %s: %v", pluginName, t, err)
-			select {
-			case ch.Err <- cerrors.TargetError{Target: t, Err: err}:
-			case <-ctx.Done():
-				ctx.Debugf("%s: ForEachTarget: received cancellation signal while reporting error", pluginName)
-			}
 		} else {
 			ctx.Debugf("%s: ForEachTarget: target %s completed successfully", pluginName, t)
-			select {
-			case ch.Out <- t:
-			case <-ctx.Done():
-				ctx.Debugf("%s: ForEachTarget: received pause signal while reporting success", pluginName)
-			}
+		}
+		select {
+		case ch.Out <- test.TestStepResult{Target: t, Err: err}:
+		case <-ctx.Done():
+			ctx.Debugf("%s: ForEachTarget: received cancellation signal while reporting result", pluginName)
 		}
 	}
 

--- a/tests/plugins/teststeps/badtargets/badtargets.go
+++ b/tests/plugins/teststeps/badtargets/badtargets.go
@@ -45,30 +45,30 @@ func (ts *badTargets) Run(ctx xcontext.Context, ch test.TestStepChannels, params
 				// We should not depend on pointer matching, so emit a copy.
 				tgt2 := *tgt
 				select {
-				case ch.Out <- &tgt2:
+				case ch.Out <- test.TestStepResult{Target: &tgt2}:
 				case <-ctx.Done():
 					return xcontext.ErrCanceled
 				}
 			case "TDup":
 				select {
-				case ch.Out <- tgt:
+				case ch.Out <- test.TestStepResult{Target: tgt}:
 				case <-ctx.Done():
 					return xcontext.ErrCanceled
 				}
 				select {
-				case ch.Out <- tgt:
+				case ch.Out <- test.TestStepResult{Target: tgt}:
 				case <-ctx.Done():
 					return xcontext.ErrCanceled
 				}
 			case "TExtra":
 				tgt2 := &target.Target{ID: "TExtra2"}
 				select {
-				case ch.Out <- tgt:
+				case ch.Out <- test.TestStepResult{Target: tgt}:
 				case <-ctx.Done():
 					return xcontext.ErrCanceled
 				}
 				select {
-				case ch.Out <- tgt2:
+				case ch.Out <- test.TestStepResult{Target: tgt2}:
 				case <-ctx.Done():
 					return xcontext.ErrCanceled
 				}
@@ -76,7 +76,7 @@ func (ts *badTargets) Run(ctx xcontext.Context, ch test.TestStepChannels, params
 				// Mangle the returned target name.
 				tgt2 := &target.Target{ID: tgt.ID + "XXX"}
 				select {
-				case ch.Out <- tgt2:
+				case ch.Out <- test.TestStepResult{Target: tgt2}:
 				case <-ctx.Done():
 					return xcontext.ErrCanceled
 				}

--- a/tests/plugins/teststeps/channels/channels.go
+++ b/tests/plugins/teststeps/channels/channels.go
@@ -30,11 +30,10 @@ func (ts *channels) Name() string {
 // Run executes a step that runs fine but closes its output channels on exit.
 func (ts *channels) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	for target := range ch.In {
-		ch.Out <- target
+		ch.Out <- test.TestStepResult{Target: target}
 	}
 	// This is bad, do not do this.
 	close(ch.Out)
-	close(ch.Err)
 	return nil
 }
 

--- a/tests/plugins/teststeps/fail/fail.go
+++ b/tests/plugins/teststeps/fail/fail.go
@@ -33,11 +33,14 @@ func (ts *fail) Name() string {
 func (ts *fail) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	for {
 		select {
-		case target := <-ch.In:
-			if target == nil {
+		case target, ok := <-ch.In:
+			if !ok {
 				return nil
 			}
-			ch.Err <- cerrors.TargetError{Target: target, Err: fmt.Errorf("Integration test failure for %v", target)}
+			ch.Out <- test.TestStepResult{
+				Target: target,
+				Err:    fmt.Errorf("Integration test failure for %v", target),
+			}
 		case <-ctx.Done():
 			return nil
 		}

--- a/tests/plugins/teststeps/noop/noop.go
+++ b/tests/plugins/teststeps/noop/noop.go
@@ -31,12 +31,12 @@ func (ts *noop) Name() string {
 func (ts *noop) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	for {
 		select {
-		case target := <-ch.In:
-			if target == nil {
+		case target, ok := <-ch.In:
+			if !ok {
 				return nil
 			}
-			ch.Out <- target
-		case <-ctx.Until(nil):
+			ch.Out <- test.TestStepResult{Target: target}
+		case <-ctx.Done():
 			return nil
 		}
 	}

--- a/tests/plugins/teststeps/noreturn/noreturn.go
+++ b/tests/plugins/teststeps/noreturn/noreturn.go
@@ -30,7 +30,7 @@ func (ts *noreturnStep) Name() string {
 // Run executes a step that never returns.
 func (ts *noreturnStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	for target := range ch.In {
-		ch.Out <- target
+		ch.Out <- test.TestStepResult{Target: target}
 	}
 	channel := make(chan struct{})
 	<-channel


### PR DESCRIPTION
Instead of sending to either TestStepChannels.Out or .Err, always send a TestStepResult to .Out.
TestStepResult associates a target and and error, nil meaning the target passed successfully.