### PR TITLE
Bugfix/align logging fields

### DIFF
--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -58,7 +58,7 @@ func (jr *JobRunner) Run(ctx xcontext.Context, j *job.Job, resumeState *job.Paus
 	runID := types.RunID(1)
 	var delay time.Duration
 
-	jobCtx := ctx.WithFields(xcontext.Fields{"jobid": j.ID})
+	jobCtx := ctx.WithField("job_id", j.ID)
 
 	if resumeState != nil {
 		runID = resumeState.RunID
@@ -84,7 +84,7 @@ func (jr *JobRunner) Run(ctx xcontext.Context, j *job.Job, resumeState *job.Paus
 	)
 
 	for ; runID <= types.RunID(j.Runs) || j.Runs == 0; runID++ {
-		runCtx := ctx.WithFields(xcontext.Fields{"runid": runID})
+		runCtx := ctx.WithField("run_id", runID)
 		if delay > 0 {
 			nextRun := time.Now().Add(delay)
 			runCtx.Infof("Sleeping %s before the next run...", delay)

--- a/pkg/xcontext/context_atomic.go
+++ b/pkg/xcontext/context_atomic.go
@@ -10,26 +10,10 @@ import (
 	"unsafe"
 )
 
-func (ctx *ctxValue) loadLoggerInstance() *Logger {
-	return (*Logger)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.loggerInstance))))
+func (ctx *ctxValue) loadDebugTools() *debugTools {
+	return (*debugTools)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.debugTools))))
 }
 
-func (ctx *ctxValue) storeLoggerInstance(newLogger Logger) {
-	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.loggerInstance)), unsafe.Pointer(&newLogger))
-}
-
-func (ctx *ctxValue) loadMetricsInstance() *Metrics {
-	return (*Metrics)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.metricsInstance))))
-}
-
-func (ctx *ctxValue) storeMetricsInstance(newMetrics Metrics) {
-	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.metricsInstance)), unsafe.Pointer(&newMetrics))
-}
-
-func (ctx *ctxValue) loadTracerInstance() *Tracer {
-	return (*Tracer)(atomic.LoadPointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.tracerInstance))))
-}
-
-func (ctx *ctxValue) storeTracerInstance(newTracer Tracer) {
-	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.tracerInstance)), unsafe.Pointer(&newTracer))
+func (ctx *ctxValue) storeDebugTools(newDebugTools *debugTools) {
+	atomic.StorePointer((*unsafe.Pointer)((unsafe.Pointer)(&ctx.debugTools)), unsafe.Pointer(newDebugTools))
 }

--- a/plugins/targetlocker/dblocker/dblocker.go
+++ b/plugins/targetlocker/dblocker/dblocker.go
@@ -16,9 +16,10 @@ import (
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/pkg/xcontext"
 
+	"github.com/benbjohnson/clock"
+
 	// this blank import registers the mysql driver
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/benbjohnson/clock"
 )
 
 // Name is the plugin name.
