### PR TITLE
Plugin API cleanup: remove Resume() and CanResume()

### DIFF
--- a/pkg/cerrors/cerrors.go
+++ b/pkg/cerrors/cerrors.go
@@ -10,17 +10,6 @@ import (
 	"strings"
 )
 
-// ErrResumeNotSupported indicates that a test step cannot resume. This can
-// be checked explicitly by the framework
-type ErrResumeNotSupported struct {
-	StepName string
-}
-
-// Error returns the error string associated with the error
-func (e *ErrResumeNotSupported) Error() string {
-	return fmt.Sprintf("test step %s does not support resume", e.StepName)
-}
-
 // ErrTestStepsNeverReturned indicates that one or multiple TestSteps
 //  did not complete when the test terminated or when the pipeline
 // received a cancellation or pause signal

--- a/pkg/pluginregistry/pluginregistry_test.go
+++ b/pkg/pluginregistry/pluginregistry_test.go
@@ -8,7 +8,6 @@ package pluginregistry
 import (
 	"testing"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -46,16 +45,6 @@ func (e AStep) Name() string {
 // Run executes the AStep
 func (e AStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
 	return nil
-}
-
-// CanResume tells whether this step is able to resume.
-func (e AStep) CanResume() bool {
-	return false
-}
-
-// Resume tries to resume AStep
-func (e AStep) Resume(ctx xcontext.Context, _ test.TestStepChannels, _ test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: "AStep"}
 }
 
 func TestRegisterTestStep(t *testing.T) {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -113,12 +113,6 @@ type TestStep interface {
 	Name() string
 	// Run runs the test step. The test step is expected to be synchronous.
 	Run(ctx xcontext.Context, ch TestStepChannels, params TestStepParameters, ev testevent.Emitter) error
-	// CanResume signals whether a test step can be resumed.
-	CanResume() bool
-	// Resume is called if a test step resume is requested, and CanResume
-	// returns true. If resume is not supported, this method should return
-	// ErrResumeNotSupported.
-	Resume(ctx xcontext.Context, ch TestStepChannels, params TestStepParameters, ev testevent.EmitterFetcher) error
 	// ValidateParameters checks that the parameters are correct before passing
 	// them to Run.
 	ValidateParameters(ctx xcontext.Context, params TestStepParameters) error

--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -196,17 +195,6 @@ func (ts *Cmd) validateAndPopulate(params test.TestStepParameters) error {
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *Cmd) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return ts.validateAndPopulate(params)
-}
-
-// Resume tries to resume a previously interrupted test step. Cmd cannot
-// resume.
-func (ts *Cmd) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *Cmd) CanResume() bool {
-	return false
 }
 
 // New initializes and returns a new Cmd test step.

--- a/plugins/teststeps/echo/echo.go
+++ b/plugins/teststeps/echo/echo.go
@@ -8,7 +8,6 @@ package echo
 import (
 	"errors"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -63,15 +62,4 @@ func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.Te
 			return nil
 		}
 	}
-}
-
-// CanResume tells whether this step is able to resume.
-func (e Step) CanResume() bool {
-	return false
-}
-
-// Resume tries to resume a previously interrupted test step. EchoStep cannot
-// resume.
-func (e Step) Resume(ctx xcontext.Context, _ test.TestStepChannels, _ test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
 }

--- a/plugins/teststeps/example/example.go
+++ b/plugins/teststeps/example/example.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -95,17 +94,6 @@ func (ts *Step) ValidateParameters(_ xcontext.Context, params test.TestStepParam
 		}
 	}
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *Step) Resume(ctx xcontext.Context, ch test.TestStepChannels, _ test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *Step) CanResume() bool {
-	return false
 }
 
 // New initializes and returns a new ExampleTestStep.

--- a/plugins/teststeps/randecho/randecho.go
+++ b/plugins/teststeps/randecho/randecho.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -79,15 +78,4 @@ func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.Te
 			}
 		},
 	)
-}
-
-// CanResume tells whether this step is able to resume.
-func (e Step) CanResume() bool {
-	return false
-}
-
-// Resume tries to resume a previously interrupted test step. RandEchoStep cannot
-// resume.
-func (e Step) Resume(ctx xcontext.Context, _ test.TestStepChannels, _ test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
 }

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kballard/go-shellquote"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -326,17 +325,6 @@ func (ts *SSHCmd) validateAndPopulate(params test.TestStepParameters) error {
 func (ts *SSHCmd) ValidateParameters(ctx xcontext.Context, params test.TestStepParameters) error {
 	ctx.Debugf("Params %+v", params)
 	return ts.validateAndPopulate(params)
-}
-
-// Resume tries to resume a previously interrupted test step. SSHCmd cannot
-// resume.
-func (ts *SSHCmd) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *SSHCmd) CanResume() bool {
-	return false
 }
 
 // New initializes and returns a new SSHCmd test step.

--- a/plugins/teststeps/terminalexpect/terminalexpect.go
+++ b/plugins/teststeps/terminalexpect/terminalexpect.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -118,17 +117,6 @@ func (ts *TerminalExpect) validateAndPopulate(params test.TestStepParameters) er
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *TerminalExpect) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return ts.validateAndPopulate(params)
-}
-
-// Resume tries to resume a previously interrupted test step. TerminalExpect cannot
-// resume.
-func (ts *TerminalExpect) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *TerminalExpect) CanResume() bool {
-	return false
 }
 
 // New initializes and returns a new TerminalExpect test step.

