### PR TITLE
Add targets parameter to TargetManager.Release method

### DIFF
--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -267,7 +267,7 @@ func (jr *JobRunner) Run(ctx xcontext.Context, j *job.Job, resumeState *job.Paus
 				// is simpler on the user's side. We run it in a goroutine in
 				// order to use a timeout for target acquisition. If Release fails, whether
 				// due to an error or for a timeout, the whole Job is considered failed
-				err := bundle.TargetManager.Release(ctx, j.ID, bundle.ReleaseParameters)
+				err := bundle.TargetManager.Release(ctx, j.ID, targets, bundle.ReleaseParameters)
 				// Announce that targets have been released
 				_ = jr.emitTargetEvents(runCtx, testEventEmitter, targets, target.EventTargetReleased)
 				// signal that we are done to the goroutine that refreshes the locks.

--- a/pkg/target/targetmanager.go
+++ b/pkg/target/targetmanager.go
@@ -26,7 +26,7 @@ type TargetManager interface {
 	ValidateAcquireParameters([]byte) (interface{}, error)
 	ValidateReleaseParameters([]byte) (interface{}, error)
 	Acquire(ctx xcontext.Context, jobID types.JobID, jobTargetManagerAcquireTimeout time.Duration, parameters interface{}, tl Locker) ([]*Target, error)
-	Release(ctx xcontext.Context, jobID types.JobID, parameters interface{}) error
+	Release(ctx xcontext.Context, jobID types.JobID, targets []*Target, parameters interface{}) error
 }
 
 // TargetManagerBundle bundles the selected TargetManager together with its

--- a/plugins/targetmanagers/csvtargetmanager/csvfile.go
+++ b/plugins/targetmanagers/csvtargetmanager/csvfile.go
@@ -206,7 +206,7 @@ func (tf *CSVFileTargetManager) Acquire(ctx xcontext.Context, jobID types.JobID,
 }
 
 // Release releases the acquired resources.
-func (tf *CSVFileTargetManager) Release(ctx xcontext.Context, jobID types.JobID, params interface{}) error {
+func (tf *CSVFileTargetManager) Release(ctx xcontext.Context, jobID types.JobID, targets []*target.Target, params interface{}) error {
 	return nil
 }
 

--- a/plugins/targetmanagers/targetlist/targetlist.go
+++ b/plugins/targetmanagers/targetlist/targetlist.go
@@ -98,7 +98,7 @@ func (t *TargetList) Acquire(ctx xcontext.Context, jobID types.JobID, jobTargetM
 }
 
 // Release releases the acquired resources.
-func (t *TargetList) Release(ctx xcontext.Context, jobID types.JobID, params interface{}) error {
+func (t *TargetList) Release(ctx xcontext.Context, jobID types.JobID, targets []*target.Target, params interface{}) error {
 	ctx.Infof("Released %d targets", len(t.targets))
 	return nil
 }


### PR DESCRIPTION
Simple first step to add targets to Release method.
After one can also add additional returned interface{} to Acquire() (targets, releaseParam, error) [We do already have a release parameter, so we should think of combining them]