### PR TITLE
bugfix(xcontext): Fix panic in StdCtxUntil

### DIFF
--- a/pkg/xcontext/context_test.go
+++ b/pkg/xcontext/context_test.go
@@ -48,3 +48,17 @@ func TestGoroutineLeak(t *testing.T) {
 	stack = stack[:n]
 	require.GreaterOrEqual(t, old, runtime.NumGoroutine(), fmt.Sprintf("%s", stack))
 }
+
+func TestStdCtxUntil(t *testing.T) {
+	ctx, pauseFn := WithNotify(nil, ErrPaused)
+	stdCtx := ctx.StdCtxUntil(nil)
+
+	select {
+	case <-stdCtx.Done():
+		t.Fatal("stdCtx should not be Done by now")
+	default:
+	}
+
+	pauseFn()
+	<-stdCtx.Done()
+}

--- a/pkg/xcontext/event_handler.go
+++ b/pkg/xcontext/event_handler.go
@@ -124,6 +124,12 @@ func (ctx *ctxValue) cloneWithStdContext(stdCtx context.Context) Context {
 }
 
 type eventHandler struct {
+	// cancelSignal is closed when a new cancel signal is arrived
+	cancelSignal chan struct{}
+
+	// children is all eventHandlers derived from this one. And for example
+	// if this one will receive a close signal, then all children will
+	// also receive a close signal.
 	children map[*eventHandler]struct{}
 
 	// locker is used exclude concurrent access to any data below (in this
@@ -139,9 +145,6 @@ type eventHandler struct {
 
 	// receivedCancels is only the cancel signals received by this node.
 	receivedCancels []error
-
-	// cancelSignal is closed when a new cancel signal is arrived
-	cancelSignal chan struct{}
 
 	// receivedNotifications same as receivedCancels, but for notification signals.
 	receivedNotifications []error


### PR DESCRIPTION
I missed method `StdCtxUntil` in unit-tests and it appears the function does not work at all. Added an unit-test, fixed the panic and added a comment explaining how the method works.

The panic was caused by wrong usage of `SetFinalizer`: `SetFinalizer` could be assigned only to pointers to a beginning of an allocated area. Therefore it should be the first field of a structure (if the data is stored in a structure).