### PR TITLE
Fix unmarshaling null step resume state

### DIFF
--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -167,7 +167,7 @@ func (tr *TestRunner) run(
 	for i, sb := range t.TestStepsBundles {
 		stepCtx, stepCancel := xcontext.WithCancel(stepsCtx)
 		var srs json.RawMessage
-		if i < len(rs.StepResumeState) {
+		if i < len(rs.StepResumeState) && string(rs.StepResumeState[i]) != "null" {
 			srs = rs.StepResumeState[i]
 		}
 		tr.steps = append(tr.steps, &stepState{

--- a/tests/e2e/test-resume.yaml
+++ b/tests/e2e/test-resume.yaml
@@ -21,9 +21,13 @@ TestDescriptors:
               - name: sleep  # Supports pause / resume.
                 label: Test 1 Step 2
                 parameters:
-                    duration: [4s]
-              - name: cmd
+                    duration: [2s]
+              - name: sleep  # Supports pause / resume.
                 label: Test 1 Step 3
+                parameters:
+                    duration: [2s]
+              - name: cmd
+                label: Test 1 Step 4
                 parameters:
                     executable: [echo]
                     args: ["Test 1, Step 3, target {{ .ID }}"]


### PR DESCRIPTION
It turns out that `null` unmarshals into a json.RawMessage of liteal 'null', not into nil.
Add an explicit check for `null`.