### PR TITLE
[storage] Add storage consistency semantics

### DIFF
--- a/pkg/event/frameworkevent/framework.go
+++ b/pkg/event/frameworkevent/framework.go
@@ -102,7 +102,6 @@ type Emitter interface {
 // Fetcher defines the interface that fetcher objects for framework events must implement
 type Fetcher interface {
 	Fetch(ctx xcontext.Context, fields ...QueryField) ([]Event, error)
-	FetchAsync(ctx xcontext.Context, fields ...QueryField) ([]Event, error)
 }
 
 // EmitterFetcher defines the interface that objects supporting emitting and retrieving framework events must implement

--- a/pkg/runner/job_runner.go
+++ b/pkg/runner/job_runner.go
@@ -435,11 +435,11 @@ func (jr *JobRunner) emitTargetEvents(ctx xcontext.Context, emitter testevent.Em
 // GetCurrentRun returns the run which is currently being executed
 // Queries read-only storage, which does not offer strict read-after-write guarantees.
 // Returns 0 if there are no runs
-func (jr *JobRunner) GetCurrentRunAsync(ctx xcontext.Context, jobID types.JobID) (types.RunID, error) {
+func (jr *JobRunner) GetCurrentRun(ctx xcontext.Context, jobID types.JobID) (types.RunID, error) {
 
 	var runID types.RunID
 
-	runEvents, err := jr.frameworkEventManager.FetchAsync(ctx,
+	runEvents, err := jr.frameworkEventManager.Fetch(ctx,
 		frameworkevent.QueryJobID(jobID),
 		frameworkevent.QueryEventName(EventRunStarted),
 	)

--- a/pkg/runner/job_runner_test.go
+++ b/pkg/runner/job_runner_test.go
@@ -26,17 +26,13 @@ func (fem emptyFrameworkEventManager) Fetch(ctx xcontext.Context, fields ...fram
 	return nil, nil
 }
 
-func (fem emptyFrameworkEventManager) FetchAsync(ctx xcontext.Context, fields ...frameworkevent.QueryField) ([]frameworkevent.Event, error) {
-	return nil, nil
-}
-
 func TestGetCurrentRunNoEvents(t *testing.T) {
 	mockRunner := JobRunner{
 		frameworkEventManager: emptyFrameworkEventManager{},
 		testEvManager:         storage.TestEventFetcher{},
 	}
 	// request a job that does not have any events at all
-	runID, err := mockRunner.GetCurrentRunAsync(xcontext.Background(), 1)
+	runID, err := mockRunner.GetCurrentRun(xcontext.Background(), 1)
 	require.NoError(t, err)
 	require.Equal(t, types.RunID(0), runID)
 }

--- a/pkg/runner/job_status_test.go
+++ b/pkg/runner/job_status_test.go
@@ -43,26 +43,6 @@ func (fem dummyFrameworkEventManager) Fetch(ctx xcontext.Context, fields ...fram
 	}, nil
 }
 
-func (fem dummyFrameworkEventManager) FetchAsync(ctx xcontext.Context, fields ...frameworkevent.QueryField) ([]frameworkevent.Event, error) {
-	require.Len(fem.t, fields, 2)
-	require.Equal(fem.t, frameworkevent.QueryEventName(EventRunStarted), fields[0])
-	require.Equal(fem.t, frameworkevent.QueryJobID(1), fields[1])
-	return []frameworkevent.Event{
-		{
-			JobID:     1,
-			EventName: EventRunStarted,
-			Payload:   &[]json.RawMessage{json.RawMessage(`{"RunID":2}`)}[0],
-			EmitTime:  time.Unix(2, 0),
-		},
-		{
-			JobID:     1,
-			EventName: EventRunStarted,
-			Payload:   &[]json.RawMessage{json.RawMessage(`{"RunID":1}`)}[0],
-			EmitTime:  time.Unix(1, 0),
-		},
-	}, nil
-}
-
 func TestBuildRunStatuses(t *testing.T) {
 	ctx := xcontext.Background()
 	jr := &JobRunner{

--- a/pkg/storage/events.go
+++ b/pkg/storage/events.go
@@ -62,7 +62,11 @@ func (ev TestEventFetcher) Fetch(ctx xcontext.Context, queryFields ...testevent.
 	if err != nil {
 		return nil, fmt.Errorf("unable to build a query: %w", err)
 	}
-	return storage.GetTestEvents(ctx, eventQuery)
+
+	if isStronglyConsistent(ctx) {
+		return storage.GetTestEvents(ctx, eventQuery)
+	}
+	return storageAsync.GetTestEvents(ctx, eventQuery)
 }
 
 // NewTestEventEmitter creates a new Emitter object associated with a Header
@@ -124,15 +128,9 @@ func (ev FrameworkEventFetcher) Fetch(ctx xcontext.Context, queryFields ...frame
 	if err != nil {
 		return nil, fmt.Errorf("unable to build a query: %w", err)
 	}
-	return storage.GetFrameworkEvent(ctx, eventQuery)
-}
 
-// FetchAsync retrieves events based on QueryFields that are used to build a Query object for FrameworkEvents
-// from read-only storage
-func (ev FrameworkEventFetcher) FetchAsync(ctx xcontext.Context, queryFields ...frameworkevent.QueryField) ([]frameworkevent.Event, error) {
-	eventQuery, err := frameworkevent.QueryFields(queryFields).BuildQuery()
-	if err != nil {
-		return nil, fmt.Errorf("unable to build a query: %w", err)
+	if isStronglyConsistent(ctx) {
+		return storage.GetFrameworkEvent(ctx, eventQuery)
 	}
 	return storageAsync.GetFrameworkEvent(ctx, eventQuery)
 }

--- a/pkg/storage/job_test.go
+++ b/pkg/storage/job_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+	"github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx"
+	"github.com/facebookincubator/contest/pkg/xcontext/logger"
+	"github.com/stretchr/testify/require"
+)
+
+type testJobStorageManagerFixture struct {
+	ctx      xcontext.Context
+	jobID    types.JobID
+	jobQuery *JobQuery
+}
+
+func mockJobStorageManagerData() *testJobStorageManagerFixture {
+	query, _ := BuildJobQuery()
+
+	return &testJobStorageManagerFixture{
+		ctx:      logrusctx.NewContext(logger.LevelDebug),
+		jobID:    types.JobID(0),
+		jobQuery: query,
+	}
+}
+
+func TestJobStorageConsistency(t *testing.T) {
+	f := mockJobStorageManagerData()
+	jsm := NewJobStorageManager()
+
+	var cases = []struct {
+		name   string
+		getter func(ctx xcontext.Context, jsm *JobStorageManager)
+	}{
+		{
+			"TestGetJobRequest",
+			func(ctx xcontext.Context, jsm *JobStorageManager) { _, _ = jsm.GetJobRequest(ctx, f.jobID) },
+		},
+		{
+			"TestGetJobReport",
+			func(ctx xcontext.Context, jsm *JobStorageManager) { _, _ = jsm.GetJobReport(ctx, f.jobID) },
+		},
+		{
+			"TestListJobs",
+			func(ctx xcontext.Context, jsm *JobStorageManager) { _, _ = jsm.ListJobs(ctx, f.jobQuery) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			storage, storageAsync := mockStorage(t)
+
+			// test with default context
+			tc.getter(f.ctx, &jsm)
+			require.Equal(t, storage.GetJobRequestCount(), 1)
+			require.Equal(t, storageAsync.GetJobRequestCount(), 0)
+
+			// test with explicit strong consistency
+			ctx := WithConsistencyModel(f.ctx, ConsistentReadAfterWrite)
+			tc.getter(ctx, &jsm)
+			require.Equal(t, storage.GetJobRequestCount(), 2)
+			require.Equal(t, storageAsync.GetJobRequestCount(), 0)
+
+			// test with explicit relaxed consistency
+			ctx = WithConsistencyModel(ctx, ConsistentEventually)
+			tc.getter(ctx, &jsm)
+			require.Equal(t, storage.GetJobRequestCount(), 2)
+			require.Equal(t, storageAsync.GetJobRequestCount(), 1)
+		})
+	}
+}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/facebookincubator/contest/pkg/event/frameworkevent"
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+	"github.com/stretchr/testify/require"
+)
+
+type nullStorage struct {
+	jobRequestCount   int
+	eventRequestCount int
+}
+
+func (n *nullStorage) GetJobRequestCount() int {
+	return n.jobRequestCount
+}
+
+func (n *nullStorage) GetEventRequestCount() int {
+	return n.eventRequestCount
+}
+
+// jobs interface
+func (n *nullStorage) StoreJobRequest(ctx xcontext.Context, request *job.Request) (types.JobID, error) {
+	n.jobRequestCount++
+	return types.JobID(0), nil
+}
+func (n *nullStorage) GetJobRequest(ctx xcontext.Context, jobID types.JobID) (*job.Request, error) {
+	n.jobRequestCount++
+	return nil, nil
+}
+func (n *nullStorage) StoreReport(ctx xcontext.Context, report *job.Report) error {
+	n.jobRequestCount++
+	return nil
+}
+func (n *nullStorage) GetJobReport(ctx xcontext.Context, jobID types.JobID) (*job.JobReport, error) {
+	n.jobRequestCount++
+	return nil, nil
+}
+func (n *nullStorage) ListJobs(ctx xcontext.Context, query *JobQuery) ([]types.JobID, error) {
+	n.jobRequestCount++
+	return nil, nil
+}
+
+// events interface
+func (n *nullStorage) StoreTestEvent(ctx xcontext.Context, event testevent.Event) error {
+	n.eventRequestCount++
+	return nil
+}
+func (n *nullStorage) GetTestEvents(ctx xcontext.Context, eventQuery *testevent.Query) ([]testevent.Event, error) {
+	n.eventRequestCount++
+	return nil, nil
+}
+func (n *nullStorage) StoreFrameworkEvent(ctx xcontext.Context, event frameworkevent.Event) error {
+	n.eventRequestCount++
+	return nil
+}
+func (n *nullStorage) GetFrameworkEvent(ctx xcontext.Context, eventQuery *frameworkevent.Query) ([]frameworkevent.Event, error) {
+	n.eventRequestCount++
+	return nil, nil
+}
+
+func (n *nullStorage) Close() error {
+	return nil
+}
+func (n *nullStorage) Version() (uint64, error) {
+	return 0, nil
+}
+
+func mockStorage(t *testing.T) (*nullStorage, *nullStorage) {
+	storage := &nullStorage{}
+	storageAsync := &nullStorage{}
+
+	// TODO: the fact that storage is global state is a problem here
+	// also removes the option of running tests in parallel
+	require.NoError(t, SetStorage(storage))
+	require.NoError(t, SetAsyncStorage(storageAsync))
+	return storage, storageAsync
+}
+
+func TestSetStorage(t *testing.T) {
+	require.NoError(t, SetStorage(&nullStorage{}))
+}
+
+func TestSetAsyncStorage(t *testing.T) {
+	require.NoError(t, SetAsyncStorage(&nullStorage{}))
+}


### PR DESCRIPTION
- add checks for the consistency model in JobStorageManager, TestEventFetcher, FrameworkEventFetcher
- remove _Async methods, use the storage consistency model to hint to the storage layer
  as to how to retrieve data
- add storage_test, job_test unit tests; refactor existing tests in storage to use fixtures

testing:
- unit tests:
```
% go test ./... -count=1
ok  	github.com/facebookincubator/contest/pkg/api	1.635s
?   	github.com/facebookincubator/contest/pkg/cerrors	[no test files]
?   	github.com/facebookincubator/contest/pkg/config	[no test files]
?   	github.com/facebookincubator/contest/pkg/event	[no test files]
?   	github.com/facebookincubator/contest/pkg/event/frameworkevent	[no test files]
?   	github.com/facebookincubator/contest/pkg/event/internal/querytools	[no test files]
?   	github.com/facebookincubator/contest/pkg/event/internal/reflecttools	[no test files]
ok  	github.com/facebookincubator/contest/pkg/event/testevent	0.931s
ok  	github.com/facebookincubator/contest/pkg/job	0.638s
?   	github.com/facebookincubator/contest/pkg/jobmanager	[no test files]
ok  	github.com/facebookincubator/contest/pkg/lib/comparison	0.778s
?   	github.com/facebookincubator/contest/pkg/logging	[no test files]
ok  	github.com/facebookincubator/contest/pkg/pluginregistry	2.356s
ok  	github.com/facebookincubator/contest/pkg/runner	3.985s
ok  	github.com/facebookincubator/contest/pkg/storage	1.819s
ok  	github.com/facebookincubator/contest/pkg/storage/limits	1.994s
ok  	github.com/facebookincubator/contest/pkg/target	1.078s
ok  	github.com/facebookincubator/contest/pkg/test	1.607s
?   	github.com/facebookincubator/contest/pkg/transport	[no test files]
?   	github.com/facebookincubator/contest/pkg/transport/http	[no test files]
?   	github.com/facebookincubator/contest/pkg/types	[no test files]
?   	github.com/facebookincubator/contest/pkg/userfunctions/donothing	[no test files]
?   	github.com/facebookincubator/contest/pkg/userfunctions/ocp	[no test files]
ok  	github.com/facebookincubator/contest/pkg/xcontext	0.492s
?   	github.com/facebookincubator/contest/pkg/xcontext/buildinfo	[no test files]
?   	github.com/facebookincubator/contest/pkg/xcontext/bundles	[no test files]
ok  	github.com/facebookincubator/contest/pkg/xcontext/bundles/logrusctx	2.521s
?   	github.com/facebookincubator/contest/pkg/xcontext/bundles/zapctx	[no test files]
ok  	github.com/facebookincubator/contest/pkg/xcontext/fields	0.325s
ok  	github.com/facebookincubator/contest/pkg/xcontext/logger	1.207s
ok  	github.com/facebookincubator/contest/pkg/xcontext/logger/internal	1.441s
ok  	github.com/facebookincubator/contest/pkg/xcontext/logger/logadapter/logrus	2.621s
?   	github.com/facebookincubator/contest/pkg/xcontext/logger/logadapter/zap	[no test files]
?   	github.com/facebookincubator/contest/pkg/xcontext/metrics	[no test files]
ok  	github.com/facebookincubator/contest/pkg/xcontext/metrics/prometheus	2.540s
ok  	github.com/facebookincubator/contest/pkg/xcontext/metrics/simplemetrics	2.561s
?   	github.com/facebookincubator/contest/pkg/xcontext/metrics/test	[no test files]
ok  	github.com/facebookincubator/contest/pkg/xcontext/metrics/tsmetrics	2.595s
```

- test a status command
```
% go run . status 3 | head -20
Requesting URL http://localhost:8080/status with requestor ID 'contestcli-http'
  with params:
    jobID: [3]
    requestor: [contestcli-http]

The server responded with status 200 OK
{
 "ServerID": "mbp",
 "Data": {
  "Status": {
   "Name": "status test",
   "State": "JobStateCompleted",
   "StateErrMsg": "",
   "StartTime": "2021-06-23T20:39:56Z",
   "EndTime": "2021-06-23T20:40:02Z",
   "RunStatus": {
    "JobID": 3,
    "RunID": 3,
    "StartTime": "0001-01-01T00:00:00Z",
    "TestStatuses": [
     {
      "JobID": 3,
      "RunID": 3,
      "TestName": "Literal test",
      "TestStepStatuses": [
       {
```
