### PR TITLE
Fix race condition in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ have a ConTest instance up and running is to bring up the server and MySQL
 containers via the default docker-compose configuration: just run
 `docker-compose up --build` from the root of the source tree.
 To use MariaDB instead, run `docker-compose -f docker-compose.mariadb.yml up --build`
+Note: you might need to set DOCKER_BUILDKIT=1 in env for Docker to interpret
+ARGs like $TARGETARCH inside the scripts.
 
 Containers can be also orchestrated separately:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
         ports:
             - 8080:8080
         depends_on:
-            - mysql
+            mysql:
+                condition: service_healthy
         networks:
             - net
 
@@ -20,6 +21,11 @@ services:
             dockerfile: docker/mysql/Dockerfile
         ports:
             - 3306:3306
+        healthcheck:
+            test: ["CMD", "mysqladmin", "ping", "-h127.0.0.1", "-ucontest", "-pcontest"]
+            interval: 5s
+            timeout: 1s
+            retries: 5
         networks:
             net:
                 aliases:


### PR DESCRIPTION
- when started from scratch, the mysql container doesn't finish starting
  the actual sql server but the container is seen as started, so
  the contest container starts and fails to connect

=========== BEFORE

\# docker-compose up
Creating network "contest_net" with the default driver
Creating contest_mysql_1 ... done
Creating contest_contest_1 ... done
Attaching to contest_mysql_1, contest_contest_1
mysql_1    | 2021-09-25 15:35:44+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.26-1debian10 started.
mysql_1    | 2021-09-25 15:35:44+00:00 [Note] [Entrypoint]: Initializing database files
mysql_1    | 2021-09-25T15:35:44.929213Z 0 [Warning] [MY-010139] [Server] Changed limits: max_open_files: 1024 (requested 8161)
mysql_1    | 2021-09-25T15:35:44.929221Z 0 [Warning] [MY-010142] [Server] Changed limits: table_open_cache: 431 (requested 4000)
mysql_1    | 2021-09-25T15:35:44.929677Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.26) initializing of server in progress as process 23
mysql_1    | 2021-09-25T15:35:44.938728Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
mysql_1    | 2021-09-25T15:35:46.102116Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:63] Registering target manager csvfiletargetmanager
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:63] Registering target manager targetlist
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:76] Registering test fetcher literal
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:76] Registering test fetcher uri
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:89] Registering test step cmd
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:89] Registering test step sleep
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:89] Registering test step sshcmd
contest_1  | [2021-09-25T15:35:47.553Z I pluginregistry.go:113] Registering reporter targetsuccess
contest_1  | [2021-09-25T15:35:47.553Z I server.go:173] Using database URI for primary storage: contest:contest@tcp(dbstorage:3306)/contest_integ?parseTime=true
contest_1  | [2021-09-25T15:35:47.554Z F server.go:176] Could not initialize database: unable to contact database: dial tcp 172.21.0.2:3306: connect: connection refused
contest_1  | exit status 1
contest_contest_1 exited with code 1


========= AFTER

\# docker-compose up
Creating network "contest_net" with the default driver
Creating contest_mysql_1 ... done
Creating contest_contest_1 ... done
Attaching to contest_mysql_1, contest_contest_1
mysql_1    | 2021-09-25 15:37:11+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.26-1debian10 started.
mysql_1    | 2021-09-25 15:37:11+00:00 [Note] [Entrypoint]: Initializing database files
mysql_1    | 2021-09-25T15:37:11.250106Z 0 [Warning] [MY-010139] [Server] Changed limits: max_open_files: 1024 (requested 8161)
mysql_1    | 2021-09-25T15:37:11.250111Z 0 [Warning] [MY-010142] [Server] Changed limits: table_open_cache: 431 (requested 4000)
mysql_1    | 2021-09-25T15:37:11.250491Z 0 [System] [MY-013169] [Server] /usr/sbin/mysqld (mysqld 8.0.26) initializing of server in progress as process 22
mysql_1    | 2021-09-25T15:37:11.257495Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
mysql_1    | 2021-09-25T15:37:11.729098Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
mysql_1    | 2021-09-25T15:37:12.979729Z 0 [Warning] [MY-013746] [Server] A deprecated TLS version TLSv1 is enabled for channel mysql_main
[...]
contest_1  | [2021-09-25T15:37:28.703Z I server.go:173] Using database URI for primary storage: contest:contest@tcp(dbstorage:3306)/contest_integ?parseTime=true
contest_1  | [2021-09-25T15:37:28.712Z I server.go:187] Storage version: 5
contest_1  | [2021-09-25T15:37:28.712Z I server.go:193] Using database URI for replica storage: contest:contest@tcp(dbstorage:3306)/contest_integ?parseTime=true
contest_1  | [2021-09-25T15:37:28.714Z I server.go:207] Storage version: 5
contest_1  | [2021-09-25T15:37:28.714Z I server.go:235] Locker engine set to auto, using DBLocker
contest_1  | [2021-09-25T15:37:28.715Z D storage.go:102] consistency model check: <nil>
contest_1  | [2021-09-25T15:37:28.717Z I jobmanager.go:223] Found 0 zombie jobs for /a35868b6cb37
contest_1  | [2021-09-25T15:37:28.717Z D httplistener.go:253] Serving a listener
contest_1  | [2021-09-25T15:37:28.717Z I httplistener.go:230] Started HTTP API listener on :8080

