### PR TITLE
log(jobmanager): Log ServerID

### DIFF
--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -141,6 +141,8 @@ func (jm *JobManager) Run(ctx xcontext.Context, resumeJobs bool) error {
 		return fmt.Errorf("Cannot start API: %w", err)
 	}
 
+	ctx = ctx.WithTag("serverID", a.ServerID())
+
 	// First, resume paused jobs.
 	if resumeJobs {
 		if err := jm.resumeJobs(ctx, a.ServerID()); err != nil {


### PR DESCRIPTION
Just adding `serverID` to the logs.

# Test plan

```
xaionaro@void:~/go/src/github.com/facebookincubator/contest$ go run ./cmds/contest
[2021-04-30T15:33:51.945+01:00 I server.go:96] Using database URI for primary storage: contest:contest@tcp(localhost:3306)/contest?parseTime=true
[2021-04-30T15:33:52.097+01:00 I server.go:110] Storage version: 0
[2021-04-30T15:33:52.097+01:00 I server.go:116] Using database URI for replica storage: contest:contest@tcp(localhost:3306)/contest?parseTime=true
[2021-04-30T15:33:52.115+01:00 I server.go:130] Storage version: 0
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:63] Registering target manager csvfiletargetmanager
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:63] Registering target manager targetlist
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:76] Registering test fetcher uri
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:76] Registering test fetcher literal
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:89] Registering test step echo
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:89] Registering test step example
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:89] Registering test step cmd
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:89] Registering test step sshcmd
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:89] Registering test step randecho
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:113] Registering reporter targetsuccess
[2021-04-30T15:33:52.116+01:00 I pluginregistry.go:113] Registering reporter noop
[2021-04-30T15:33:52.116+01:00 D httplistener.go:252] Serving a listener	serverID=void
[2021-04-30T15:33:52.116+01:00 I httplistener.go:229] Started HTTP API listener on :8080	serverID=void
[2021-04-30T15:34:34.429+01:00 D jobmanager.go:170] Handling event &{Context:0xc00024d810 Type:event_type_start ServerID:void Err:<nil> Msg:{requestor:contestcli-http TestID: NumRuns:0 JobDescriptor:{
    "JobName": "test job",
    "Reporting": {
        "FinalReporters": [
            {
                "Name": "noop"
            }
        ],
        "RunReporters": [
            {
                "Name": "TargetSuccess",
                "Parameters": {
                    "SuccessExpression": "\u003e80%"
                }
            },
            {
                "Name": "Noop"
            }
        ]
    },
    "RunInterval": "3s",
    "Runs": 3,
    "Tags": [
        "test",
        "csv"
    ],
    "TestDescriptors": [
        {
            "TargetManagerAcquireParameters": {
                "Targets": [
                    {
                        "FQDN": "example.org",
                        "ID": "1234"
                    }
                ]
            },
            "TargetManagerName": "TargetList",
            "TargetManagerReleaseParameters": {},
            "TestFetcherFetchParameters": {
                "Steps": [
                    {
                        "label": "some label",
                        "name": "cmd",
                        "parameters": {
                            "args": [
                                "Title={{ Title .FQDN }}, ToUpper={{ ToUpper .FQDN }}"
                            ],
                            "executable": [
                                "echo"
                            ]
                        }
                    }
                ],
                "TestName": "Literal test"
            },
            "TestFetcherName": "literal"
        }
    ]
}} RespCh:0xc000204720}	serverID=void
[2021-04-30T15:34:34.433+01:00 D jobmanager.go:123] Sending response &{Requestor:contestcli-http JobID:0 Err:could not create job request: could not store job request in database: Error 1146: Table 'contest.jobs' doesn't exist Status:<nil> JobIDs:[]}	api_method=start	ttp_job_id=	http_requestor=contestcli-http	http_verb=start	serverID=void
```