### PR TITLE
Add end to end tests, with real server and client

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           stable: "false"
-          go-version: "1.15.6"
+          go-version: "1.16.2"
       - name: Run Linters
         run: ./run_lint.sh
       - name: Run Tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 cmds/contest/contest
-cmds/clients/contestcli-http/contestcli-http
+cmds/clients/contestcli/contestcli
 .*.swp
 profile.out

--- a/cmds/clients/contestcli/cli/cli.go
+++ b/cmds/clients/contestcli/cli/cli.go
@@ -1,0 +1,82 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/transport/http"
+
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	defaultRequestor = "contestcli-http"
+	jobWaitPoll      = 10 * time.Second
+)
+
+var (
+	flagSet       *flag.FlagSet
+	flagAddr      *string
+	flagRequestor *string
+	flagWait      *bool
+	flagYAML      *bool
+	flagStates    *[]string
+	flagTags      *[]string
+)
+
+func initFlags(cmd string) {
+	flagSet = flag.NewFlagSet(cmd, flag.ContinueOnError)
+	flagAddr = flagSet.StringP("addr", "a", "http://localhost:8080", "ConTest server [scheme://]host:port[/basepath] to connect to")
+	flagRequestor = flagSet.StringP("requestor", "r", defaultRequestor, "Identifier of the requestor of the API call")
+	flagWait = flagSet.BoolP("wait", "w", false, "After starting a job, wait for it to finish, and exit 0 only if it is successful")
+	flagYAML = flagSet.BoolP("yaml", "Y", false, "Parse job descriptor as YAML instead of JSON")
+
+	// Flags for the "list" command.
+	flagStates = flagSet.StringSlice("states", []string{}, "List of job states for the list command. A job must be in any of the specified states to match.")
+	flagTags = flagSet.StringSlice("tags", []string{}, "List of tags for the list command. A job must have all the tags to match.")
+
+	flagSet.Usage = func() {
+		fmt.Fprintf(flagSet.Output(),
+			`Usage:
+
+  contestcli [flags] command
+
+Commands:
+  start [file]
+        start a new job using the job description from the specified file
+        or passed via stdin.
+        when used with -wait flag, stdout will have two JSON outputs
+        for job start and completion status separated with newline
+  stop int
+        stop a job by job ID
+  status int
+        get the status of a job by job ID
+  retry int
+        retry a job by job ID
+  list [--states=JobStateStarted,...] [--tags=foo,...]
+        list jobs by state and/or tags
+  version
+        request the API version to the server
+
+Flags:
+`)
+		flagSet.PrintDefaults()
+	}
+}
+
+func CLIMain(cmd string, args []string, stdout io.Writer) error {
+	initFlags(cmd)
+	if err := flagSet.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+	return run(*flagRequestor, &http.HTTP{Addr: *flagAddr}, stdout)
+}

--- a/cmds/clients/contestcli/main.go
+++ b/cmds/clients/contestcli/main.go
@@ -8,11 +8,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"time"
 
-	"github.com/facebookincubator/contest/pkg/transport/http"
-
-	flag "github.com/spf13/pflag"
+	"github.com/facebookincubator/contest/cmds/clients/contestcli/cli"
 )
 
 // Unauthenticated, unencrypted sample HTTP client for ConTest.
