### PR TITLE
pluginregistry: Better error for unknown teststeps

### DIFF
--- a/pkg/jobmanager/bundles.go
+++ b/pkg/jobmanager/bundles.go
@@ -68,16 +68,9 @@ func newBundlesFromSteps(ctx xcontext.Context, descriptors []*test.TestStepDescr
 		if err := limits.NewValidator().ValidateTestStepLabel(descriptor.Label); err != nil {
 			return nil, err
 		}
-		tse, err := registry.NewTestStepEvents(descriptor.Name)
-		if err != nil {
-			return nil, err
-		}
-		tsb, err := registry.NewTestStepBundle(ctx, *descriptor, tse)
+		tsb, err := registry.NewTestStepBundle(ctx, *descriptor)
 		if err != nil {
 			return nil, fmt.Errorf("NewStepBundle for test step '%s' with index %d failed: %w", descriptor.Name, idx, err)
-		}
-		if err != nil {
-			return nil, err
 		}
 		stepBundles = append(stepBundles, *tsb)
 	}

--- a/pkg/pluginregistry/bundles.go
+++ b/pkg/pluginregistry/bundles.go
@@ -8,7 +8,6 @@ package pluginregistry
 import (
 	"fmt"
 
-	"github.com/facebookincubator/contest/pkg/event"
 	"github.com/facebookincubator/contest/pkg/job"
 	"github.com/facebookincubator/contest/pkg/target"
 	"github.com/facebookincubator/contest/pkg/test"
@@ -16,13 +15,17 @@ import (
 )
 
 // NewTestStepBundle creates a TestStepBundle from a TestStepDescriptor
-func (r *PluginRegistry) NewTestStepBundle(ctx xcontext.Context, testStepDescriptor test.TestStepDescriptor, allowedEvents map[event.Name]bool) (*test.TestStepBundle, error) {
+func (r *PluginRegistry) NewTestStepBundle(ctx xcontext.Context, testStepDescriptor test.TestStepDescriptor) (*test.TestStepBundle, error) {
 	testStep, err := r.NewTestStep(testStepDescriptor.Name)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the desired TestStep (%s): %v", testStepDescriptor.Name, err)
 	}
 	if err := testStep.ValidateParameters(ctx, testStepDescriptor.Parameters); err != nil {
 		return nil, fmt.Errorf("could not validate parameters for test step %s: %v", testStepDescriptor.Name, err)
+	}
+	allowedEvents, err := r.NewTestStepEvents(testStepDescriptor.Name)
+	if err != nil {
+		return nil, err
 	}
 	label := testStepDescriptor.Label
 	if label == "" {

--- a/pkg/runner/test_runner_test.go
+++ b/pkg/runner/test_runner_test.go
@@ -118,7 +118,7 @@ func newStep(label, name string, params *test.TestStepParameters) test.TestStepB
 	if params != nil {
 		td.Parameters = *params
 	}
-	sb, err := pluginRegistry.NewTestStepBundle(ctx, td, nil)
+	sb, err := pluginRegistry.NewTestStepBundle(ctx, td)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create test step bundle: %v", err))
 	}


### PR DESCRIPTION
When creating a job, we load the allowed Events before the test step itself, which means unknown test step result in this confusing error message:
```
"Err": "could not create step bundles: could not create test steps bundle: TestStep foobar does not have any event associated"
```

Change this around to load the test step first, now the error message is:
```
"Err": "could not create step bundles: could not create test steps bundle: NewStepBundle for test step 'foobar' with index 0 failed: could not get the desired TestStep (foobar): TestStep foobar is not registered"
```