### PR TITLE
Support MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ You can look at the tools implemented under [cmds/*](cmds/) for usage examples.
 
 ## Requirements
 
-ConTest is developed on Linux. It may work on other platforms, but it is only being actively tested on Linux.
+ConTest is developed and heavily tested in production on Linux with MySQL.
+There is some minimal testing with MacOS and MariaDB, but no production experience.
 You will also need a recent version of Go (we recommend at least Go 1.15 at the
 moment).
 
@@ -36,14 +37,16 @@ moment).
 
 We offer a few Docker files to help setup ConTest. The fastest way to
 have a ConTest instance up and running is to bring up the server and MySQL
-containers via the docker-compose configuration: just run
+containers via the default docker-compose configuration: just run
 `docker-compose up --build` from the root of the source tree.
+To use MariaDB instead, run `docker-compose -f docker-compose.mariadb.yml up --build`
 
-ConTest and MySQL containers can be also orchestrated separately:
+Containers can be also orchestrated separately:
 
 * [docker/mysql](docker/mysql) will configure and bring up a MySQL
   instance with a pre-populated ConTest database that you can use with a local
   instance. Just run `docker-compose mysql up` from the root of the source tree.
+* [docker/mariadb](docker/mariadb) is an alternative to MySQL. Don't start both!
 * [docker/contest](docker/contest) supports running ConTest as standalone instance
 as explained at the beginning of this section and also supports integration tests.
 For a full test run please see `run_tests.sh`.

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -8,16 +8,16 @@ services:
         ports:
             - 8080:8080
         depends_on:
-            - mysql
+            - mariadb
         networks:
             - net
 
-    mysql:
+    mariadb:
         environment:
-            - MYSQL_RANDOM_ROOT_PASSWORD=true
+            - MARIADB_RANDOM_ROOT_PASSWORD=true
         build:
             context: .
-            dockerfile: docker/mysql/Dockerfile
+            dockerfile: docker/mariadb/Dockerfile
         ports:
             - 3306:3306
         networks:

--- a/docker/contest/tests.sh
+++ b/docker/contest/tests.sh
@@ -27,7 +27,7 @@ for d in $(go list ./... | grep -v vendor); do
 done
 
 # MySQL should be up by now.
-if ! mysqladmin -h mysql -P 3306 -u contest --protocol tcp --password=contest ping; then
+if ! mysqladmin -h dbstorage -P 3306 -u contest --protocol tcp --password=contest ping; then
     echo "MySQL is not ready!"
     exit 1
 fi

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,0 +1,35 @@
+FROM mariadb:10.6
+
+# Configure golang environment to run migration against database
+RUN apt-get update && apt-get install -y curl && apt-get clean
+RUN curl -L https://golang.org/dl/go1.16.2.linux-amd64.tar.gz | tar xzf -
+ENV GOROOT=/go
+ENV PATH=$PATH:/go/bin
+
+RUN mkdir /home/mysql && chown mysql:mysql /home/mysql
+
+USER mysql
+
+COPY --chown=mysql:mysql . /home/mysql/contest
+
+WORKDIR /home/mysql
+
+# Pre-build the migration script, make sure it builds.
+RUN cd /home/mysql/contest && \
+    go build github.com/facebookincubator/contest/tools/migration/rdbms
+
+# All scripts in docker-entrypoint-initdb.d/ are automatically
+# executed during container startup
+COPY docker/mariadb/initdb.sql /docker-entrypoint-initdb.d/
+COPY db/rdbms/schema/v0/create_contest_db.sql /
+
+# Run all known migrations at the time of the creation of the container.
+# From container documentation:
+# """
+# When a container is started for the first time, a new database with the
+# specified name will be created and initialized with the provided configuration
+# variables. Furthermore, it will execute files with extensions .sh, .sql and .sql.gz
+# that are found in /docker-entrypoint-initdb.d. Files will be executed in alphabetical
+# order.
+# """
+COPY docker/mariadb/migration.sh /docker-entrypoint-initdb.d/

--- a/docker/mariadb/initdb.sql
+++ b/docker/mariadb/initdb.sql
@@ -1,0 +1,23 @@
+-- Copyright (c) Facebook, Inc. and its affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+
+CREATE DATABASE contest;
+CREATE DATABASE contest_integ;
+
+/*
+ * use mysql_native_password as auth method because caching_sha2_password is
+ * not supported by mariadb and it's the default for MySQL (starting from 8.0).
+ * See https://mariadb.com/kb/en/library/authentication-plugin-sha-256/
+ */
+CREATE USER 'contest'@'%' IDENTIFIED WITH mysql_native_password AS PASSWORD('contest');
+GRANT ALL ON contest.* TO 'contest'@'%';
+GRANT ALL ON contest_integ.* TO 'contest'@'%';
+FLUSH PRIVILEGES;
+
+USE contest;
+source /create_contest_db.sql
+
+USE contest_integ;
+source /create_contest_db.sql

--- a/docker/mariadb/migration.sh
+++ b/docker/mariadb/migration.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eo pipefail
+echo "Running database migrations..."
+cd /home/mysql/contest
+# Migrate main db and integration tests db
+go run tools/migration/rdbms/main.go -dbURI "contest:contest@unix(/var/run/mysqld/mysqld.sock)/contest?parseTime=true" -dir db/rdbms/migration up
+go run tools/migration/rdbms/main.go -dbURI "contest:contest@unix(/var/run/mysqld/mysqld.sock)/contest_integ?parseTime=true" -dir db/rdbms/migration up

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -7,18 +7,32 @@
 
 set -eu
 
+export DATABASE=${database:-mysql}
 export CI=${CI:-false}
+
+while getopts d: flag
+do
+    case "${flag}" in
+        d) DATABASE=${OPTARG};;
+    esac
+done
 
 if [ "${UID}" -ne 0 ]
 then
     echo "Re-running as root with sudo"
