### PR TITLE
Add target manager state to the target

### DIFF
--- a/cmds/plugins/plugins.go
+++ b/cmds/plugins/plugins.go
@@ -30,7 +30,7 @@ import (
 	"github.com/facebookincubator/contest/plugins/teststeps/sshcmd"
 )
 
-var targetManagers = []target.TargetManagerLoader{
+var TargetManagers = []target.TargetManagerLoader{
 	csvtargetmanager.Load,
 	targetlist.Load,
 }
@@ -64,7 +64,7 @@ var testInitOnce sync.Once
 func Init(pluginRegistry *pluginregistry.PluginRegistry, log xcontext.Logger) {
 
 	// Register TargetManager plugins
-	for _, tmloader := range targetManagers {
+	for _, tmloader := range TargetManagers {
 		if err := pluginRegistry.RegisterTargetManager(tmloader()); err != nil {
 			log.Fatalf("%v", err)
 		}

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -6,6 +6,7 @@
 package target
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -47,6 +48,9 @@ type Target struct {
 	FQDN        string `json:"FQDN,omitempty"`
 	PrimaryIPv4 net.IP `json:"PrimaryIPv4,omitempty"`
 	PrimaryIPv6 net.IP `json:"PrimaryIPv6,omitempty"`
+	// This field is reserved for TargetManager to associate any state needed to keep track of the target between Acquire and Release.
+	// It will be serialized between server restarts. Please keep it small.
+	TargetManagerState json.RawMessage `json:"TMS,omitempty"`
 }
 
 // String produces a string representation for a Target.
@@ -65,6 +69,9 @@ func (t *Target) String() string {
 	}
 	if t.PrimaryIPv6 != nil {
 		res.WriteString(fmt.Sprintf(`, PrimaryIPv6: "%v"`, t.PrimaryIPv6))
+	}
+	if len(t.TargetManagerState) > 0 {
+		res.WriteString(fmt.Sprintf(`, TMS: "%s"`, t.TargetManagerState))
 	}
 	res.WriteString("}")
 	return res.String()

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -47,4 +47,9 @@ func TestTargetStringification(t *testing.T) {
 	require.Equal(t, `Target{ID: "123", FQDN: "example.com", PrimaryIPv6: "::1"}`, t4.String())
 	tj4, _ := json.Marshal(t4)
 	require.Equal(t, `{"ID":"123","FQDN":"example.com","PrimaryIPv6":"::1"}`, string(tj4))
+
+	t5 := &Target{ID: "123", TargetManagerState: json.RawMessage([]byte(`{"hello": "world"}`))}
+	require.Equal(t, `Target{ID: "123", TMS: "{"hello": "world"}"}`, t5.String())
+	tj5, _ := json.Marshal(t5)
+	require.Equal(t, `{"ID":"123","TMS":{"hello":"world"}}`, string(tj5))
 }

--- a/plugins/targetmanagers/targetlist/targetlist.go
+++ b/plugins/targetmanagers/targetlist/targetlist.go
@@ -55,7 +55,6 @@ type ReleaseParameters struct {
 
 // TargetList implements the contest.TargetManager interface.
 type TargetList struct {
-	targets []*target.Target
 }
 
 // ValidateAcquireParameters valides parameters that will be passed to Acquire.
@@ -92,14 +91,14 @@ func (t *TargetList) Acquire(ctx xcontext.Context, jobID types.JobID, jobTargetM
 		ctx.Warnf("Failed to lock %d targets: %v", len(acquireParameters.Targets), err)
 		return nil, err
 	}
-	t.targets = acquireParameters.Targets
-	ctx.Infof("Acquired %d targets", len(t.targets))
+
+	ctx.Infof("Acquired %d targets", len(acquireParameters.Targets))
 	return acquireParameters.Targets, nil
 }
 
 // Release releases the acquired resources.
 func (t *TargetList) Release(ctx xcontext.Context, jobID types.JobID, targets []*target.Target, params interface{}) error {
-	ctx.Infof("Released %d targets", len(t.targets))
+	ctx.Infof("Released %d targets", len(targets))
 	return nil
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/facebookincubator/contest/cmds/plugins"
 	"github.com/facebookincubator/contest/pkg/api"
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/job"
@@ -36,6 +37,7 @@ import (
 	testsCommon "github.com/facebookincubator/contest/tests/common"
 	"github.com/facebookincubator/contest/tests/common/goroutine_leak_check"
 	"github.com/facebookincubator/contest/tests/integ/common"
+	"github.com/facebookincubator/contest/tests/plugins/targetlist_with_state"
 
 	"github.com/facebookincubator/contest/cmds/clients/contestcli/cli"
 	"github.com/facebookincubator/contest/cmds/contest/server"
@@ -65,6 +67,7 @@ func (ts *E2ETestSuite) SetupSuite() {
 	parts := strings.Split(ln.Addr().String(), ":")
 	ts.serverPort, _ = strconv.Atoi(parts[len(parts)-1])
 	ln.Close()
+	plugins.TargetManagers = append(plugins.TargetManagers, targetlist_with_state.Load)
 }
 
 func (ts *E2ETestSuite) TearDownSuite() {

--- a/tests/e2e/test-resume.yaml
+++ b/tests/e2e/test-resume.yaml
@@ -2,7 +2,7 @@ JobName: A job to test resumption
 Runs: 2
 RunInterval: 5s
 TestDescriptors:
-    - TargetManagerName: TargetList
+    - TargetManagerName: TargetListWithState
       TargetManagerAcquireParameters:
         Targets:
           - ID: T1
@@ -32,7 +32,7 @@ TestDescriptors:
                     args: ["Test 1, Step 3, target {{ .ID }}"]
                     emit_stdout: [true]
                     emit_stderr: [true]
-    - TargetManagerName: TargetList
+    - TargetManagerName: TargetListWithState
       TargetManagerAcquireParameters:
         Targets:
           - ID: T2

--- a/tests/plugins/targetlist_with_state/targetlist_with_state.go
+++ b/tests/plugins/targetlist_with_state/targetlist_with_state.go
@@ -1,0 +1,94 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Same as targetlist but verifies that state survives from Acquire to Resume.
+
+package targetlist_with_state
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+)
+
+// Name defined the name of the plugin
+var Name = "TargetListWithState"
+
+// AcquireParameters contains the parameters necessary to acquire targets.
+type AcquireParameters struct {
+	Targets []*target.Target
+}
+
+// ReleaseParameters contains the parameters necessary to release targets.
+type ReleaseParameters struct {
+}
+
+// TargetListWithState implements the contest.TargetManager interface.
+type TargetListWithState struct {
+}
+
+// ValidateAcquireParameters valides parameters that will be passed to Acquire.
+func (tlws TargetListWithState) ValidateAcquireParameters(params []byte) (interface{}, error) {
+	var ap AcquireParameters
+	if err := json.Unmarshal(params, &ap); err != nil {
+		return nil, err
+	}
+	return ap, nil
+}
+
+// ValidateReleaseParameters valides parameters that will be passed to Release.
+func (tlws TargetListWithState) ValidateReleaseParameters(params []byte) (interface{}, error) {
+	return nil, nil
+}
+
+// Acquire implements contest.TargetManager.Acquire
+func (tlws *TargetListWithState) Acquire(ctx xcontext.Context, jobID types.JobID, jobTargetManagerAcquireTimeout time.Duration, parameters interface{}, tl target.Locker) ([]*target.Target, error) {
+	acquireParameters, ok := parameters.(AcquireParameters)
+	if !ok {
+		return nil, fmt.Errorf("Acquire expects %T object, got %T", acquireParameters, parameters)
+	}
+
+	if err := tl.Lock(ctx, jobID, jobTargetManagerAcquireTimeout, acquireParameters.Targets); err != nil {
+		ctx.Warnf("Failed to lock %d targets: %v", len(acquireParameters.Targets), err)
+		return nil, err
+	}
+	var tt []*target.Target
+	for _, tgt := range acquireParameters.Targets {
+		tc := *tgt
+		tc.TargetManagerState = json.RawMessage([]byte(fmt.Sprintf(`{"token":"%d-%s"}`, jobID, tc.ID)))
+		tt = append(tt, &tc)
+	}
+	ctx.Infof("Acquired %d targets", tt)
+	return tt, nil
+}
+
+// Release releases the acquired resources.
+func (tlws *TargetListWithState) Release(ctx xcontext.Context, jobID types.JobID, targets []*target.Target, params interface{}) error {
+	// Validate tokens to make sure state was passed correctly.
+	for _, t := range targets {
+		actualState := string(t.TargetManagerState)
+		expectedState := fmt.Sprintf(`{"token":"%d-%s"}`, jobID, t.ID)
+		if actualState != expectedState {
+			panic(fmt.Sprintf("state mismatch: expected %q, got %q", expectedState, actualState))
+		}
+	}
+	ctx.Infof("Released %d targets", len(targets))
+	return nil
+}
+
+// New builds a new TargetListWithState object.
+func New() target.TargetManager {
+	return &TargetListWithState{}
+}
+
+// Load returns the name and factory which are needed to register the
+// TargetManager.
+func Load() (string, target.TargetManagerFactory) {
+	return Name, New
+}


### PR DESCRIPTION
It's state that target manager may need to store to facilitate release
of the target across server restarts.

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>