### PR TITLE
Produce and commit run reports to storage as soon as the run ends

### DIFF
--- a/pkg/job/reporting.go
+++ b/pkg/job/reporting.go
@@ -62,9 +62,11 @@ type ReporterBundle struct {
 
 // Report wraps the information of a run report or a final report.
 type Report struct {
+	JobID        types.JobID
+	RunID        types.RunID `json:"RunID,omitempty"` // 0 for a final report
 	ReporterName string
-	Success      bool
 	ReportTime   time.Time
+	Success      bool
 	Data         interface{}
 }
 

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -95,7 +95,7 @@ func New(l api.Listener, pr *pluginregistry.PluginRegistry, opts ...Option) (*Jo
 		frameworkEvManager: frameworkEvManager,
 		testEvManager:      testEvManager,
 	}
-	jm.jobRunner = runner.NewJobRunner(cfg.clock, cfg.targetLockDuration)
+	jm.jobRunner = runner.NewJobRunner(jsm, cfg.clock, cfg.targetLockDuration)
 	return &jm, nil
 }
 

--- a/pkg/storage/events_test.go
+++ b/pkg/storage/events_test.go
@@ -51,7 +51,7 @@ func (n *nullStorage) StoreJobRequest(ctx xcontext.Context, request *job.Request
 func (n *nullStorage) GetJobRequest(ctx xcontext.Context, jobID types.JobID) (*job.Request, error) {
 	return nil, nil
 }
-func (n *nullStorage) StoreJobReport(ctx xcontext.Context, report *job.JobReport) error { return nil }
+func (n *nullStorage) StoreReport(ctx xcontext.Context, report *job.Report) error { return nil }
 func (n *nullStorage) GetJobReport(ctx xcontext.Context, jobID types.JobID) (*job.JobReport, error) {
 	return nil, nil
 }

--- a/pkg/storage/job.go
+++ b/pkg/storage/job.go
@@ -21,7 +21,7 @@ type JobStorage interface {
 	GetJobRequest(ctx xcontext.Context, jobID types.JobID) (*job.Request, error)
 
 	// Job report interface
-	StoreJobReport(ctx xcontext.Context, report *job.JobReport) error
+	StoreReport(ctx xcontext.Context, report *job.Report) error
 	GetJobReport(ctx xcontext.Context, jobID types.JobID) (*job.JobReport, error)
 
 	// Job enumeration interface
@@ -51,9 +51,9 @@ func (jsm JobStorageManager) GetJobRequestAsync(ctx xcontext.Context, jobID type
 	return request, nil
 }
 
-// StoreJobReport submits a job report to the storage layer
-func (jsm JobStorageManager) StoreJobReport(ctx xcontext.Context, report *job.JobReport) error {
-	return storage.StoreJobReport(ctx, report)
+// StoreReport submits a job run or final report to the storage layer
+func (jsm JobStorageManager) StoreReport(ctx xcontext.Context, report *job.Report) error {
+	return storage.StoreReport(ctx, report)
 }
 
 // GetJobReport fetches a job report from the storage layer

--- a/plugins/storage/memory/memory.go
+++ b/plugins/storage/memory/memory.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,13 +36,12 @@ type Memory struct {
 type jobInfo struct {
 	request *job.Request
 	desc    *job.Descriptor
-	report  *job.JobReport
 	state   job.State
+	reports []*job.Report
 }
 
 func emptyEventQuery(eventQuery *event.Query) bool {
 	return eventQuery.JobID == 0 && len(eventQuery.EventNames) == 0 && eventQuery.EmittedStartTime.IsZero() && eventQuery.EmittedEndTime.IsZero()
-
 }
 
 // emptyFrameworkEventQuery returns whether the Query contains only default values
@@ -184,32 +184,57 @@ func (m *Memory) GetJobRequest(_ xcontext.Context, jobID types.JobID) (*job.Requ
 	return v.request, nil
 }
 
-// StoreJobReport stores a report associated to a job. Returns an error if there is
-// already a report associated to the job
-func (m *Memory) StoreJobReport(_ xcontext.Context, report *job.JobReport) error {
+// StoreReport stores a report associated to a job. Returns an error if there is
+// already a report associated with this run.
+func (m *Memory) StoreReport(_ xcontext.Context, report *job.Report) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	v := m.jobInfo[report.JobID]
-	if v == nil {
+	ji := m.jobInfo[report.JobID]
+	if ji == nil {
 		return fmt.Errorf("could not find job with id %v", report.JobID)
 	}
-	if v.report != nil {
-		return fmt.Errorf("job report already present for job id %v", report.JobID)
+	for _, r := range ji.reports {
+		if r.JobID == report.JobID && r.RunID == report.RunID && r.ReporterName == report.ReporterName {
+			return fmt.Errorf("duplicate report %d/%d/%s", r.JobID, r.RunID, r.ReporterName)
+		}
 	}
-	v.report = report
+	ji.reports = append(ji.reports, report)
 	return nil
 }
 
 // GetJobReport returns the report associated to a given job
-func (m *Memory) GetJobReport(_ xcontext.Context, jobID types.JobID) (*job.JobReport, error) {
+func (m *Memory) GetJobReport(ctx xcontext.Context, jobID types.JobID) (*job.JobReport, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	v := m.jobInfo[jobID]
-	if v == nil || v.report == nil {
+	jr := &job.JobReport{JobID: jobID}
+	ji := m.jobInfo[jobID]
+	if ji == nil {
 		// return a job report with no results
-		return &job.JobReport{JobID: jobID}, nil
+		return jr, nil
 	}
-	return v.report, nil
+	// Sort reports by run id and reporter name
+	sort.Slice(ji.reports, func(i, j int) bool {
+		if ji.reports[i].RunID < ji.reports[j].RunID {
+			return true
+		}
+		return strings.Compare(ji.reports[i].ReporterName, ji.reports[i].ReporterName) < 0
+	})
+	for _, r := range ji.reports {
+		if r.RunID == 0 {
+			jr.FinalReports = append(jr.FinalReports, r)
+		} else {
+			i := int(r.RunID) - 1
+			if i > len(jr.RunReports) {
+				ctx.Errorf("Incomplete set of run reports for job %d", jobID)
+				break
+			}
+			if i == len(jr.RunReports) {
+				jr.RunReports = append(jr.RunReports, nil)
+			}
+			jr.RunReports[i] = append(jr.RunReports[i], r)
+		}
+	}
+	return jr, nil
 }
 
 func (m *Memory) ListJobs(_ xcontext.Context, query *storage.JobQuery) ([]types.JobID, error) {

--- a/plugins/targetlocker/inmemory/inmemory.go
+++ b/plugins/targetlocker/inmemory/inmemory.go
@@ -214,7 +214,7 @@ func (tl *InMemory) TryLock(ctx xcontext.Context, jobID types.JobID, duration ti
 	tl.lockRequests <- &req
 	// wait for result
 	err := <-req.err
-	ctx.Debugf("TryLock %d targets for %s: %d %v", len(targets), duration, req.locked, err)
+	ctx.Debugf("TryLock %d targets for %s: %d %v", len(targets), duration, len(req.locked), err)
 	return req.locked, err
 }
 


### PR DESCRIPTION
Instead of waiting for the entire job to finish

Tested with unit tests and that "contestcli status" works with
intermediate state.

Status output after first run and after job finished:
https://gist.github.com/rojer9-fb/320074b037044bf242411f1134a06505

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>