### PR TITLE
Fix test step shutdown timeout handling

### DIFF
--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -314,6 +314,7 @@ func TestNoReturnStepWithCorrectTargetForwarding(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.IsType(t, &cerrors.ErrTestStepsNeverReturned{}, err)
+	require.Contains(t, getStepEvents("Step 1"), "step [Step 1] did not return")
 }
 
 // A misbehaving step that panics.


### PR DESCRIPTION
Never close test's output channel while runner goroutine is still up
to prevent "write on closed channel" panics.

If step runner fails to exit within shutdown timeout after aving
processed all the targets, assert cancellation to release the reader.

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>