@@ -20,61 +17,23 @@ import (
 //
 // Usage examples:
 // Start a job with the provided job description from a JSON file
-//   ./contestcli-http start < start.json
+//   ./contestcli start start.json
 //
 // Get the status of a job whose ID is 10
-//   ./contestcli-http status 10
+//   ./contestcli status 10
 //
 // List all the jobs:
-//   ./contestcli-http list
+//   ./contestcli list
 //
 // List all the failed jobs:
-//   ./contestcli-http list -state JobStateFailed
+//   ./contestcli list -state JobStateFailed
 //
 // List all the failed jobs with tags "foo" and "bar":
-//   ./contestcli-http list -state JobStateFailed -tags foo,bar
-
-const (
-	defaultRequestor = "contestcli-http"
-	jobWaitPoll      = 10 * time.Second
-)
-
-var (
-	flagAddr      = flag.StringP("addr", "a", "http://localhost:8080", "ConTest server [scheme://]host:port[/basepath] to connect to")
-	flagRequestor = flag.StringP("requestor", "r", defaultRequestor, "Identifier of the requestor of the API call")
-	flagWait      = flag.BoolP("wait", "w", false, "After starting a job, wait for it to finish, and exit 0 only if it is successful")
-	flagYAML      = flag.BoolP("yaml", "Y", false, "Parse job descriptor as YAML instead of JSON")
-
-	// Flags for the "list" command.
-	flagStates = flag.StringSlice("states", []string{}, "List of job states for the list command. A job must be in any of the specified states to match.")
-	flagTags   = flag.StringSlice("tags", []string{}, "List of tags for the list command. A job must have all the tags to match.")
-)
+//   ./contestcli list -state JobStateFailed -tags foo,bar
 
 func main() {
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of contestcli-http:\n\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  contestcli-http [args] command\n\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "command: start, stop, status, retry, version\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  start\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        start a new job using the job description passed via stdin\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        when used with -wait flag, stdout will have two JSON outputs\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        for job start and completion status separated with newline\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  stop int\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        stop a job by job ID\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  status int\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        get the status of a job by job ID\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  retry int\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        retry a job by job ID\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  list [--states=JobStateStarted,...] [--tags=foo,...]\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        list jobs by state and/or tags\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "  version\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "        request the API version to the server\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "\nargs:\n")
-		flag.PrintDefaults()
-	}
-	flag.Parse()
-	if err := run(*flagRequestor, &http.HTTP{Addr: *flagAddr}); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+	if err := cli.CLIMain(os.Args[0], os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmds/contest/main.go
+++ b/cmds/contest/main.go
@@ -6,203 +6,20 @@
 package main
 
 import (
-	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
-	"github.com/benbjohnson/clock"
-
-	"github.com/facebookincubator/contest/cmds/plugins"
-	"github.com/facebookincubator/contest/pkg/api"
-	"github.com/facebookincubator/contest/pkg/config"
-	"github.com/facebookincubator/contest/pkg/jobmanager"
-	"github.com/facebookincubator/contest/pkg/logging"
-	"github.com/facebookincubator/contest/pkg/pluginregistry"
-	"github.com/facebookincubator/contest/pkg/storage"
-	"github.com/facebookincubator/contest/pkg/target"
-	"github.com/facebookincubator/contest/pkg/xcontext"
-	"github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx"
-	"github.com/facebookincubator/contest/pkg/xcontext/logger"
-	"github.com/facebookincubator/contest/plugins/listeners/httplistener"
-	"github.com/facebookincubator/contest/plugins/storage/memory"
-	"github.com/facebookincubator/contest/plugins/storage/rdbms"
-	"github.com/facebookincubator/contest/plugins/targetlocker/dblocker"
-	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
-)
-
-var (
-	flagDBURI              = flag.String("dbURI", config.DefaultDBURI, "Database URI")
-	flagServerID           = flag.String("serverID", "", "Set a static server ID, e.g. the host name or another unique identifier. If unset, will use the listener's default")
-	flagProcessTimeout     = flag.Duration("processTimeout", api.DefaultEventTimeout, "API request processing timeout")
-	flagTargetLocker       = flag.String("targetLocker", inmemory.Name, "Target locker implementation to use")
-	flagInstanceTag        = flag.String("instanceTag", "", "A tag for this instance. Server will only operate on jobs with this tag and will add this tag to the jobs it creates.")
-	flagLogLevel           = flag.String("logLevel", "debug", "A log level, possible values: debug, info, warning, error, panic, fatal")
-	flagPauseTimeout       = flag.Duration("pauseTimeout", 0, "SIGINT/SIGTERM shutdown timeout (seconds), after which pause will be escalated to cancellaton; -1 - no escalation, 0 - do not pause, cancel immediately")
-	flagResumeJobs         = flag.Bool("resumeJobs", false, "Attempt to resume paused jobs")
-	flagTargetLockDuration = flag.Duration("targetLockDuration", config.DefaultTargetLockDuration,
-		"The amount of time target lock is extended by while the job is running. "+
-			"This is the maximum amount of time a job can stay paused safely.")
+	"github.com/facebookincubator/contest/cmds/contest/server"
 )
 
 func main() {
-	flag.Parse()
-	logLevel, err := logger.ParseLogLevel(*flagLogLevel)
-	if err != nil {
-		panic(err)
-	}
-
-	clk := clock.New()
-
-	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logLevel, logging.DefaultOptions()...))
-	ctx, pause := xcontext.WithNotify(ctx, xcontext.ErrPaused)
-	log := ctx.Logger()
-
-	pluginRegistry := pluginregistry.NewPluginRegistry(ctx)
-
-	// primary storage initialization
-	if *flagDBURI != "" {
-		log.Infof("Using database URI for primary storage: %s", *flagDBURI)
-
-		primaryDBURI := *flagDBURI
-		s, err := rdbms.New(primaryDBURI)
-		if err != nil {
-			log.Fatalf("Could not initialize database: %v", err)
-		}
-		if err := storage.SetStorage(s); err != nil {
-			log.Fatalf("Could not set storage: %v", err)
-		}
-
-		dbVerPrim, err := s.Version()
-		if err != nil {
-			log.Warnf("Could not determine storage version: %v", err)
-		} else {
-			log.Infof("Storage version: %d", dbVerPrim)
-		}
-
-		// replica storage initialization
-		log.Infof("Using database URI for replica storage: %s", *flagDBURI)
-
-		// pointing to main database for now but can be used to point to replica
-		replicaDBURI := *flagDBURI
-		r, err := rdbms.New(replicaDBURI)
-		if err != nil {
-			log.Fatalf("Could not initialize replica database: %v", err)
-		}
-		if err := storage.SetAsyncStorage(r); err != nil {
-			log.Fatalf("Could not set replica storage: %v", err)
-		}
-
-		dbVerRepl, err := r.Version()
-		if err != nil {
-			log.Warnf("Could not determine storage version: %v", err)
-		} else {
-			log.Infof("Storage version: %d", dbVerRepl)
-		}
-
-		if dbVerPrim != dbVerRepl {
-			log.Fatalf("Primary and Replica DB Versions are different: %v and %v", dbVerPrim, dbVerRepl)
-		}
-	} else {
-		log.Warnf("Using in-memory storage")
-		if ms, err := memory.New(); err == nil {
-			if err := storage.SetStorage(ms); err != nil {
-				log.Fatalf("Could not set storage: %v", err)
-			}
-			if err := storage.SetAsyncStorage(ms); err != nil {
-				log.Fatalf("Could not set replica storage: %v", err)
-			}
-		} else {
-			log.Fatalf("Could not create storage: %v", err)
-		}
-	}
-
-	// set Locker engine
-	switch *flagTargetLocker {
-	case inmemory.Name:
-		target.SetLocker(inmemory.New(clk))
-	case dblocker.Name:
-		if l, err := dblocker.New(*flagDBURI, dblocker.WithClock(clk)); err == nil {
-			target.SetLocker(l)
-		} else {
-			log.Fatalf("Failed to create locker %q: %v", *flagTargetLocker, err)
-		}
-	default:
-		log.Fatalf("Invalid target locker name %q", *flagTargetLocker)
-	}
-
-	plugins.Init(pluginRegistry, ctx.Logger())
-
-	// spawn JobManager
-	listener := httplistener.NewHTTPListener()
-
-	opts := []jobmanager.Option{
-		jobmanager.APIOption(api.OptionEventTimeout(*flagProcessTimeout)),
-	}
-	if *flagServerID != "" {
-		opts = append(opts, jobmanager.APIOption(api.OptionServerID(*flagServerID)))
-	}
-	if *flagInstanceTag != "" {
-		opts = append(opts, jobmanager.OptionInstanceTag(*flagInstanceTag))
-	}
-	if *flagTargetLockDuration != 0 {
-		opts = append(opts, jobmanager.OptionTargetLockDuration(*flagTargetLockDuration))
-	}
-
-	jm, err := jobmanager.New(listener, pluginRegistry, opts...)
-	if err != nil {
-		log.Fatalf("%v", err)
-	}
-
 	sigs := make(chan os.Signal, 1)
+	defer close(sigs)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
-
-	go func() {
-		intLevel := 0
-		// cancel immediately if pauseTimeout is zero
-		if *flagPauseTimeout == 0 {
-			intLevel = 1
-		}
-		for {
-			sig, ok := <-sigs
-			if !ok {
-				return
-			}
-			switch sig {
-			case syscall.SIGUSR1:
-				// Gentle shutdown: stop accepting requests, drain without asserting pause signal.
-				jm.StopAPI()
-			case syscall.SIGINT:
-				fallthrough
-			case syscall.SIGTERM:
-				// First signal - pause and drain, second - cancel.
-				jm.StopAPI()
-				if intLevel == 0 {
-					log.Infof("Signal %q, pausing jobs", sig)
-					pause()
-					if *flagPauseTimeout > 0 {
-						go func() {
-							select {
-							case <-ctx.Done():
-							case <-time.After(*flagPauseTimeout):
-								log.Errorf("Timed out waiting for jobs to pause, canceling")
-								cancel()
-							}
-						}()
-					}
-					intLevel++
-				} else {
-					log.Infof("Signal %q, canceling", sig)
-					cancel()
-				}
-			}
-		}
-	}()
-
-	if err := jm.Run(ctx, *flagResumeJobs); err != nil {
-		log.Fatalf("%v", err)
+	if err := server.ServerMain(os.Args[0], os.Args[1:], sigs); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
 	}
-	close(sigs)
-	log.Infof("Exiting")
 }

