### PR TITLE
make sure jobID, runID are available in Reporters, TestSteps, TMs

### DIFF
--- a/pkg/job/reporting.go
+++ b/pkg/job/reporting.go
@@ -7,12 +7,12 @@ package job
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"time"
 
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
 )
 
 // Reporting is the configuration section that determines how to report the
@@ -49,8 +49,8 @@ type Reporter interface {
 
 	Name() string
 
-	RunReport(ctx context.Context, parameters interface{}, runStatus *RunStatus, ev testevent.Fetcher) (bool, interface{}, error)
-	FinalReport(ctx context.Context, parameters interface{}, runStatuses []RunStatus, ev testevent.Fetcher) (bool, interface{}, error)
+	RunReport(ctx xcontext.Context, parameters interface{}, runStatus *RunStatus, ev testevent.Fetcher) (bool, interface{}, error)
+	FinalReport(ctx xcontext.Context, parameters interface{}, runStatuses []RunStatus, ev testevent.Fetcher) (bool, interface{}, error)
 }
 
 // ReporterBundle bundles the selected Reporter together with its parameters

--- a/pkg/runner/test_runner.go
+++ b/pkg/runner/test_runner.go
@@ -126,6 +126,8 @@ func (tr *TestRunner) Run(
 		"job_id": jobID,
 		"run_id": runID,
 	})
+	ctx = xcontext.WithValue(ctx, types.KeyJobID, jobID)
+	ctx = xcontext.WithValue(ctx, types.KeyRunID, runID)
 
 	ctx.Debugf("== test runner starting job %d, run %d", jobID, runID)
 	resumeState, err := tr.run(ctx.WithTag("phase", "run"), t, targets, jobID, runID, resumeState)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,7 +5,11 @@
 
 package types
 
-import "strconv"
+import (
+	"strconv"
+
+	"github.com/facebookincubator/contest/pkg/xcontext"
+)
 
 // JobID represents a unique job identifier
 type JobID uint64
