### PR TITLE
Add support for intra-step pause

### DIFF
--- a/cmds/plugins/plugins.go
+++ b/cmds/plugins/plugins.go
@@ -27,6 +27,7 @@ import (
 	"github.com/facebookincubator/contest/plugins/teststeps/echo"
 	"github.com/facebookincubator/contest/plugins/teststeps/example"
 	"github.com/facebookincubator/contest/plugins/teststeps/randecho"
+	"github.com/facebookincubator/contest/plugins/teststeps/sleep"
 	"github.com/facebookincubator/contest/plugins/teststeps/sshcmd"
 )
 
@@ -41,11 +42,12 @@ var testFetchers = []test.TestFetcherLoader{
 }
 
 var testSteps = []test.TestStepLoader{
+	cmd.Load,
 	echo.Load,
 	example.Load,
-	cmd.Load,
-	sshcmd.Load,
 	randecho.Load,
+	sleep.Load,
+	sshcmd.Load,
 }
 
 var reporters = []job.ReporterLoader{

--- a/pkg/pluginregistry/pluginregistry_test.go
+++ b/pkg/pluginregistry/pluginregistry_test.go
@@ -6,6 +6,7 @@
 package pluginregistry
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/facebookincubator/contest/pkg/event"
@@ -43,8 +44,8 @@ func (e AStep) Name() string {
 }
 
 // Run executes the AStep
-func (e AStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
-	return nil
+func (e AStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+	return nil, nil
 }
 
 func TestRegisterTestStep(t *testing.T) {

--- a/pkg/test/step.go
+++ b/pkg/test/step.go
@@ -6,6 +6,7 @@
 package test
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -112,7 +113,8 @@ type TestStep interface {
 	// Name returns the name of the step
 	Name() string
 	// Run runs the test step. The test step is expected to be synchronous.
-	Run(ctx xcontext.Context, ch TestStepChannels, params TestStepParameters, ev testevent.Emitter) error
+	Run(ctx xcontext.Context, ch TestStepChannels, params TestStepParameters, ev testevent.Emitter,
+		resumeState json.RawMessage) (json.RawMessage, error)
 	// ValidateParameters checks that the parameters are correct before passing
 	// them to Run.
 	ValidateParameters(ctx xcontext.Context, params TestStepParameters) error

--- a/plugins/teststeps/cmd/cmd.go
+++ b/plugins/teststeps/cmd/cmd.go
@@ -93,11 +93,11 @@ func emitEvent(ctx xcontext.Context, name event.Name, payload interface{}, tgt *
 }
 
 // Run executes the cmd step.
-func (ts *Cmd) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *Cmd) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	log := ctx.Logger()
 
 	if err := ts.validateAndPopulate(params); err != nil {
-		return err
+		return nil, err
 	}
 	f := func(ctx xcontext.Context, target *target.Target) error {
 		// expand args

--- a/plugins/teststeps/echo/echo.go
+++ b/plugins/teststeps/echo/echo.go
@@ -6,6 +6,7 @@
 package echo
 
 import (
+	"encoding/json"
 	"errors"
 
 	"github.com/facebookincubator/contest/pkg/event"
@@ -49,17 +50,17 @@ func (e Step) Name() string {
 }
 
 // Run executes the step
-func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	for {
 		select {
 		case target, ok := <-ch.In:
 			if !ok {
-				return nil
+				return nil, nil
 			}
 			ctx.Infof("Running on target %s with text '%s'", target, params.GetOne("text"))
 			ch.Out <- test.TestStepResult{Target: target}
 		case <-ctx.Done():
-			return nil
+			return nil, nil
 		}
 	}
 }

--- a/plugins/teststeps/example/example.go
+++ b/plugins/teststeps/example/example.go
@@ -6,6 +6,7 @@
 package example
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 
@@ -60,7 +61,7 @@ func (ts *Step) shouldFail(t *target.Target) bool {
 }
 
 // Run executes the example step.
-func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	f := func(ctx xcontext.Context, target *target.Target) error {
 		ctx.Infof("Executing on target %s", target)
 		// NOTE: you may want more robust error handling here, possibly just

--- a/plugins/teststeps/randecho/randecho.go
+++ b/plugins/teststeps/randecho/randecho.go
@@ -6,6 +6,7 @@
 package randecho
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -53,7 +54,7 @@ func (e Step) Name() string {
 }
 
 // Run executes the step
-func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	return teststeps.ForEachTarget(Name, ctx, ch,
 		func(ctx xcontext.Context, target *target.Target) error {
 			r := rand.Intn(2)

--- a/plugins/teststeps/sleep/sleep.go
+++ b/plugins/teststeps/sleep/sleep.go
@@ -1,0 +1,175 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package sleep
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/event"
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/test"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+)
+
+// Name is the name used to look this plugin up.
+var Name = "Sleep"
+
+// Events defines the events that a TestStep is allow to emit
+var Events = []event.Name{}
+
+// sleepStep implements an echo-style printing plugin.
+type sleepStep struct {
+	mu       sync.Mutex
+	wg       sync.WaitGroup
+	inFlight map[*target.Target]time.Time
+}
+
+// New initializes and returns a new EchoStep. It implements the TestStepFactory
+// interface.
+func New() test.TestStep {
+	return &sleepStep{
+		inFlight: make(map[*target.Target]time.Time),
+	}
+}
+
+// Load returns the name, factory and events which are needed to register the step.
+func Load() (string, test.TestStepFactory, []event.Name) {
+	return Name, New, Events
+}
+
+func getDuration(params test.TestStepParameters) (time.Duration, error) {
+	durP := params.GetOne("duration")
+	if durP.IsEmpty() {
+		return 0, errors.New("Missing 'duration' field in sleep parameters")
+	}
+	dur, err := time.ParseDuration(durP.String())
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", durP.String(), err)
+	}
+	return dur, nil
+}
+
+// ValidateParameters validates the parameters that will be passed to the Run
+// and Resume methods of the test step.
+func (ss *sleepStep) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
+	_, err := getDuration(params)
+	return err
+}
+
+// Name returns the name of the Step
+func (ss *sleepStep) Name() string {
+	return Name
+}
+
+type targetState struct {
+	Target     *target.Target `json:"T"`
+	DeadlineMS int64          `json:"D"`
+}
+
+const currentStateVersion = 1
+
+type sleepStepState struct {
+	Version  int `json:"V"`
+	InFlight []targetState
+}
+
+func (ss *sleepStep) loadState(ctx xcontext.Context, resumeState json.RawMessage, out chan<- test.TestStepResult) error {
+	if len(resumeState) == 0 {
+		return nil
+	}
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	var sss sleepStepState
+	if err := json.Unmarshal(resumeState, &sss); err != nil {
+		return fmt.Errorf("invalid resume state: %w", err)
+	}
+	if sss.Version != currentStateVersion {
+		return fmt.Errorf("incompatible resume state (want %d, got %d)", currentStateVersion, sss.Version)
+	}
+	now := time.Now()
+	for _, e := range sss.InFlight {
+		ss.wg.Add(1)
+		deadline := time.Unix(e.DeadlineMS/1000, (e.DeadlineMS%1000)*1000000)
+		go ss.doSleep(ctx, e.Target, deadline.Sub(now), out)
+	}
+	return nil
+}
+
+func (ss *sleepStep) doSleep(ctx xcontext.Context, t *target.Target, dur time.Duration, out chan<- test.TestStepResult) {
+	deadline := time.Now().Add(dur)
+	ss.mu.Lock()
+	ss.inFlight[t] = deadline
+	ss.mu.Unlock()
+	ctx.Debugf("%s: Sleeping for %s", t, dur)
+	select {
+	case <-time.After(dur):
+		select {
+		case out <- test.TestStepResult{Target: t, Err: nil}:
+			ss.mu.Lock()
+			delete(ss.inFlight, t)
+			ss.mu.Unlock()
+		case <-ctx.Done():
+		}
+	case <-ctx.Until(xcontext.ErrPaused):
+		ctx.Debugf("%s: Paused with %s left", t, time.Until(deadline))
+	case <-ctx.Done():
+		ctx.Debugf("%s: Cancelled with %s left", t, time.Until(deadline))
+	}
+	ss.wg.Done()
+}
+
+// Run executes the step
+func (ss *sleepStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+	dur, err := getDuration(params)
+	if err != nil {
+		return nil, err
+	}
+	if err := ss.loadState(ctx, resumeState, ch.Out); err != nil {
+		return nil, err
+	}
+loop:
+	for {
+		select {
+		case t, ok := <-ch.In:
+			if ok {
+				ss.wg.Add(1)
+				go ss.doSleep(ctx, t, dur, ch.Out)
+			} else {
+				break loop
+			}
+		case <-ctx.Done():
+			break loop
+		}
+	}
+	ss.wg.Wait()
+	select {
+	case <-ctx.Until(xcontext.ErrPaused):
+		sss := sleepStepState{
+			Version: currentStateVersion,
+		}
+		ss.mu.Lock()
+		for t, deadline := range ss.inFlight {
+			deadlineMS := deadline.UnixNano() / 1000000
+			sss.InFlight = append(sss.InFlight, targetState{
+				Target:     t,
+				DeadlineMS: deadlineMS,
+			})
+		}
+		ss.mu.Unlock()
+		resumeState, err := json.Marshal(&sss)
+		if err != nil {
+			return nil, err
+		}
+		return resumeState, xcontext.ErrPaused
+	default:
+	}
+	return nil, nil
+}

--- a/plugins/teststeps/sshcmd/sshcmd.go
+++ b/plugins/teststeps/sshcmd/sshcmd.go
@@ -17,6 +17,7 @@ package sshcmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -68,7 +69,7 @@ func (ts SSHCmd) Name() string {
 }
 
 // Run executes the cmd step.
-func (ts *SSHCmd) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *SSHCmd) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	log := ctx.Logger()
 
 	// XXX: Dragons ahead! The target (%t) substitution, and function
@@ -80,7 +81,7 @@ func (ts *SSHCmd) Run(ctx xcontext.Context, ch test.TestStepChannels, params tes
 	// Function evaluation could be done at validation time, but target
 	// substitution cannot, because the targets are not known at that time.
 	if err := ts.validateAndPopulate(params); err != nil {
-		return err
+		return nil, err
 	}
 
 	f := func(ctx xcontext.Context, target *target.Target) error {

--- a/plugins/teststeps/terminalexpect/terminalexpect.go
+++ b/plugins/teststeps/terminalexpect/terminalexpect.go
@@ -6,6 +6,7 @@
 package terminalexpect
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -53,15 +54,15 @@ func match(match string, log xcontext.Logger) termhook.LineHandler {
 }
 
 // Run executes the terminal step.
-func (ts *TerminalExpect) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *TerminalExpect) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	log := ctx.Logger()
 
 	if err := ts.validateAndPopulate(params); err != nil {
-		return err
+		return nil, err
 	}
 	hook, err := termhook.NewHook(ts.Port, ts.Speed, false, match(ts.Match, log))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// f implements plugins.PerTargetFunc
 	f := func(ctx xcontext.Context, target *target.Target) error {

--- a/plugins/teststeps/teststeps.go
+++ b/plugins/teststeps/teststeps.go
@@ -6,6 +6,7 @@
 package teststeps
 
 import (
+	"encoding/json"
 	"sync"
 
 	"github.com/facebookincubator/contest/pkg/target"
@@ -25,7 +26,7 @@ type PerTargetFunc func(ctx xcontext.Context, target *target.Target) error
 // provide an implementation of a per-target function that will be called on
 // each target. The implementation of the per-target function is responsible for
 // handling internal cancellation and pausing.
-func ForEachTarget(pluginName string, ctx xcontext.Context, ch test.TestStepChannels, f PerTargetFunc) error {
+func ForEachTarget(pluginName string, ctx xcontext.Context, ch test.TestStepChannels, f PerTargetFunc) (json.RawMessage, error) {
 	reportTarget := func(t *target.Target, err error) {
 		if err != nil {
 			ctx.Errorf("%s: ForEachTarget: failed to apply test step function on target %s: %v", pluginName, t, err)
@@ -63,5 +64,5 @@ func ForEachTarget(pluginName string, ctx xcontext.Context, ch test.TestStepChan
 		}
 	}()
 	wg.Wait()
-	return nil
+	return nil, nil
 }

--- a/plugins/teststeps/teststeps_test.go
+++ b/plugins/teststeps/teststeps_test.go
@@ -77,7 +77,7 @@ func TestForEachTargetOneTarget(t *testing.T) {
 			}
 		}
 	}()
-	err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 }
 
@@ -109,7 +109,7 @@ func TestForEachTargetOneTargetAllFail(t *testing.T) {
 			}
 		}
 	}()
-	err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 }
 
@@ -141,7 +141,7 @@ func TestForEachTargetTenTargets(t *testing.T) {
 			}
 		}
 	}()
-	err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 }
 