--- a/cmds/contest/server/server.go
+++ b/cmds/contest/server/server.go
@@ -1,0 +1,227 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package server
+
+import (
+	"flag"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"github.com/facebookincubator/contest/cmds/plugins"
+	"github.com/facebookincubator/contest/pkg/api"
+	"github.com/facebookincubator/contest/pkg/config"
+	"github.com/facebookincubator/contest/pkg/jobmanager"
+	"github.com/facebookincubator/contest/pkg/logging"
+	"github.com/facebookincubator/contest/pkg/pluginregistry"
+	"github.com/facebookincubator/contest/pkg/storage"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+	"github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx"
+	"github.com/facebookincubator/contest/pkg/xcontext/logger"
+	"github.com/facebookincubator/contest/plugins/listeners/httplistener"
+	"github.com/facebookincubator/contest/plugins/storage/memory"
+	"github.com/facebookincubator/contest/plugins/storage/rdbms"
+	"github.com/facebookincubator/contest/plugins/targetlocker/dblocker"
+	"github.com/facebookincubator/contest/plugins/targetlocker/inmemory"
+)
+
+var (
+	flagSet                *flag.FlagSet
+	flagDBURI              *string
+	flagListenAddr         *string
+	flagServerID           *string
+	flagProcessTimeout     *time.Duration
+	flagTargetLocker       *string
+	flagInstanceTag        *string
+	flagLogLevel           *string
+	flagPauseTimeout       *time.Duration
+	flagResumeJobs         *bool
+	flagTargetLockDuration *time.Duration
+)
+
+func initFlags(cmd string) {
+	flagSet = flag.NewFlagSet(cmd, flag.ContinueOnError)
+	flagDBURI = flagSet.String("dbURI", config.DefaultDBURI, "Database URI")
+	flagListenAddr = flagSet.String("listenAddr", ":8080", "Listen address and port")
+	flagServerID = flagSet.String("serverID", "", "Set a static server ID, e.g. the host name or another unique identifier. If unset, will use the listener's default")
+	flagProcessTimeout = flagSet.Duration("processTimeout", api.DefaultEventTimeout, "API request processing timeout")
+	flagTargetLocker = flagSet.String("targetLocker", inmemory.Name, "Target locker implementation to use")
+	flagInstanceTag = flagSet.String("instanceTag", "", "A tag for this instance. Server will only operate on jobs with this tag and will add this tag to the jobs it creates.")
+	flagLogLevel = flagSet.String("logLevel", "debug", "A log level, possible values: debug, info, warning, error, panic, fatal")
+	flagPauseTimeout = flagSet.Duration("pauseTimeout", 0, "SIGINT/SIGTERM shutdown timeout (seconds), after which pause will be escalated to cancellaton; -1 - no escalation, 0 - do not pause, cancel immediately")
+	flagResumeJobs = flagSet.Bool("resumeJobs", false, "Attempt to resume paused jobs")
+	flagTargetLockDuration = flagSet.Duration("targetLockDuration", config.DefaultTargetLockDuration,
+		"The amount of time target lock is extended by while the job is running. "+
+			"This is the maximum amount of time a job can stay paused safely.")
+}
+
+func ServerMain(cmd string, args []string, sigs <-chan os.Signal) error {
+	initFlags(cmd)
+	if err := flagSet.Parse(args); err != nil {
+		return err
+	}
+
+	logLevel, err := logger.ParseLogLevel(*flagLogLevel)
+	if err != nil {
+		return err
+	}
+
+	clk := clock.New()
+
+	ctx, cancel := xcontext.WithCancel(logrusctx.NewContext(logLevel, logging.DefaultOptions()...))
+	ctx, pause := xcontext.WithNotify(ctx, xcontext.ErrPaused)
+	log := ctx.Logger()
+	defer cancel()
+
+	pluginRegistry := pluginregistry.NewPluginRegistry(ctx)
+
+	// primary storage initialization
+	if *flagDBURI != "" {
+		log.Infof("Using database URI for primary storage: %s", *flagDBURI)
+
+		primaryDBURI := *flagDBURI
+		s, err := rdbms.New(primaryDBURI)
+		if err != nil {
+			log.Fatalf("Could not initialize database: %v", err)
+		}
+		if err := storage.SetStorage(s); err != nil {
+			log.Fatalf("Could not set storage: %v", err)
+		}
+
+		dbVerPrim, err := s.Version()
+		if err != nil {
+			log.Warnf("Could not determine storage version: %v", err)
+		} else {
+			log.Infof("Storage version: %d", dbVerPrim)
+		}
+
+		// replica storage initialization
+		log.Infof("Using database URI for replica storage: %s", *flagDBURI)
+
+		// pointing to main database for now but can be used to point to replica
+		replicaDBURI := *flagDBURI
+		r, err := rdbms.New(replicaDBURI)
+		if err != nil {
+			log.Fatalf("Could not initialize replica database: %v", err)
+		}
+		if err := storage.SetAsyncStorage(r); err != nil {
+			log.Fatalf("Could not set replica storage: %v", err)
+		}
+
+		dbVerRepl, err := r.Version()
+		if err != nil {
+			log.Warnf("Could not determine storage version: %v", err)
+		} else {
+			log.Infof("Storage version: %d", dbVerRepl)
+		}
+
+		if dbVerPrim != dbVerRepl {
+			log.Fatalf("Primary and Replica DB Versions are different: %v and %v", dbVerPrim, dbVerRepl)
+		}
+	} else {
+		log.Warnf("Using in-memory storage")
+		if ms, err := memory.New(); err == nil {
+			if err := storage.SetStorage(ms); err != nil {
+				log.Fatalf("Could not set storage: %v", err)
+			}
+			if err := storage.SetAsyncStorage(ms); err != nil {
+				log.Fatalf("Could not set replica storage: %v", err)
+			}
+		} else {
+			log.Fatalf("Could not create storage: %v", err)
+		}
+	}
+
+	// set Locker engine
+	switch *flagTargetLocker {
+	case inmemory.Name:
+		target.SetLocker(inmemory.New(clk))
+	case dblocker.Name:
+		if l, err := dblocker.New(*flagDBURI, dblocker.WithClock(clk)); err == nil {
+			target.SetLocker(l)
+		} else {
+			log.Fatalf("Failed to create locker %q: %v", *flagTargetLocker, err)
+		}
+	default:
+		log.Fatalf("Invalid target locker name %q", *flagTargetLocker)
+	}
+
+	plugins.Init(pluginRegistry, ctx.Logger())
+
+	// spawn JobManager
+	listener := httplistener.NewHTTPListener(*flagListenAddr)
+
+	opts := []jobmanager.Option{
+		jobmanager.APIOption(api.OptionEventTimeout(*flagProcessTimeout)),
+	}
+	if *flagServerID != "" {
+		opts = append(opts, jobmanager.APIOption(api.OptionServerID(*flagServerID)))
+	}
+	if *flagInstanceTag != "" {
+		opts = append(opts, jobmanager.OptionInstanceTag(*flagInstanceTag))
+	}
+	if *flagTargetLockDuration != 0 {
+		opts = append(opts, jobmanager.OptionTargetLockDuration(*flagTargetLockDuration))
+	}
+
+	jm, err := jobmanager.New(listener, pluginRegistry, opts...)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	pauseTimeout := *flagPauseTimeout
+
+	go func() {
+		intLevel := 0
+		// cancel immediately if pauseTimeout is zero
+		if *flagPauseTimeout == 0 {
+			intLevel = 1
+		}
+		for {
+			sig, ok := <-sigs
+			if !ok {
+				return
+			}
+			switch sig {
+			case syscall.SIGUSR1:
+				// Gentle shutdown: stop accepting requests, drain without asserting pause signal.
+				jm.StopAPI()
+			case syscall.SIGINT:
+				fallthrough
+			case syscall.SIGTERM:
+				// First signal - pause and drain, second - cancel.
+				jm.StopAPI()
+				if intLevel == 0 {
+					log.Infof("Signal %q, pausing jobs", sig)
+					pause()
+					if *flagPauseTimeout > 0 {
+						go func() {
+							select {
+							case <-ctx.Done():
+							case <-time.After(pauseTimeout):
+								log.Errorf("Timed out waiting for jobs to pause, canceling")
+								cancel()
+							}
+						}()
+					}
+					intLevel++
+				} else {
+					log.Infof("Signal %q, canceling", sig)
+					cancel()
+				}
+			}
+		}
+	}()
+
+	err = jm.Run(ctx, *flagResumeJobs)
+
+	log.Infof("Exiting, %v", err)
+
+	return err
+}

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -156,6 +156,7 @@ func (jm *JobManager) Run(ctx xcontext.Context, resumeJobs bool) error {
 		lErr := jm.apiListener.Serve(apiCtx, a)
 		ctx.Infof("Listener shut down successfully.")
 		errCh <- lErr
+		close(errCh)
 	}()
 
 loop:
