### PR TITLE
Continue refresh locks for paused jobs until server exits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/u-root/u-root v7.0.0+incompatible
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	github.com/xaionaro-go/metrics v0.0.0-20210425194006-68050b337673
-	github.com/xaionaro-go/unsafetools v0.0.0-20210220092901-4686db630395 // indirect
+	github.com/xaionaro-go/unsafetools v0.0.0-20210220092901-4686db630395
 	go.uber.org/atomic v1.7.0
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0

--- a/pkg/jobmanager/jobmanager.go
+++ b/pkg/jobmanager/jobmanager.go
@@ -136,6 +136,9 @@ func (jm *JobManager) handleEvent(ctx xcontext.Context, ev *api.Event) {
 
 // Run is responsible for starting the API listener and responding to incoming events.
 func (jm *JobManager) Run(ctx xcontext.Context, resumeJobs bool) error {
+	jm.jobRunner.StartLockRefresh()
+	defer jm.jobRunner.StopLockRefresh()
+
 	a, err := api.New(jm.config.apiOptions...)
 	if err != nil {
 		return fmt.Errorf("Cannot start API: %w", err)
@@ -202,6 +205,8 @@ loop:
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
+	// Refresh locks one last time for jobs that were paused.
+	jm.jobRunner.RefreshLocks()
 	return nil
 }
 

--- a/pkg/runner/job_runner_test.go
+++ b/pkg/runner/job_runner_test.go
@@ -32,7 +32,6 @@ func (fem emptyFrameworkEventManager) FetchAsync(ctx xcontext.Context, fields ..
 
 func TestGetCurrentRunNoEvents(t *testing.T) {
 	mockRunner := JobRunner{
-		targetMap:             nil,
 		frameworkEventManager: emptyFrameworkEventManager{},
 		testEvManager:         storage.TestEventFetcher{},
 	}

--- a/pkg/runner/job_status_test.go
+++ b/pkg/runner/job_status_test.go
@@ -66,7 +66,6 @@ func (fem dummyFrameworkEventManager) FetchAsync(ctx xcontext.Context, fields ..
 func TestBuildRunStatuses(t *testing.T) {
 	ctx := xcontext.Background()
 	jr := &JobRunner{
-		targetMap:             nil,
 		frameworkEventManager: dummyFrameworkEventManager{t: t},
 		testEvManager:         nil,
 	}


### PR DESCRIPTION
If one job takes longer to pause than other(s), locks on successfully
paused job's targets may expire before the server gets the chance to resume them.

This change centralizes lock refresh in a background routine that
refreshes locks for all the currently running jobs. As jobs complete,
they are rmeoved from the map. Paused jobs, however, are not, and thus their targets continue to be refreshed.