### PR TITLE
feat(xcontext): Pass-through log format string

### DIFF
--- a/pkg/xcontext/logger/logadapter/zap/wrapper.go
+++ b/pkg/xcontext/logger/logadapter/zap/wrapper.go
@@ -40,7 +40,10 @@ type Wrapper struct {
 
 // Logf implements internal.MinimalLoggerCompact.
 func (l Wrapper) Logf(level logger.Level, format string, args ...interface{}) {
-	internal.MinimalLoggerLogf(l.Backend, level, format, args...)
+	// Passing through "format" for better automatic error categorization
+	// by Sentry-like services. This way we can detect which exactly
+	// Errorf line was used even when lines being shifted up and down.
+	internal.MinimalLoggerLogf(l.Backend.Named(format), level, format, args...)
 }
 
 // OriginalLogger implements internal.LoggerExtensions.


### PR DESCRIPTION
Normally error categorization requires human to set categorization keys for each error. But we do categorization automatically, and to effectively group errors we want to use error message format as part of the key.

Why format:
In the initial approach (to test how it works) I used file + line number. And the only problem here is that an inserted or a deleted line in the top of a file shifts the rest of the code. And line number of `Errorf`-s is not the same anymore. It leads to new errors categories. Which is obviously a bad categorization. And the plan is to replace line number with error format: error format is stable to changes, does not depend on variable values and distinctive about which error occurred.


In other words, this PR is required to automatically create tasks on new errors.