@@ -182,6 +183,7 @@ loop:
 	}
 	// Stop the API (if not already)
 	jm.StopAPI()
+	<-errCh
 	// Wait for jobs to complete or for cancellation signal.
 	doneCh := ctx.Done()
 	for !jm.checkIdle(ctx) {

--- a/plugins/listeners/httplistener/httplistener.go
+++ b/plugins/listeners/httplistener/httplistener.go
@@ -24,10 +24,12 @@ import (
 )
 
 // HTTPListener implements the api.Listener interface.
-type HTTPListener struct{}
+type HTTPListener struct {
+	listenAddr string
+}
 
-func NewHTTPListener() *HTTPListener {
-	return &HTTPListener{}
+func NewHTTPListener(listenAddr string) *HTTPListener {
+	return &HTTPListener{listenAddr: listenAddr}
 }
 
 // HTTPAPIResponse is returned when an API method succeeds. It wraps the content
@@ -242,7 +244,7 @@ func (h *HTTPListener) Serve(ctx xcontext.Context, a *api.API) error {
 		return errors.New("API object is nil")
 	}
 	s := http.Server{
-		Addr:         ":8080",
+		Addr:         h.listenAddr,
 		Handler:      &apiHandler{ctx: ctx, api: a},
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,

--- a/plugins/storage/rdbms/init.go
+++ b/plugins/storage/rdbms/init.go
@@ -124,6 +124,16 @@ func (r *RDBMS) Version() (uint64, error) {
 	return migrationlib.DBVersion(r.db)
 }
 
+// Reset wipes entire database contents. Used in tests.
+func (r *RDBMS) Reset() error {
+	for _, t := range []string{"jobs", "job_tags", "run_reports", "final_reports", "test_events", "framework_events"} {
+		if _, err := r.db.Exec(fmt.Sprintf("TRUNCATE TABLE %s", t)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *RDBMS) init() error {
 
 	driverName := "mysql"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,312 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/facebookincubator/contest/pkg/api"
+	"github.com/facebookincubator/contest/pkg/event"
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/logging"
+	"github.com/facebookincubator/contest/pkg/storage"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx"
+	"github.com/facebookincubator/contest/pkg/xcontext/logger"
+	"github.com/facebookincubator/contest/plugins/targetlocker/dblocker"
+	"github.com/facebookincubator/contest/plugins/teststeps/cmd"
+	testsCommon "github.com/facebookincubator/contest/tests/common"
+	"github.com/facebookincubator/contest/tests/common/goroutine_leak_check"
+	"github.com/facebookincubator/contest/tests/integ/common"
+
+	"github.com/facebookincubator/contest/cmds/clients/contestcli/cli"
+	"github.com/facebookincubator/contest/cmds/contest/server"
+)
+
+// NB: When adding a test here you need to invoke it explicitly from docker/contest/tests.sh
+
+var (
+	ctx = logrusctx.NewContext(logger.LevelDebug, logging.DefaultOptions()...)
+)
+
+type E2ETestSuite struct {
+	suite.Suite
+
+	dbURI string
+	st    storage.Storage
+
+	serverPort int
+	serverSigs chan<- os.Signal
+	serverDone <-chan struct{}
+}
+
+func (ts *E2ETestSuite) SetupSuite() {
+	// Find a random available port to use.
+	ln, err := net.Listen("tcp", ":0")
+	require.NoError(ts.T(), err)
+	parts := strings.Split(ln.Addr().String(), ":")
+	ts.serverPort, _ = strconv.Atoi(parts[len(parts)-1])
+	ln.Close()
+}
+
+func (ts *E2ETestSuite) TearDownSuite() {
+	ctx.Infof("Teardown")
+	time.Sleep(20 * time.Millisecond)
+	if err := goroutine_leak_check.CheckLeakedGoRoutines(
+		// TODO(rojer): shut storage down properly
+		"github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher.*",
+	); err != nil {
+		panic(fmt.Sprintf("%s", err))
+	}
+}
+
+func (ts *E2ETestSuite) SetupTest() {
+	ts.dbURI = common.GetDatabaseURI()
+	ctx.Infof("DB URI: %s", ts.dbURI)
+	st, err := common.NewStorage()
+	require.NoError(ts.T(), err)
+	require.NoError(ts.T(), st.(storage.ResettableStorage).Reset())
+	tl, err := dblocker.New(common.GetDatabaseURI())
+	require.NoError(ts.T(), err)
+	tl.ResetAllLocks(ctx)
+	ts.st = st
+}
+
+func (ts *E2ETestSuite) startServer(extraArgs ...string) {
+	args := []string{
+		fmt.Sprintf("--listenAddr=localhost:%d", ts.serverPort),
+		"--logLevel=debug",
+		"--dbURI", ts.dbURI,
+		"--targetLocker=DBLocker",
+	}
+	args = append(args, extraArgs...)
+	serverSigs := make(chan os.Signal)
+	serverDone := make(chan struct{})
+	go func() {
+		server.ServerMain("contest", args, serverSigs)
+		close(serverDone)
+	}()
+	ts.serverDone = serverDone
+	ts.serverSigs = serverSigs
+	for i := 0; i < 200; i++ {
+		time.Sleep(10 * time.Millisecond)
+		conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", ts.serverPort))
+		if err != nil {
+			continue
+		}
+		conn.Close()
+		ctx.Infof("Server is up")
+		return
+	}
+	require.NoError(ts.T(), fmt.Errorf("Server failed to initialize"))
+}
+
+func (ts *E2ETestSuite) stopServer(timeout time.Duration) error {
+	if ts.serverSigs == nil {
+		return nil
+	}
+	ctx.Infof("Stopping server...")
+	var err error
+	select {
+	case ts.serverSigs <- syscall.SIGTERM:
+	default:
+	}
+	close(ts.serverSigs)
+	select {
+	case <-ts.serverDone:
+	case <-time.After(5 * time.Second):
+		err = fmt.Errorf("Server failed to exit")
+	}
+	ts.serverSigs = nil
+	ts.serverDone = nil
+	ctx.Infof("Server stopped, err %v", err)
+	return err
+}
+
+func (ts *E2ETestSuite) runClient(resp interface{}, extraArgs ...string) (string, error) {
+	args := []string{
+		fmt.Sprintf("--addr=http://localhost:%d", ts.serverPort),
+	}
+	args = append(args, extraArgs...)
+	stdout := &bytes.Buffer{}
+	err := cli.CLIMain("contestcli", args, stdout)
+	if err == nil && resp != nil {
+		err = json.Unmarshal(stdout.Bytes(), resp)
+		if err != nil {
+			err = fmt.Errorf("%w, output:\n%s\n", err, stdout.String())
+		}
+	}
+	return stdout.String(), err
+}
+
+func (ts *E2ETestSuite) TestCLIErrors() {
+	var err error
+	_, err = ts.runClient(nil, "--help")
+	require.NoError(ts.T(), err)
+	_, err = ts.runClient(nil)
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "INVALID")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "start", "NOTFOUND")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "start", "--invalid")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "stop")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "stop", "123")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "status")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "status", "123")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "retry")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "retry", "123")
+	require.Error(ts.T(), err)
+	_, err = ts.runClient(nil, "version")
+	require.Error(ts.T(), err)
+}
+
+func (ts *E2ETestSuite) TestSimple() {
+	var jobID types.JobID
+	ts.startServer()
+	{ // No jobs to begin with.
+		var resp api.ListResponse
+		_, err := ts.runClient(&resp, "list")
+		require.NoError(ts.T(), err)
+		require.Empty(ts.T(), resp.Data.JobIDs)
+	}
+	{ // Start a job.
+		var resp api.StartResponse
+		_, err := ts.runClient(&resp, "start", "-Y", "test-simple.yaml")
+		require.NoError(ts.T(), err)
+		ctx.Infof("%+v", resp)
+		require.NotEqual(ts.T(), 0, resp.Data.JobID)
+		jobID = resp.Data.JobID
+	}
+	{ // Wait for the job to finish
+		var resp api.StatusResponse
+		for i := 1; i < 5; i++ {
+			time.Sleep(1 * time.Second)
+			stdout, err := ts.runClient(&resp, "status", fmt.Sprintf("%d", jobID))
+			require.NoError(ts.T(), err)
+			ctx.Infof("Job %d state %s", jobID, resp.Data.Status.State)
+			if resp.Data.Status.State == string(job.EventJobCompleted) {
+				ctx.Debugf("Job %d status: %s", jobID, stdout)
+				break
+			}
+		}
+		require.Equal(ts.T(), string(job.EventJobCompleted), resp.Data.Status.State)
+	}
+	{ // Verify step output.
+		es := testsCommon.GetJobEventsAsString(ctx, ts.st, jobID, []event.Name{
+			cmd.EventCmdStdout, target.EventTargetAcquired, target.EventTargetReleased,
+		})
+		ctx.Debugf("%s", es)
+		require.Equal(ts.T(),
+			fmt.Sprintf(`
+{[%d 1 Test 1 ][Target{ID: "T1"} TargetAcquired]}
+{[%d 1 Test 1 Test 1 Step 1][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 1, target T1\\n\"}"]}
+{[%d 1 Test 1 Test 1 Step 2][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 2, target T1\\n\"}"]}
+{[%d 1 Test 1 ][Target{ID: "T1"} TargetReleased]}
+{[%d 1 Test 2 ][Target{ID: "T2"} TargetAcquired]}
+{[%d 1 Test 2 Test 2 Step 1][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 1, target T2\\n\"}"]}
+{[%d 1 Test 2 Test 2 Step 2][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 2, target T2\\n\"}"]}
+{[%d 1 Test 2 ][Target{ID: "T2"} TargetReleased]}
+{[%d 2 Test 1 ][Target{ID: "T1"} TargetAcquired]}
+{[%d 2 Test 1 Test 1 Step 1][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 1, target T1\\n\"}"]}
+{[%d 2 Test 1 Test 1 Step 2][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 2, target T1\\n\"}"]}
+{[%d 2 Test 1 ][Target{ID: "T1"} TargetReleased]}
+{[%d 2 Test 2 ][Target{ID: "T2"} TargetAcquired]}
+{[%d 2 Test 2 Test 2 Step 1][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 1, target T2\\n\"}"]}
+{[%d 2 Test 2 Test 2 Step 2][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 2, target T2\\n\"}"]}
+{[%d 2 Test 2 ][Target{ID: "T2"} TargetReleased]}
+`, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID),
+			es,
+		)
+	}
+	require.NoError(ts.T(), ts.stopServer(5*time.Second))
+}
+
+func (ts *E2ETestSuite) TestPauseResume() {
+	var jobID types.JobID
+	ts.startServer("--pauseTimeout=60s", "--resumeJobs")
+	{ // Start a job.
+		var resp api.StartResponse
+		_, err := ts.runClient(&resp, "start", "-Y", "test-resume.yaml")
+		require.NoError(ts.T(), err)
+		ctx.Infof("%+v", resp)
+		require.NotEqual(ts.T(), 0, resp.Data.JobID)
+		jobID = resp.Data.JobID
+	}
+	{ // Stop/start the server up to 20 times or until the job completes.
+		var resp api.StatusResponse
+		for i := 1; i < 20; i++ {
+			time.Sleep(1 * time.Second)
+			_, err := ts.runClient(&resp, "status", fmt.Sprintf("%d", jobID))
+			require.NoError(ts.T(), err)
+			ctx.Infof("Job %d state %s", jobID, resp.Data.Status.State)
+			if resp.Data.Status.State == string(job.EventJobCompleted) {
+				ctx.Debugf("Job %d completed after %d restarts", jobID, i)
+				break
+			}
+			require.NoError(ts.T(), ts.stopServer(5*time.Second))
+			ts.startServer("--pauseTimeout=60s", "--resumeJobs")
+		}
+		require.Equal(ts.T(), string(job.EventJobCompleted), resp.Data.Status.State)
+	}
+	{ // Verify step output.
+		es := testsCommon.GetJobEventsAsString(ctx, ts.st, jobID, []event.Name{
+			cmd.EventCmdStdout, target.EventTargetAcquired, target.EventTargetReleased,
+		})
+		ctx.Debugf("%s", es)
+		require.Equal(ts.T(),
+			fmt.Sprintf(`
+{[%d 1 Test 1 ][Target{ID: "T1"} TargetAcquired]}
+{[%d 1 Test 1 Test 1 Step 1][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 1, target T1\\n\"}"]}
+{[%d 1 Test 1 Test 1 Step 2][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"\"}"]}
+{[%d 1 Test 1 Test 1 Step 3][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 3, target T1\\n\"}"]}
+{[%d 1 Test 1 ][Target{ID: "T1"} TargetReleased]}
+{[%d 1 Test 2 ][Target{ID: "T2"} TargetAcquired]}
+{[%d 1 Test 2 Test 2 Step 1][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 1, target T2\\n\"}"]}
+{[%d 1 Test 2 Test 2 Step 2][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"\"}"]}
+{[%d 1 Test 2 Test 2 Step 3][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 3, target T2\\n\"}"]}
+{[%d 1 Test 2 ][Target{ID: "T2"} TargetReleased]}
+{[%d 2 Test 1 ][Target{ID: "T1"} TargetAcquired]}
+{[%d 2 Test 1 Test 1 Step 1][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 1, target T1\\n\"}"]}
+{[%d 2 Test 1 Test 1 Step 2][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"\"}"]}
+{[%d 2 Test 1 Test 1 Step 3][Target{ID: "T1"} CmdStdout &"{\"Msg\":\"Test 1, Step 3, target T1\\n\"}"]}
+{[%d 2 Test 1 ][Target{ID: "T1"} TargetReleased]}
+{[%d 2 Test 2 ][Target{ID: "T2"} TargetAcquired]}
+{[%d 2 Test 2 Test 2 Step 1][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 1, target T2\\n\"}"]}
+{[%d 2 Test 2 Test 2 Step 2][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"\"}"]}
+{[%d 2 Test 2 Test 2 Step 3][Target{ID: "T2"} CmdStdout &"{\"Msg\":\"Test 2, Step 3, target T2\\n\"}"]}
+{[%d 2 Test 2 ][Target{ID: "T2"} TargetReleased]}
+`, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID, jobID),
+			es,
+		)
+	}
+	require.NoError(ts.T(), ts.stopServer(5*time.Second))
+}
+
+func TestE2E(t *testing.T) {
+	suite.Run(t, &E2ETestSuite{serverPort: 8888})
+}