--- a/tests/plugins/teststeps/badtargets/badtargets.go
+++ b/tests/plugins/teststeps/badtargets/badtargets.go
@@ -8,7 +8,6 @@ package badtargets
 import (
 	"fmt"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -92,17 +91,6 @@ func (ts *badTargets) Run(ctx xcontext.Context, ch test.TestStepChannels, params
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *badTargets) ValidateParameters(ctx xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *badTargets) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *badTargets) CanResume() bool {
-	return false
 }
 
 // New creates a new badTargets step

--- a/tests/plugins/teststeps/channels/channels.go
+++ b/tests/plugins/teststeps/channels/channels.go
@@ -6,7 +6,6 @@
 package channels
 
 import (
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -40,17 +39,6 @@ func (ts *channels) Run(ctx xcontext.Context, ch test.TestStepChannels, params t
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *channels) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. Channels test step
-// cannot resume.
-func (ts *channels) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *channels) CanResume() bool {
-	return false
 }
 
 // New creates a new Channels step

--- a/tests/plugins/teststeps/crash/crash.go
+++ b/tests/plugins/teststeps/crash/crash.go
@@ -8,7 +8,6 @@ package crash
 import (
 	"fmt"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -37,17 +36,6 @@ func (ts *crash) Run(ctx xcontext.Context, ch test.TestStepChannels, params test
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *crash) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *crash) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *crash) CanResume() bool {
-	return false
 }
 
 // New creates a new noop step

--- a/tests/plugins/teststeps/fail/fail.go
+++ b/tests/plugins/teststeps/fail/fail.go
@@ -8,7 +8,6 @@ package fail
 import (
 	"fmt"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -50,17 +49,6 @@ func (ts *fail) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *fail) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *fail) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *fail) CanResume() bool {
-	return false
 }
 
 // New creates a new noop step

--- a/tests/plugins/teststeps/hanging/hanging.go
+++ b/tests/plugins/teststeps/hanging/hanging.go
@@ -6,7 +6,6 @@
 package hanging
 
 import (
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -37,17 +36,6 @@ func (ts *hanging) Run(ctx xcontext.Context, ch test.TestStepChannels, params te
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *hanging) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *hanging) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *hanging) CanResume() bool {
-	return false
 }
 
 // New creates a new hanging step

--- a/tests/plugins/teststeps/noop/noop.go
+++ b/tests/plugins/teststeps/noop/noop.go
@@ -6,7 +6,6 @@
 package noop
 
 import (
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -45,17 +44,6 @@ func (ts *noop) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *noop) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *noop) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *noop) CanResume() bool {
-	return false
 }
 
 // New creates a new noop step

--- a/tests/plugins/teststeps/noreturn/noreturn.go
+++ b/tests/plugins/teststeps/noreturn/noreturn.go
@@ -6,7 +6,6 @@
 package noreturn
 
 import (
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -40,17 +39,6 @@ func (ts *noreturnStep) Run(ctx xcontext.Context, ch test.TestStepChannels, para
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *noreturnStep) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *noreturnStep) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *noreturnStep) CanResume() bool {
-	return false
 }
 
 // New creates a new noreturnStep which forwards targets before hanging

--- a/tests/plugins/teststeps/panicstep/panicstep.go
+++ b/tests/plugins/teststeps/panicstep/panicstep.go
@@ -6,7 +6,6 @@
 package panicstep
 
 import (
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -35,17 +34,6 @@ func (ts *panicStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params 
 // ValidateParameters validates the parameters associated to the TestStep
 func (ts *panicStep) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. ExampleTestStep
-// cannot resume.
-func (ts *panicStep) Resume(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *panicStep) CanResume() bool {
-	return false
 }
 
 // New creates a new panicStep

--- a/tests/plugins/teststeps/slowecho/slowecho.go
+++ b/tests/plugins/teststeps/slowecho/slowecho.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -93,15 +92,4 @@ func (e *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.T
 		return nil
 	}
 	return teststeps.ForEachTarget(Name, ctx, ch, f)
-}
-
-// CanResume tells whether this step is able to resume.
-func (e Step) CanResume() bool {
-	return false
-}
-
-// Resume tries to resume a previously interrupted test step. EchoStep cannot
-// resume.
-func (e Step) Resume(ctx xcontext.Context, _ test.TestStepChannels, _ test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
 }

--- a/tests/plugins/teststeps/teststep/teststep.go
+++ b/tests/plugins/teststeps/teststep/teststep.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/facebookincubator/contest/pkg/cerrors"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/target"
@@ -133,17 +132,6 @@ func (ts *Step) ValidateParameters(_ xcontext.Context, params test.TestStepParam
 		}
 	}
 	return nil
-}
-
-// Resume tries to resume a previously interrupted test step. TestTestStep
-// cannot resume.
-func (ts *Step) Resume(ctx xcontext.Context, ch test.TestStepChannels, _ test.TestStepParameters, ev testevent.EmitterFetcher) error {
-	return &cerrors.ErrResumeNotSupported{StepName: Name}
-}
-
-// CanResume tells whether this step is able to resume.
-func (ts *Step) CanResume() bool {
-	return false
 }
 
 // New initializes and returns a new TestStep.


### PR DESCRIPTION
These will not be used, don't need them.

The plan is to pass resume state directly to Run().