### PR TITLE
cli: Fix output in case of server error + report timeout properly

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -144,7 +144,7 @@ func (a *API) SendReceiveEvent(ev *Event, timeout *time.Duration) (*EventRespons
 	case resp = <-ev.RespCh:
 		return resp, nil
 	case <-time.After(to):
-		return nil, fmt.Errorf("time out waiting for response after %v", timeout)
+		return nil, fmt.Errorf("time out waiting for response after %v", to)
 	}
 }
 

--- a/pkg/transport/http/http.go
+++ b/pkg/transport/http/http.go
@@ -45,8 +45,10 @@ func (h *HTTP) Version(ctx context.Context, requestor string) (*api.VersionRespo
 		return nil, err
 	}
 	data := api.ResponseDataVersion{}
-	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
-		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	if string(resp.Data) != "" {
+		if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+			return nil, fmt.Errorf("cannot decode json response: %v", err)
+		}
 	}
 	return &api.VersionResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
@@ -59,8 +61,10 @@ func (h *HTTP) Start(ctx context.Context, requestor string, jobDescriptor string
 		return nil, err
 	}
 	data := api.ResponseDataStart{}
-	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
-		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	if string(resp.Data) != "" {
+		if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+			return nil, fmt.Errorf("cannot decode json response: %v", err)
+		}
 	}
 	return &api.StartResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
@@ -73,8 +77,10 @@ func (h *HTTP) Stop(ctx context.Context, requestor string, jobID types.JobID) (*
 		return nil, err
 	}
 	data := api.ResponseDataStop{}
-	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
-		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	if string(resp.Data) != "" {
+		if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+			return nil, fmt.Errorf("cannot decode json response: %v", err)
+		}
 	}
 	return &api.StopResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
@@ -87,8 +93,10 @@ func (h *HTTP) Status(ctx context.Context, requestor string, jobID types.JobID) 
 		return nil, err
 	}
 	data := api.ResponseDataStatus{}
-	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
-		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	if string(resp.Data) != "" {
+		if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+			return nil, fmt.Errorf("cannot decode json response: %v", err)
+		}
 	}
 	return &api.StatusResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
@@ -101,8 +109,10 @@ func (h *HTTP) Retry(ctx context.Context, requestor string, jobID types.JobID) (
 		return nil, err
 	}
 	data := api.ResponseDataRetry{}
-	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
-		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	if string(resp.Data) != "" {
+		if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+			return nil, fmt.Errorf("cannot decode json response: %v", err)
+		}
 	}
 	return &api.RetryResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }
@@ -124,8 +134,10 @@ func (h *HTTP) List(ctx context.Context, requestor string, states []job.State, t
 		return nil, err
 	}
 	var data api.ResponseDataList
-	if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
-		return nil, fmt.Errorf("cannot decode json response: %v", err)
+	if string(resp.Data) != "" {
+		if err := json.Unmarshal([]byte(resp.Data), &data); err != nil {
+			return nil, fmt.Errorf("cannot decode json response: %v", err)
+		}
 	}
 	return &api.ListResponse{ServerID: resp.ServerID, Data: data, Err: resp.Error}, nil
 }


### PR DESCRIPTION
If the server returned any error, the client would not print it, but instead say "invalid JSON response", because it tried to unmarshal the empty response data.

Also fixing a minor problem where it did not report the correct timeout in the error message.

Test Plan: (provoking a timeout error in the server)
Before:
```
> contest % go run ./cmds/clients/contestcli status 14
Requesting URL http://localhost:8080/status with requestor ID 'contestcli-http'
  with params:
    jobID: [14]
    requestor: [contestcli-http]

The server responded with status 400 Bad Request
cannot decode json response: unexpected end of JSON input
exit status 1
```

Now:
```
> contest % go run ./cmds/clients/contestcli status 14
Requesting URL http://localhost:8080/status with requestor ID 'contestcli-http'
  with params:
    jobID: [14]
    requestor: [contestcli-http]

The server responded with status 400 Bad Request
{
 "ServerID": "",
 "Data": {
  "Status": null
 },
 "Err": "Status failed: time out waiting for response after 3s"
}
```