--- a/tests/e2e/test-resume.yaml
+++ b/tests/e2e/test-resume.yaml
@@ -1,0 +1,72 @@
+JobName: A job to test resumption
+Runs: 2
+RunInterval: 5s
+TestDescriptors:
+    - TargetManagerName: TargetList
+      TargetManagerAcquireParameters:
+        Targets:
+          - ID: T1
+      TargetManagerReleaseParameters:
+      TestFetcherName: literal
+      TestFetcherFetchParameters:
+          TestName: Test 1
+          Steps:
+              - name: cmd
+                label: Test 1 Step 1
+                parameters:
+                    executable: [echo]
+                    args: ["Test 1, Step 1, target {{ .ID }}"]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+              - name: cmd
+                label: Test 1 Step 2
+                parameters:
+                    executable: [sleep]
+                    args: [2]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+              - name: cmd
+                label: Test 1 Step 3
+                parameters:
+                    executable: [echo]
+                    args: ["Test 1, Step 3, target {{ .ID }}"]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+    - TargetManagerName: TargetList
+      TargetManagerAcquireParameters:
+        Targets:
+          - ID: T2
+      TargetManagerReleaseParameters:
+      TestFetcherName: literal
+      TestFetcherFetchParameters:
+          TestName: Test 2
+          Steps:
+              - name: cmd
+                label: Test 2 Step 1
+                parameters:
+                    executable: [echo]
+                    args: ["Test 2, Step 1, target {{ .ID }}"]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+              - name: cmd
+                label: Test 2 Step 2
+                parameters:
+                    executable: [sleep]
+                    args: [2]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+              - name: cmd
+                label: Test 2 Step 3
+                parameters:
+                    executable: [echo]
+                    args: ["Test 2, Step 3, target {{ .ID }}"]
+                    emit_stdout: [true]
+                    emit_stderr: [true]
+Reporting:
+    RunReporters:
+        - name: TargetSuccess
+          parameters:
+              SuccessExpression: "=100%"
+        - name: noop
+    FinalReporters:
+        - name: noop