@@ -173,7 +173,7 @@ func TestForEachTargetTenTargetsAllFail(t *testing.T) {
 			}
 		}
 	}()
-	err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 }
 
@@ -219,7 +219,7 @@ func TestForEachTargetTenTargetsOneFails(t *testing.T) {
 			}
 		}
 	}()
-	err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_one_target ", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 }
 
@@ -289,7 +289,7 @@ func TestForEachTargetTenTargetsParallelism(t *testing.T) {
 		}
 	}()
 
-	err := ForEachTarget("test_parallel", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_parallel", d.ctx, d.stepChans, fn)
 
 	wg.Wait() //wait for receiver
 
@@ -333,7 +333,7 @@ func TestForEachTargetCancelSignalPropagation(t *testing.T) {
 		d.cancel()
 	}()
 
-	err := ForEachTarget("test_cancelation", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_cancelation", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(numTargets), canceledTargets)
@@ -373,7 +373,7 @@ func TestForEachTargetCancelBeforeInputChannelClosed(t *testing.T) {
 		d.cancel()
 	}()
 
-	err := ForEachTarget("test_cancelation", d.ctx, d.stepChans, fn)
+	_, err := ForEachTarget("test_cancelation", d.ctx, d.stepChans, fn)
 	require.NoError(t, err)
 
 	wg.Done()

--- a/tests/e2e/test-resume.yaml
+++ b/tests/e2e/test-resume.yaml
@@ -1,6 +1,6 @@
 JobName: A job to test resumption
 Runs: 2
-RunInterval: 5s
+RunInterval: 3s
 TestDescriptors:
     - TargetManagerName: TargetListWithState
       TargetManagerAcquireParameters:
@@ -18,13 +18,10 @@ TestDescriptors:
                     args: ["Test 1, Step 1, target {{ .ID }}"]
                     emit_stdout: [true]
                     emit_stderr: [true]
-              - name: cmd
+              - name: sleep  # Supports pause / resume.
                 label: Test 1 Step 2
                 parameters:
-                    executable: [sleep]
-                    args: [2]
-                    emit_stdout: [true]
-                    emit_stderr: [true]
+                    duration: [4s]
               - name: cmd
                 label: Test 1 Step 3
                 parameters:
@@ -48,7 +45,7 @@ TestDescriptors:
                     args: ["Test 2, Step 1, target {{ .ID }}"]
                     emit_stdout: [true]
                     emit_stderr: [true]
-              - name: cmd
+              - name: cmd  # Does not support pause, will have to wait.
                 label: Test 2 Step 2
                 parameters:
                     executable: [sleep]

--- a/tests/plugins/teststeps/channels/channels.go
+++ b/tests/plugins/teststeps/channels/channels.go
@@ -6,6 +6,8 @@
 package channels
 
 import (
+	"encoding/json"
+
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -27,13 +29,13 @@ func (ts *channels) Name() string {
 }
 
 // Run executes a step that runs fine but closes its output channels on exit.
-func (ts *channels) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *channels) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	for target := range ch.In {
 		ch.Out <- test.TestStepResult{Target: target}
 	}
 	// This is bad, do not do this.
 	close(ch.Out)
-	return nil
+	return nil, nil
 }
 
 // ValidateParameters validates the parameters associated to the TestStep

--- a/tests/plugins/teststeps/crash/crash.go
+++ b/tests/plugins/teststeps/crash/crash.go
@@ -6,6 +6,7 @@
 package crash
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/facebookincubator/contest/pkg/event"
@@ -28,9 +29,9 @@ func (ts *crash) Name() string {
 	return Name
 }
 
-// Run executes a step which does never return.
-func (ts *crash) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
-	return fmt.Errorf("TestStep crashed")
+// Run executes a step which returns an error
+func (ts *crash) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+	return nil, fmt.Errorf("TestStep crashed")
 }
 
 // ValidateParameters validates the parameters associated to the TestStep