-    sudo --preserve-env=CI,GITHUB_ACTIONS,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_HEAD_REF,GITHUB_SHA,GITHUB_RUN_ID,PATH "$0" "$@"
+    sudo --preserve-env=DATABASE,CI,GITHUB_ACTIONS,GITHUB_REF,GITHUB_REPOSITORY,GITHUB_HEAD_REF,GITHUB_SHA,GITHUB_RUN_ID,PATH "$0" "$@"
     exit $?
 fi
 
+COMPOSE_FILE=docker-compose.yml
+if [ "${DATABASE}" != "mysql" ]
+then
+    COMPOSE_FILE=docker-compose.$DATABASE.yml
+fi
+
 codecov_env=`bash <(curl -s https://codecov.io/env)`
-docker-compose build mysql contest
-docker-compose run \
+docker-compose -f $COMPOSE_FILE build $DATABASE contest
+docker-compose -f $COMPOSE_FILE run \
     ${codecov_env} -e "CI=${CI}" \
     contest \
     /go/src/github.com/facebookincubator/contest/docker/contest/tests.sh \

--- a/tests/integ/common/storage.go
+++ b/tests/integ/common/storage.go
@@ -14,7 +14,7 @@ import (
 
 func GetDatabaseURI() string {
 	if os.Getenv("CI") != "" {
-		return "contest:contest@tcp(mysql:3306)/contest_integ?parseTime=true"
+		return "contest:contest@tcp(dbstorage:3306)/contest_integ?parseTime=true"
 	} else {
 		return "contest:contest@tcp(localhost:3306)/contest_integ?parseTime=true"
 	}


### PR DESCRIPTION
This adds support for MariaDB as an alternative to MySQL.

MariaDB must be selected explicitly by pointing the tooling to `docker-compose.mariadb.yml`, or running the test script with `run-test.sh -d mariadb`. There are no plans to change the default.
    
Primary motivation is that MySQL has no official images for non-x86 architectures in Docker Hub. (Full support for this in the next PR)