--- a/tests/e2e/test-simple.yaml
+++ b/tests/e2e/test-simple.yaml
@@ -1,6 +1,9 @@
-JobName: A job to test resumption
+JobName: A simple test job
 Runs: 2
-RunInterval: 10s
+RunInterval: 1s
+Tags:
+  - test
+  - simple
 TestDescriptors:
     - TargetManagerName: TargetList
       TargetManagerAcquireParameters:
@@ -21,15 +24,8 @@ TestDescriptors:
               - name: cmd
                 label: Test 1 Step 2
                 parameters:
-                    executable: [sleep]
-                    args: [5]
-                    emit_stdout: [true]
-                    emit_stderr: [true]
-              - name: cmd
-                label: Test 1 Step 3
-                parameters:
                     executable: [echo]
-                    args: ["Test 1, Step 3, target {{ .ID }}"]
+                    args: ["Test 1, Step 2, target {{ .ID }}"]
                     emit_stdout: [true]
                     emit_stderr: [true]
     - TargetManagerName: TargetList
@@ -51,15 +47,8 @@ TestDescriptors:
               - name: cmd
                 label: Test 2 Step 2
                 parameters:
-                    executable: [sleep]
-                    args: [5]
-                    emit_stdout: [true]
-                    emit_stderr: [true]
-              - name: cmd
-                label: Test 2 Step 3
-                parameters:
                     executable: [echo]