--- a/tests/plugins/teststeps/hanging/hanging.go
+++ b/tests/plugins/teststeps/hanging/hanging.go
@@ -6,6 +6,8 @@
 package hanging
 
 import (
+	"encoding/json"
+
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -27,10 +29,10 @@ func (ts *hanging) Name() string {
 }
 
 // Run executes a step that does not process any targets and never returns.
-func (ts *hanging) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *hanging) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	channel := make(chan struct{})
 	<-channel
-	return nil
+	return nil, nil
 }
 
 // ValidateParameters validates the parameters associated to the TestStep

--- a/tests/plugins/teststeps/noop/noop.go
+++ b/tests/plugins/teststeps/noop/noop.go
@@ -6,10 +6,14 @@
 package noop
 
 import (
+	"encoding/json"
+
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/test"
 	"github.com/facebookincubator/contest/pkg/xcontext"
+	"github.com/facebookincubator/contest/plugins/teststeps"
 )
 
 // Name is the name used to look this plugin up.
@@ -26,19 +30,11 @@ func (ts *noop) Name() string {
 	return Name
 }
 
-// Run executes a step which does never return.
-func (ts *noop) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
-	for {
-		select {
-		case target, ok := <-ch.In:
-			if !ok {
-				return nil
-			}
-			ch.Out <- test.TestStepResult{Target: target}
-		case <-ctx.Done():
-			return nil
-		}
-	}
+// Run executes a step that does nothing and returns targets with success.
+func (ts *noop) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+	return teststeps.ForEachTarget(Name, ctx, ch, func(ctx xcontext.Context, t *target.Target) error {
+		return nil
+	})
 }
 
 // ValidateParameters validates the parameters associated to the TestStep

