### PR TITLE
ignore macos .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cmds/contest/contest
 cmds/clients/contestcli/contestcli
 .*.swp
 profile.out
+.DS_Store


### PR DESCRIPTION
Finder (file explorer) likes to drop these files everywhere