@@ -351,7 +352,7 @@ func DriverName(name string) Opt {
 // New initializes and returns a new DBLocker target locker.
 func New(dbURI string, opts ...Opt) (target.Locker, error) {
 	res := &DBLocker{
-		Clock:          clock.New(),
+		Clock: clock.New(),
 	}
 
 	for _, Opt := range opts {


### PR DESCRIPTION
Here we have 2 commits:
* [Rename log fields "runid" and "jobid" to "run_id" and "job_id"](https://github.com/facebookincubator/contest/pull/254/commits/48438679f83d40cfe6512cd4a39f577c69e2848d).
* [Simplify the log to handle logger/tracer/metrics instances and their fields/tags](https://github.com/facebookincubator/contest/pull/254/commits/af723d405f1c3b525ac89863018bc5f9306dae66).

The first is required to be able to filter jobs by `job_id`.

The second is a defensive change to avoid misbehavior of fields. Attempts to solve race conditions made the code quite convoluted and difficult to validate if it is really correct. Therefore I moved logger, metrics, tracer and fields/tags to a separate structure which is always access atomically (and never modified after returning it somewhere) -- this will guarantee the data is always correct and it is easier to validate.

# Test Plan

```
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go test ./... -tags integration,integration_storage -race
?       github.com/facebookincubator/contest/cmds/clients/contestcli    [no test files]
?       github.com/facebookincubator/contest/cmds/contest       [no test files]
?       github.com/facebookincubator/contest/cmds/plugins       [no test files]
?       github.com/facebookincubator/contest/db/rdbms/migration [no test files]
ok      github.com/facebookincubator/contest/pkg/api    0.048s
?       github.com/facebookincubator/contest/pkg/cerrors        [no test files]
?       github.com/facebookincubator/contest/pkg/config [no test files]
?       github.com/facebookincubator/contest/pkg/event  [no test files]
?       github.com/facebookincubator/contest/pkg/event/frameworkevent   [no test files]
?       github.com/facebookincubator/contest/pkg/event/internal/querytools      [no test files]
?       github.com/facebookincubator/contest/pkg/event/internal/reflecttools    [no test files]
ok      github.com/facebookincubator/contest/pkg/event/testevent        0.026s
ok      github.com/facebookincubator/contest/pkg/job    0.026s
?       github.com/facebookincubator/contest/pkg/jobmanager     [no test files]
ok      github.com/facebookincubator/contest/pkg/lib/comparison (cached)
?       github.com/facebookincubator/contest/pkg/logging        [no test files]
ok      github.com/facebookincubator/contest/pkg/pluginregistry 0.052s
ok      github.com/facebookincubator/contest/pkg/runner 2.965s
ok      github.com/facebookincubator/contest/pkg/storage        0.041s
ok      github.com/facebookincubator/contest/pkg/storage/limits 0.113s
ok      github.com/facebookincubator/contest/pkg/target 0.028s
ok      github.com/facebookincubator/contest/pkg/test   0.037s
?       github.com/facebookincubator/contest/pkg/transport      [no test files]
?       github.com/facebookincubator/contest/pkg/transport/http [no test files]
?       github.com/facebookincubator/contest/pkg/types  [no test files]
?       github.com/facebookincubator/contest/pkg/userfunctions/donothing        [no test files]
?       github.com/facebookincubator/contest/pkg/userfunctions/ocp      [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext       0.056s
?       github.com/facebookincubator/contest/pkg/xcontext/buildinfo     [no test files]
?       github.com/facebookincubator/contest/pkg/xcontext/bundles       [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx     0.021s
?       github.com/facebookincubator/contest/pkg/xcontext/bundles/zapctx        [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext/fields        (cached)
ok      github.com/facebookincubator/contest/pkg/xcontext/logger        (cached)
ok      github.com/facebookincubator/contest/pkg/xcontext/logger/internal       (cached)
ok      github.com/facebookincubator/contest/pkg/xcontext/logger/logadapter/logrus      (cached)
?       github.com/facebookincubator/contest/pkg/xcontext/logger/logadapter/zap [no test files]
ok      github.com/facebookincubator/contest/pkg/xcontext/metrics       (cached)
?       github.com/facebookincubator/contest/plugins/listeners/httplistener     [no test files]
?       github.com/facebookincubator/contest/plugins/reporters/noop     [no test files]
?       github.com/facebookincubator/contest/plugins/reporters/targetsuccess    [no test files]
ok      github.com/facebookincubator/contest/plugins/storage/memory     0.028s
?       github.com/facebookincubator/contest/plugins/storage/rdbms      [no test files]
?       github.com/facebookincubator/contest/plugins/targetlocker/dblocker      [no test files]
ok      github.com/facebookincubator/contest/plugins/targetlocker/inmemory      0.325s
ok      github.com/facebookincubator/contest/plugins/targetlocker/noop  0.061s
?       github.com/facebookincubator/contest/plugins/targetmanagers/csvtargetmanager    [no test files]
?       github.com/facebookincubator/contest/plugins/targetmanagers/targetlist  [no test files]
?       github.com/facebookincubator/contest/plugins/testfetchers/literal       [no test files]
?       github.com/facebookincubator/contest/plugins/testfetchers/uri   [no test files]
ok      github.com/facebookincubator/contest/plugins/teststeps  0.529s
?       github.com/facebookincubator/contest/plugins/teststeps/cmd      [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/echo     [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/example  [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/randecho [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/sshcmd   [no test files]
?       github.com/facebookincubator/contest/plugins/teststeps/terminalexpect   [no test files]
?       github.com/facebookincubator/contest/tests/common       [no test files]
ok      github.com/facebookincubator/contest/tests/common/goroutine_leak_check  (cached)
?       github.com/facebookincubator/contest/tests/integ/common [no test files]
ok      github.com/facebookincubator/contest/tests/integ/events/frameworkevents 0.178s
ok      github.com/facebookincubator/contest/tests/integ/events/testevents      0.245s
ok      github.com/facebookincubator/contest/tests/integ/job    0.126s
ok      github.com/facebookincubator/contest/tests/integ/jobmanager     21.675s
ok      github.com/facebookincubator/contest/tests/integ/migration      0.073s
ok      github.com/facebookincubator/contest/tests/integ/test   1.142s
ok      github.com/facebookincubator/contest/tests/plugins/targetlocker/dblocker        0.871s
?       github.com/facebookincubator/contest/tests/plugins/teststeps/badtargets [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/channels   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/crash      [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/fail       [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/hanging    [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/noop       [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/noreturn   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/panicstep  [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/slowecho   [no test files]
?       github.com/facebookincubator/contest/tests/plugins/teststeps/teststep   [no test files]
?       github.com/facebookincubator/contest/tools/migration/rdbms      [no test files]
?       github.com/facebookincubator/contest/tools/migration/rdbms/migrate      [no test files]
?       github.com/facebookincubator/contest/tools/migration/rdbms/migrationlib [no test files]

```