--- a/tests/plugins/teststeps/noreturn/noreturn.go
+++ b/tests/plugins/teststeps/noreturn/noreturn.go
@@ -6,6 +6,8 @@
 package noreturn
 
 import (
+	"encoding/json"
+
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -27,13 +29,13 @@ func (ts *noreturnStep) Name() string {
 }
 
 // Run executes a step that never returns.
-func (ts *noreturnStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *noreturnStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	for target := range ch.In {
 		ch.Out <- test.TestStepResult{Target: target}
 	}
 	channel := make(chan struct{})
 	<-channel
-	return nil
+	return nil, nil
 }
 
 // ValidateParameters validates the parameters associated to the TestStep

--- a/tests/plugins/teststeps/panicstep/panicstep.go
+++ b/tests/plugins/teststeps/panicstep/panicstep.go
@@ -6,6 +6,8 @@
 package panicstep
 
 import (
+	"encoding/json"
+
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -27,7 +29,7 @@ func (ts *panicStep) Name() string {
 }
 
 // Run executes the example step.
-func (ts *panicStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *panicStep) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	panic("panic step")
 }
 

--- a/tests/plugins/teststeps/slowecho/slowecho.go
+++ b/tests/plugins/teststeps/slowecho/slowecho.go
@@ -6,6 +6,7 @@
 package slowecho
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"time"
@@ -79,10 +80,10 @@ func (e *Step) ValidateParameters(_ xcontext.Context, params test.TestStepParame
 }
 
 // Run executes the step
-func (e *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (e *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	sleep, err := sleepTime(params.GetOne("sleep").String())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	clk := Clock
 	if clk == nil {

--- a/tests/plugins/teststeps/teststep/teststep.go
+++ b/tests/plugins/teststeps/teststep/teststep.go
@@ -6,6 +6,7 @@
 package teststep
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -64,7 +65,7 @@ func (ts *Step) shouldFail(t *target.Target, params test.TestStepParameters) boo
 }
 
 // Run executes the example step.
-func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter) error {
+func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
 	f := func(ctx xcontext.Context, target *target.Target) error {
 		// Sleep to ensure TargetIn fires first. This simplifies test assertions.
 		time.Sleep(50 * time.Millisecond)
@@ -93,13 +94,13 @@ func (ts *Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.
 		return nil
 	}
 	if err := ev.Emit(ctx, testevent.Data{EventName: StepRunningEvent}); err != nil {
-		return fmt.Errorf("failed to emit failed event: %v", err)
+		return nil, fmt.Errorf("failed to emit failed event: %v", err)
 	}
-	res := teststeps.ForEachTarget(Name, ctx, ch, f)
+	_, res := teststeps.ForEachTarget(Name, ctx, ch, f)
 	if err := ev.Emit(ctx, testevent.Data{EventName: StepFinishedEvent}); err != nil {
-		return fmt.Errorf("failed to emit failed event: %v", err)
+		return nil, fmt.Errorf("failed to emit failed event: %v", err)
 	}
-	return res
+	return nil, res
 }
 
 // ValidateParameters validates the parameters associated to the TestStep


### PR DESCRIPTION
If asked to pause, a step can return ErrPaused with a piece of state
that will be passed to a new instance when the job is resumed.
The state is opaque but at a minimum should contain targets that were in
flight at the time, they will not be reinjected and runner will expect
results for them when the job is resumed.

Handling pause is not a requirement, a step can completely ignore
the pause signal and pausing will still work between steps.