### PR TITLE
Change event payload to MEDIUMTEXT

### DIFF
--- a/db/rdbms/migration/0005_event_payload_mediumtext.sql
+++ b/db/rdbms/migration/0005_event_payload_mediumtext.sql
@@ -1,0 +1,14 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+
+-- +goose Up
+
+ALTER TABLE test_events MODIFY COLUMN payload MEDIUMTEXT;
+ALTER TABLE framework_events MODIFY COLUMN payload MEDIUMTEXT;
+
+-- +goose Down
+
+ALTER TABLE test_events MODIFY COLUMN payload TEXT;
+ALTER TABLE framework_events MODIFY COLUMN payload TEXT;


### PR DESCRIPTION
Specifically framework_events.payload needs to be bigger to accommodate resume state for larger jobs, modifying test_events.payload for consistency.

```
$ docker rmi contest_mysql
$ cd ~/contest; docker-compose up mysql
...
mysql_1    | 2021/06/01 13:59:34 OK    0003_add_jobs_state_column.sql
mysql_1    | 2021/06/01 13:59:34 OK    0004_add_job_tags_table.sql
mysql_1    | 2021/06/01 13:59:34 OK    0005_event_payload_mediumtext.sql
mysql_1    | 2021/06/01 13:59:34 goose: no migrations to run. current version: 5
```

```
$ mysql -u contest -pcontest -h 127.0.0.1 contest
mysql> show create table framework_events;
...
  `payload` mediumtext,
  `emit_time` timestamp NOT NULL,
  PRIMARY KEY (`event_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |

mysql> show create table test_events;
...
  `payload` mediumtext,
  `emit_time` timestamp NOT NULL,
  PRIMARY KEY (`event_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci |
```