-                    args: ["Test 2, Step 3, target {{ .ID }}"]
+                    args: ["Test 2, Step 2, target {{ .ID }}"]
                     emit_stdout: [true]
                     emit_stderr: [true]
 Reporting:
@@ -67,6 +56,5 @@ Reporting:
         - name: TargetSuccess
           parameters:
               SuccessExpression: "=100%"
-        - name: noop
     FinalReporters:
         - name: noop

--- a/tests/plugins/targetlocker/targetlocker_common_test.go
+++ b/tests/plugins/targetlocker/targetlocker_common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/facebookincubator/contest/pkg/logging"
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx"
@@ -32,7 +33,7 @@ var (
 	twoTargets = []*target.Target{target1[0], target2[0]}
 	allTargets = []*target.Target{target1[0], target2[0], &target.Target{ID: "003"}, &target.Target{ID: "004"}}
 
-	ctx = logrusctx.NewContext(logger.LevelDebug)
+	ctx = logrusctx.NewContext(logger.LevelDebug, logging.DefaultOptions()...)
 )
 
 type TargetLockerTestSuite struct {


### PR DESCRIPTION
Client and server binary are refactored to be reusable within the same process,
tests/e2e/e2e_test starts server on a random port, uses client to submit jobs and check status.
This is as close to using standalone binaries as possible but still provides coverage.

Two E2E tests are implemented:
 * A simple test that runs a single job in one go and checks its status.
 * A pause/resume test that starts a job and then stops server multiple
   times to force pause and resume, then verifies that all teh steps
   have been executed once and in the correct order.

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>