@@ -19,4 +23,28 @@ func (v JobID) String() string {
 
 func (v RunID) String() string {
 	return strconv.FormatUint(uint64(v), 10)
+}
+
+type key string
+
+const (
+	KeyJobID = key("job_id")
+	KeyRunID = key("run_id")
+)
+
+// JobIDFromContext is a helper to get the JobID, this is useful
+// for plugins which need to know which job they are running.
+// Not all context object everywhere have this set, but this is
+// guaranteed to work in TargetManagers, TestSteps and Reporters
+func JobIDFromContext(ctx xcontext.Context) (JobID, bool) {
+	v, ok := ctx.Value(KeyJobID).(JobID)
+	return v, ok
+}
+
+// RunIDFromContext is a helper to get the RunID.
+// Not all context object everywhere have this set, but this is
+// guaranteed to work in TargetManagers, TestSteps and RunReporters
+func RunIDFromContext(ctx xcontext.Context) (RunID, bool) {
+	v, ok := ctx.Value(KeyRunID).(RunID)
+	return v, ok
 }

--- a/plugins/reporters/noop/noop.go
+++ b/plugins/reporters/noop/noop.go
@@ -6,9 +6,9 @@
 package noop
 
 import (
-	"context"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/xcontext"
 )
 
 // Name defines the name of the reporter used within the plugin registry
@@ -35,12 +35,12 @@ func (n *Noop) Name() string {
 }
 
 // RunReport calculates the report to be associated with a job run.
-func (n *Noop) RunReport(ctx context.Context, parameters interface{}, runStatus *job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
+func (n *Noop) RunReport(ctx xcontext.Context, parameters interface{}, runStatus *job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
 	return true, "I did nothing", nil
 }
 
 // FinalReport calculates the final report to be associated to a job.
-func (n *Noop) FinalReport(ctx context.Context, parameters interface{}, runStatuses []job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
+func (n *Noop) FinalReport(ctx xcontext.Context, parameters interface{}, runStatuses []job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
 	return true, "I did nothing at the end, all good", nil
 }
 

--- a/plugins/reporters/targetsuccess/targetsuccess.go
+++ b/plugins/reporters/targetsuccess/targetsuccess.go
@@ -6,13 +6,13 @@
 package targetsuccess
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/lib/comparison"
+	"github.com/facebookincubator/contest/pkg/xcontext"
 )
 
 // Name defines the name of the reporter used within the plugin registry
@@ -73,7 +73,7 @@ func (ts *TargetSuccessReporter) Name() string {
 }
 
 // RunReport calculates the report to be associated with a job run.
-func (ts *TargetSuccessReporter) RunReport(ctx context.Context, parameters interface{}, runStatus *job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
+func (ts *TargetSuccessReporter) RunReport(ctx xcontext.Context, parameters interface{}, runStatus *job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
 
 	var (
 		success, fail uint64
@@ -125,7 +125,7 @@ func (ts *TargetSuccessReporter) RunReport(ctx context.Context, parameters inter
 }
 
 // FinalReport calculates the final report to be associated to a job.
-func (ts *TargetSuccessReporter) FinalReport(ctx context.Context, parameters interface{}, runStatuses []job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
+func (ts *TargetSuccessReporter) FinalReport(ctx xcontext.Context, parameters interface{}, runStatuses []job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
 	return false, nil, fmt.Errorf("final reporting not implemented yet in %s", Name)
 }
 

--- a/plugins/teststeps/echo/echo.go
+++ b/plugins/teststeps/echo/echo.go
@@ -12,6 +12,7 @@ import (
 	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/event/testevent"
 	"github.com/facebookincubator/contest/pkg/test"
+	"github.com/facebookincubator/contest/pkg/types"
 	"github.com/facebookincubator/contest/pkg/xcontext"
 )
 
@@ -57,7 +58,10 @@ func (e Step) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.Te
 			if !ok {
 				return nil, nil
 			}
-			ctx.Infof("Running on target %s with text '%s'", target, params.GetOne("text"))
+			// guaranteed to work here
+			jobID, _ := types.JobIDFromContext(ctx)
+			runID, _ := types.RunIDFromContext(ctx)
+			ctx.Infof("This is job %d, run %d on target %s with text '%s'", jobID, runID, params.GetOne("text"))
 			ch.Out <- test.TestStepResult{Target: target}
 		case <-ctx.Done():
 			return nil, nil

--- a/tests/integ/jobmanager/jobdescriptors.go
+++ b/tests/integ/jobmanager/jobdescriptors.go
@@ -292,3 +292,46 @@ var jobDescriptorSlowEcho2 = descriptorMust2(&templateData{
        "TestName": "IntegrationTest: resume"
    }`,
 })
+
+var jobDescriptorReadmeta = `
+{
+    "JobName": "test job",
+    "Runs": 1,
+    "RunInterval": "5s",
+    "Tags": [
+        "integration_testing"
+    ],
+    "TestDescriptors": [
+        {
+            "TargetManagerName": "readmeta",
+            "TargetManagerAcquireParameters": {},
+            "TargetManagerReleaseParameters": {},
+            "TestFetcherName": "literal",
+            "TestFetcherFetchParameters": {
+                "Steps": [
+                    {
+                        "name": "readmeta",
+                        "label": "readmeta_label",
+                        "parameters": {}
+                    }
+                ],
+                "TestName": "IntegrationTest: noop"
+            }
+        }
+    ],
+    "Reporting": {
+        "RunReporters": [
+            {
+                "Name": "readmeta",
+                "Parameters": {}
+            }
+        ],
+        "FinalReporters": [
+            {
+                "Name": "readmeta",
+                "Parameters": {}
+            }
+        ]
+    }
+}
+`

--- a/tests/plugins/reporters/readmeta/readmeta.go
+++ b/tests/plugins/reporters/readmeta/readmeta.go
@@ -1,0 +1,72 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package readmeta_test
+
+import (
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/pkg/job"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+)
+
+// Name defines the name of the reporter used within the plugin registry
+var Name = "readmeta"
+
+// Noop is a reporter that does nothing. Probably only useful for testing.
+type Readmeta struct{}
+
+// ValidateRunParameters validates the parameters for the run reporter
+func (n *Readmeta) ValidateRunParameters(params []byte) (interface{}, error) {
+	var s string
+	return s, nil
+}
+
+// ValidateFinalParameters validates the parameters for the final reporter
+func (n *Readmeta) ValidateFinalParameters(params []byte) (interface{}, error) {
+	var s string
+	return s, nil
+}
+
+// Name returns the Name of the reporter
+func (n *Readmeta) Name() string {
+	return Name
+}
+
+// RunReport calculates the report to be associated with a job run.
+func (n *Readmeta) RunReport(ctx xcontext.Context, parameters interface{}, runStatus *job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
+	// test metadata exists
+	jobID, ok1 := types.JobIDFromContext(ctx)
+	// note this must use panic to abort the test run, as this is a test for the job runner which ignore the actual outcome
+	if jobID == 0 || !ok1 {
+		panic("Unable to extract jobID from context")
+	}
+	runID, ok2 := types.RunIDFromContext(ctx)
+	if runID == 0 || !ok2 {
+		panic("Unable to extract runID from context")
+	}
+	return true, "I did nothing", nil
+}
+
+// FinalReport calculates the final report to be associated to a job.
+func (n *Readmeta) FinalReport(ctx xcontext.Context, parameters interface{}, runStatuses []job.RunStatus, ev testevent.Fetcher) (bool, interface{}, error) {
+	// this one only has jobID, there is no specific runID in the final reporter
+	jobID, ok1 := types.JobIDFromContext(ctx)
+	// note this must use panic to abort the test run, as this is a test for the job runner which ignore the actual outcome
+	if jobID == 0 || !ok1 {
+		panic("Unable to extract jobID from context")
+	}
+	return true, "I did nothing at all", nil
+}
+
+// New builds a new TargetSuccessReporter
+func New() job.Reporter {
+	return &Readmeta{}
+}
+
+// Load returns the name and factory which are needed to register the Reporter
+func Load() (string, job.ReporterFactory) {
+	return Name, New
+}

--- a/tests/plugins/targetmanagers/readmeta/readmeta.go
+++ b/tests/plugins/targetmanagers/readmeta/readmeta.go
@@ -1,0 +1,75 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package readmeta
+
+import (
+	"time"
+
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+)
+
+// Name defined the name of the plugin
+var (
+	Name = "readmeta"
+)
+
+// Readmeta implements the contest.TargetManager interface.
+type Readmeta struct {
+}
+
+// ValidateAcquireParameters valides parameters that will be passed to Acquire.
+func (r Readmeta) ValidateAcquireParameters(params []byte) (interface{}, error) {
+	return nil, nil
+}
+
+// ValidateReleaseParameters valides parameters that will be passed to Release.
+func (r Readmeta) ValidateReleaseParameters(params []byte) (interface{}, error) {
+	return nil, nil
+}
+
+// Acquire implements contest.TargetManager.Acquire
+func (t *Readmeta) Acquire(ctx xcontext.Context, jobID types.JobID, jobTargetManagerAcquireTimeout time.Duration, parameters interface{}, tl target.Locker) ([]*target.Target, error) {
+	// test metadata exists
+	jobID2, ok1 := types.JobIDFromContext(ctx)
+	// note this must use panic to abort the test run, as this is a test for the job runner which ignore the actual outcome
+	if jobID2 == 0 || !ok1 {
+		panic("Unable to extract jobID from context")
+	}
+	runID, ok2 := types.RunIDFromContext(ctx)
+	if runID == 0 || !ok2 {
+		panic("Unable to extract runID from context")
+	}
+	// return one target so the test continues normally
+	return []*target.Target{{ID: "testtarget123"}}, nil
+}
+
+// Release releases the acquired resources.
+func (t *Readmeta) Release(ctx xcontext.Context, jobID types.JobID, targets []*target.Target, params interface{}) error {
+	// test metadata exists
+	jobID2, ok1 := types.JobIDFromContext(ctx)
+	// note this must use panic to abort the test run, as this is a test for the job runner which ignore the actual outcome
+	if jobID2 == 0 || !ok1 {
+		panic("Unable to extract jobID from context")
+	}
+	runID, ok2 := types.RunIDFromContext(ctx)
+	if runID == 0 || !ok2 {
+		panic("Unable to extract runID from context")
+	}
+	return nil
+}
+
+// New builds a new Readmeta object.
+func New() target.TargetManager {
+	return &Readmeta{}
+}
+
+// Load returns the name and factory which are needed to register the
+// TargetManager.
+func Load() (string, target.TargetManagerFactory) {
+	return Name, New
+}

--- a/tests/plugins/teststeps/readmeta/readmeta.go
+++ b/tests/plugins/teststeps/readmeta/readmeta.go
@@ -1,0 +1,73 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+package readmeta
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/facebookincubator/contest/pkg/event"
+	"github.com/facebookincubator/contest/pkg/event/testevent"
+	"github.com/facebookincubator/contest/pkg/target"
+	"github.com/facebookincubator/contest/pkg/test"
+	"github.com/facebookincubator/contest/pkg/types"
+	"github.com/facebookincubator/contest/pkg/xcontext"
+	"github.com/facebookincubator/contest/plugins/teststeps"
+)
+
+// Name is the name used to look this plugin up.
+var Name = "readmeta"
+
+var MetadataEventName = event.Name("MetadataEvent")
+
+// Events defines the events that a TestStep is allow to emit
+var Events = []event.Name{
+	MetadataEventName,
+}
+
+type readmeta struct {
+}
+
+// Name returns the name of the Step
+func (ts *readmeta) Name() string {
+	return Name
+}
+
+// Run executes a step that reads the job metadata that must be in the context and panics if it is missing.
+func (ts *readmeta) Run(ctx xcontext.Context, ch test.TestStepChannels, params test.TestStepParameters, ev testevent.Emitter, resumeState json.RawMessage) (json.RawMessage, error) {
+	return teststeps.ForEachTarget(Name, ctx, ch, func(ctx xcontext.Context, t *target.Target) error {
+		jobID, ok1 := types.JobIDFromContext(ctx)
+		if jobID == 0 || !ok1 {
+			return fmt.Errorf("unable to extract jobID from context")
+		}
+		runID, ok2 := types.RunIDFromContext(ctx)
+		if runID == 0 || !ok2 {
+			return fmt.Errorf("unable to extract jobID from context")
+		}
+		payload := make(map[string]int)
+		payload["job_id"] = int(jobID)
+		payload["run_id"] = int(runID)
+		payloadStr, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		payloadJson := json.RawMessage(payloadStr)
+		if err := ev.Emit(ctx, testevent.Data{EventName: MetadataEventName, Payload: &payloadJson}); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// ValidateParameters validates the parameters associated to the TestStep
+func (ts *readmeta) ValidateParameters(_ xcontext.Context, params test.TestStepParameters) error {
+	return nil
+}
+
+// New creates a new readmeta step
+func New() test.TestStep {
+	return &readmeta{}
+}


### PR DESCRIPTION
... and switch Reporters to use xcontext to allow this

This means TestSteps, Reporters and TargetManagers can now find out about their own `JobID` and `RunID` with a simple

`types.JobIDFromContext(ctx)`



Also adding integration tests that make sure these values are actually available so this won't regress.